### PR TITLE
Item Balancing: 5 Swinging Polearms

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -791,7 +791,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="0.92">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -869,7 +869,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.9" CraftingCost="110">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="205" weight="0.9" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1392,10 +1392,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.48">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="65" weight="0.335">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.875" />
-      <Swing damage_type="Cut" damage_factor="1.359995" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="5.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -881,7 +881,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.9" CraftingCost="110">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="222" weight="1.15" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1339,10 +1339,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.445">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.505">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.06" />
-      <Swing damage_type="Cut" damage_factor="1.93" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1401,10 +1401,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.24244">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="42" weight="0.39">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.7" />
-      <Swing damage_type="Cut" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1419,15 +1419,14 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.49">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.484">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="0.91" />
-      <Swing damage_type="Cut" damage_factor="2.38" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron5" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -791,13 +791,13 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="161" weight="1.5">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="161" weight="1">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1.2">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -881,7 +881,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="222" weight="1.15" CraftingCost="110">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="234" weight="0.85" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1272,7 +1272,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="1.125" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="1" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Pierce" damage_factor="3" />
     </BladeData>
@@ -1339,10 +1339,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.505">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.295">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1401,10 +1401,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="42" weight="0.39">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="42" weight="0.275">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1419,14 +1419,15 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.484">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.275">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron5" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -674,7 +674,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_polearm_1_t1_handle" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="spear_handle_1" length="155" weight="0.9" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
+  <CraftingPiece id="crpg_peasant_polearm_1_t1_handle" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="spear_handle_1" length="149" weight="0.7" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -791,7 +791,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="161" weight="1">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -869,7 +869,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="205" weight="0.9" CraftingCost="110">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.9" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -881,7 +881,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="234" weight="0.85" CraftingCost="110">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.85" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1276,7 +1276,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="1" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="0.7" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Pierce" damage_factor="3" />
     </BladeData>
@@ -1344,9 +1344,9 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.295">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.32">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
@@ -1397,7 +1397,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="65" weight="0.335">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="1.4" />
       <Swing damage_type="Cut" damage_factor="5.0" />
@@ -1406,10 +1406,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="42" weight="0.275">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.25">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1424,11 +1424,11 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.275">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.385">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="5.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -674,7 +674,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_polearm_1_t1_handle" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="spear_handle_1" length="149" weight="1.2" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
+  <CraftingPiece id="crpg_peasant_polearm_1_t1_handle" name="{=Uhc0KIdz}Pine Spear Staff" tier="1" piece_type="Handle" mesh="spear_handle_1" length="155" weight="0.9" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
     <BuildData piece_offset="14.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1274,7 +1274,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="1.125" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Pierce" damage_factor="0.6825" />
+      <Swing damage_type="Pierce" damage_factor="3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -21147,9 +21147,9 @@
     "name": "Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 93,
-    "weight": 2.33,
-    "tier": 0.134657323,
+    "price": 3332,
+    "weight": 2.03,
+    "tier": 3.97789764,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21161,7 +21161,7 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 96,
+        "length": 99,
         "balance": 0.48,
         "handling": 70,
         "bodyArmor": 0,
@@ -21174,8 +21174,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 91,
-        "swingDamage": 6,
+        "thrustSpeed": 92,
+        "swingDamage": 30,
         "swingDamageType": "Pierce",
         "swingSpeed": 84
       }

--- a/items.json
+++ b/items.json
@@ -10497,33 +10497,12 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 247,
-    "weight": 1.92,
-    "tier": 0.5271651,
+    "price": 15203,
+    "weight": 1.22,
+    "tier": 9.662041,
     "requirement": 0,
     "flags": [],
     "weapons": [
-      {
-        "class": "OneHandedPolearm",
-        "itemUsage": "onehanded_polearm_block_long_rshield_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 163,
-        "balance": 0.0,
-        "handling": 80,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "WideGrip"
-        ],
-        "thrustDamage": 18,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 41,
-        "swingDamageType": "Cut",
-        "swingSpeed": 54
-      },
       {
         "class": "TwoHandedPolearm",
         "itemUsage": "polearm_block_long_shield_swing_thrust",
@@ -10531,8 +10510,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 163,
-        "balance": 0.72,
-        "handling": 79,
+        "balance": 0.7,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10540,12 +10519,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
+        "thrustSpeed": 99,
         "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 90
       }
     ]
   },
@@ -15402,42 +15381,21 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 161,
-    "weight": 1.84,
-    "tier": 0.322278947,
+    "price": 15175,
+    "weight": 1.23,
+    "tier": 9.65228,
     "requirement": 0,
     "flags": [],
     "weapons": [
-      {
-        "class": "OneHandedPolearm",
-        "itemUsage": "onehanded_polearm_block_long_rshield_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 149,
-        "balance": 0.0,
-        "handling": 81,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "WideGrip"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 40,
-        "swingDamageType": "Cut",
-        "swingSpeed": 57
-      },
       {
         "class": "TwoHandedPolearm",
         "itemUsage": "polearm_block_long_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 149,
+        "length": 148,
         "balance": 0.81,
-        "handling": 81,
+        "handling": 80,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -15447,8 +15405,8 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 40,
+        "thrustSpeed": 100,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
         "swingSpeed": 94
       }
@@ -15459,41 +15417,20 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 204,
-    "weight": 1.38,
-    "tier": 0.4287261,
+    "price": 15530,
+    "weight": 1.1,
+    "tier": 9.777052,
     "requirement": 0,
     "flags": [],
     "weapons": [
-      {
-        "class": "OneHandedPolearm",
-        "itemUsage": "onehanded_polearm_block_long_rshield_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 190,
-        "balance": 0.0,
-        "handling": 72,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "WideGrip"
-        ],
-        "thrustDamage": 14,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 50,
-        "swingDamageType": "Cut",
-        "swingSpeed": 41
-      },
       {
         "class": "TwoHandedPolearm",
         "itemUsage": "polearm_block_long_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 190,
-        "balance": 0.4,
+        "length": 189,
+        "balance": 0.43,
         "handling": 70,
         "bodyArmor": 0,
         "flags": [
@@ -15504,10 +15441,10 @@
         ],
         "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
+        "thrustSpeed": 99,
         "swingDamage": 50,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 82
       }
     ]
   },
@@ -21335,9 +21272,9 @@
     "name": "Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 71,
-    "weight": 2.33,
-    "tier": 0.0683656558,
+    "price": 3461,
+    "weight": 1.42,
+    "tier": 4.072739,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21349,9 +21286,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 99,
-        "balance": 0.57,
-        "handling": 72,
+        "length": 97,
+        "balance": 0.86,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -21362,10 +21299,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 94,
+        "thrustSpeed": 98,
         "swingDamage": 30,
         "swingDamageType": "Pierce",
-        "swingSpeed": 87
+        "swingSpeed": 95
       }
     ]
   },
@@ -29329,45 +29266,23 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 185,
-    "weight": 1.3,
-    "tier": 0.380955279,
+    "price": 15086,
+    "weight": 1.15,
+    "tier": 9.620824,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
     ],
     "weapons": [
       {
-        "class": "OneHandedPolearm",
-        "itemUsage": "onehanded_polearm_block_long_rshield_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 145,
-        "balance": 0.0,
-        "handling": 74,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "WideGrip",
-          "BonusAgainstShield"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 49,
-        "swingDamageType": "Cut",
-        "swingSpeed": 52
-      },
-      {
         "class": "TwoHandedPolearm",
         "itemUsage": "polearm_block_long_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 145,
-        "balance": 0.65,
-        "handling": 72,
+        "length": 143,
+        "balance": 0.56,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -29378,10 +29293,10 @@
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 49,
+        "thrustSpeed": 99,
+        "swingDamage": 54,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 86
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -10426,15 +10426,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-<<<<<<< HEAD
-    "price": 56760,
-    "weight": 1.53,
-    "tier": 19.6928272,
-=======
-    "price": 1120,
-    "weight": 1.92,
-    "tier": 1.92381942,
->>>>>>> 817367ba1d3253423fec289f421190838301a206
+    "price": 15792,
+    "weight": 1.59,
+    "tier": 9.868067,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10446,18 +10440,18 @@
         "stackAmount": 0,
         "length": 163,
         "balance": 0.0,
-        "handling": 75,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 14,
+        "thrustSpeed": 88,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 46
+        "swingSpeed": 44
       },
       {
         "class": "TwoHandedPolearm",
@@ -10466,8 +10460,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 163,
-        "balance": 0.51,
-        "handling": 74,
+        "balance": 0.46,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10478,9 +10472,9 @@
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 96,
-        "swingDamage": 48,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 83
       }
     ]
   },
@@ -15289,15 +15283,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-<<<<<<< HEAD
-    "price": 56437,
-    "weight": 1.74,
-    "tier": 19.6334782,
-=======
-    "price": 287,
-    "weight": 1.84,
-    "tier": 0.614859462,
->>>>>>> 817367ba1d3253423fec289f421190838301a206
+    "price": 15622,
+    "weight": 1.89,
+    "tier": 9.809111,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15307,20 +15295,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 145,
+        "length": 149,
         "balance": 0.0,
-        "handling": 79,
+        "handling": 75,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 16,
+        "thrustSpeed": 85,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 54
+        "swingSpeed": 47
       },
       {
         "class": "TwoHandedPolearm",
@@ -15328,9 +15316,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 145,
-        "balance": 0.7,
-        "handling": 78,
+        "length": 149,
+        "balance": 0.53,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -15340,10 +15328,10 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 45,
+        "thrustSpeed": 94,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 86
       }
     ]
   },
@@ -29107,15 +29095,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-<<<<<<< HEAD
-    "price": 53085,
-    "weight": 1.3,
-    "tier": 19.0078,
-=======
-    "price": 687,
-    "weight": 1.3,
-    "tier": 1.3312757,
->>>>>>> 817367ba1d3253423fec289f421190838301a206
+    "price": 16069,
+    "weight": 1.52,
+    "tier": 9.963823,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -29127,21 +29109,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 143,
+        "length": 140,
         "balance": 0.0,
-        "handling": 70,
+        "handling": 69,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "WideGrip",
-          "BonusAgainstShield"
+          "WideGrip"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 15,
+        "thrustSpeed": 87,
+        "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 42
+        "swingSpeed": 41
       },
       {
         "class": "TwoHandedPolearm",
@@ -29149,23 +29130,22 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 143,
-        "balance": 0.42,
-        "handling": 67,
+        "length": 140,
+        "balance": 0.39,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
-          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 59,
+        "thrustSpeed": 95,
+        "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 81
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -15340,9 +15340,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 135,
-    "weight": 1.38,
-    "tier": 0.252496123,
+    "price": 14708,
+    "weight": 1.24,
+    "tier": 9.485883,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15352,20 +15352,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 206,
+        "length": 190,
         "balance": 0.0,
-        "handling": 64,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 13,
+        "thrustSpeed": 90,
+        "swingDamage": 50,
         "swingDamageType": "Cut",
-        "swingSpeed": 25
+        "swingSpeed": 41
       },
       {
         "class": "TwoHandedPolearm",
@@ -15373,9 +15373,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 206,
-        "balance": 0.05,
-        "handling": 61,
+        "length": 190,
+        "balance": 0.4,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -15383,12 +15383,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 13,
+        "thrustSpeed": 98,
+        "swingDamage": 50,
         "swingDamageType": "Cut",
-        "swingSpeed": 71
+        "swingSpeed": 81
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -15381,9 +15381,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 15175,
-    "weight": 1.23,
-    "tier": 9.65228,
+    "price": 16229,
+    "weight": 1.19,
+    "tier": 10.0187845,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15394,8 +15394,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 148,
-        "balance": 0.81,
-        "handling": 80,
+        "balance": 0.83,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",

--- a/items.json
+++ b/items.json
@@ -10426,9 +10426,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 133,
-    "weight": 1.92,
-    "tier": 0.247856408,
+    "price": 15839,
+    "weight": 1.19,
+    "tier": 9.884594,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10440,7 +10440,7 @@
         "stackAmount": 0,
         "length": 163,
         "balance": 0.0,
-        "handling": 74,
+        "handling": 80,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10448,10 +10448,10 @@
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 38,
+        "thrustSpeed": 93,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 44
+        "swingSpeed": 54
       },
       {
         "class": "TwoHandedPolearm",
@@ -10460,8 +10460,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 163,
-        "balance": 0.46,
-        "handling": 72,
+        "balance": 0.72,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10471,10 +10471,10 @@
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 38,
+        "thrustSpeed": 100,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 91
       }
     ]
   },
@@ -15283,9 +15283,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 149,
-    "weight": 1.84,
-    "tier": 0.288941145,
+    "price": 15264,
+    "weight": 1.27,
+    "tier": 9.683873,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15297,7 +15297,7 @@
         "stackAmount": 0,
         "length": 149,
         "balance": 0.0,
-        "handling": 75,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -15305,10 +15305,10 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 37,
+        "thrustSpeed": 92,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 47
+        "swingSpeed": 57
       },
       {
         "class": "TwoHandedPolearm",
@@ -15317,8 +15317,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 149,
-        "balance": 0.53,
-        "handling": 74,
+        "balance": 0.81,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -15328,10 +15328,10 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 37,
+        "thrustSpeed": 99,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 94
       }
     ]
   },
@@ -21147,9 +21147,9 @@
     "name": "Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 71,
-    "weight": 2.33,
-    "tier": 0.0693582,
+    "price": 1612,
+    "weight": 1.9,
+    "tier": 2.482056,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21162,8 +21162,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.48,
-        "handling": 70,
+        "balance": 0.57,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -21174,10 +21174,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
+        "thrustSpeed": 94,
         "swingDamage": 30,
         "swingDamageType": "Pierce",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -29095,9 +29095,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 129,
-    "weight": 1.3,
-    "tier": 0.236155868,
+    "price": 14728,
+    "weight": 1.04,
+    "tier": 9.493185,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -29109,20 +29109,21 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 140,
+        "length": 145,
         "balance": 0.0,
-        "handling": 69,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "WideGrip"
+          "WideGrip",
+          "BonusAgainstShield"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 93,
         "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 41
+        "swingSpeed": 52
       },
       {
         "class": "TwoHandedPolearm",
@@ -29130,22 +29131,23 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 140,
-        "balance": 0.39,
-        "handling": 66,
+        "length": 145,
+        "balance": 0.65,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
+          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
+        "thrustSpeed": 100,
         "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 89
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -63,8 +63,8 @@
   </CraftedItem>
   <CraftedItem id="crpg_peasant_polearm_1_t1" name="{=aGbTPme1}Scythe" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_peasant_polearm_1_t1_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_peasant_polearm_1_t1_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_peasant_polearm_1_t1_blade" Type="Blade" scale_factor="102" />
+      <Piece id="crpg_peasant_polearm_1_t1_handle" Type="Handle" scale_factor="101" />
     </Pieces>
   </CraftedItem>
   <Item id="crpg_training_bow" name="{=SUSbUAEl}Practice Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.3" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
@@ -679,9 +679,9 @@
   </CraftedItem>
   <CraftedItem id="crpg_khuzait_polearm_1_t4" name="{=6hwZwODh}Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_khuzait_polearm_1_t4_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_khuzait_polearm_1_t4_blade" Type="Blade" scale_factor="112" />
       <Piece id="crpg_khuzait_polearm_1_t4_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_khuzait_polearm_1_t4_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_khuzait_polearm_1_t4_handle" Type="Handle" scale_factor="95" />
       <Piece id="crpg_khuzait_polearm_1_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -719,10 +719,10 @@
   </CraftedItem>
   <CraftedItem id="crpg_khuzait_polearm_2_t5" name="{=JxV66l02}Long Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_khuzait_polearm_2_t5_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_khuzait_polearm_2_t5_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_khuzait_polearm_2_t5_handle" Type="Handle" scale_factor="100" />
-      <Piece id="crpg_khuzait_polearm_2_t5_pommel" Type="Pommel" scale_factor="100" />
+      <Piece id="crpg_khuzait_polearm_2_t5_blade" Type="Blade" scale_factor="92" />
+      <Piece id="crpg_khuzait_polearm_2_t5_guard" Type="Guard" scale_factor="92" />
+      <Piece id="crpg_khuzait_polearm_2_t5_handle" Type="Handle" scale_factor="92" />
+      <Piece id="crpg_khuzait_polearm_2_t5_pommel" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_lance_1_t3" name="{=j4XraSN6}Light Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -679,9 +679,9 @@
   </CraftedItem>
   <CraftedItem id="crpg_khuzait_polearm_1_t4" name="{=6hwZwODh}Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_khuzait_polearm_1_t4_blade" Type="Blade" scale_factor="112" />
+      <Piece id="crpg_khuzait_polearm_1_t4_blade" Type="Blade" scale_factor="102" />
       <Piece id="crpg_khuzait_polearm_1_t4_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_khuzait_polearm_1_t4_handle" Type="Handle" scale_factor="95" />
+      <Piece id="crpg_khuzait_polearm_1_t4_handle" Type="Handle" scale_factor="98" />
       <Piece id="crpg_khuzait_polearm_1_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -2000,25 +2000,19 @@
       <AvailablePiece id="crpg_eastern_javelin_1_t2_pommel" />
       <AvailablePiece id="crpg_northern_javelin_1_t2_pommel" />
       <AvailablePiece id="crpg_western_javelin_1_t2_pommel" />
-      <AvailablePiece id="crpg_khuzait_polearm_2_t5_pommel" />
       <AvailablePiece id="crpg_empire_polearm_2_t5_pommel" />
-      <AvailablePiece id="crpg_vlandia_polearm_1_t5_pommel" />
       <AvailablePiece id="crpg_battania_polearm_1_t5_pommel" />
       <AvailablePiece id="crpg_easter_polesword_t4_pommel" />
-      <AvailablePiece id="crpg_khuzait_polearm_1_t4_pommel" />
-      <AvailablePiece id="crpg_empire_polearm_1_t4_pommel" />
       <AvailablePiece id="crpg_sturgia_polearm_1_t5_pommel" />
       <AvailablePiece id="crpg_billhook_polearm_t2_pommel" />
       <AvailablePiece id="crpg_eastern_spear_3_t3_pommel" />
       <AvailablePiece id="crpg_practice_spear_t1_pommel" />
       <AvailablePiece id="crpg_khuzait_lance_1_t3_guard" />
-      <AvailablePiece id="crpg_khuzait_polearm_1_t4_guard" />
       <AvailablePiece id="crpg_southern_spear_3_t3_guard" />
       <AvailablePiece id="crpg_western_spear_3_t3_guard" />
       <AvailablePiece id="crpg_western_spear_5_t4_guard" />
       <AvailablePiece id="crpg_western_spear_4_t4_guard" />
       <AvailablePiece id="crpg_northern_spear_2_t3_guard" />
-      <AvailablePiece id="crpg_empire_polearm_1_t4_guard" />
       <AvailablePiece id="crpg_generic_javelin_1_t3_guard" />
       <AvailablePiece id="crpg_northern_javelin_1_t2_guard" />
       <AvailablePiece id="crpg_khuzait_lance_3_t5_guard" />
@@ -2038,9 +2032,7 @@
       <AvailablePiece id="crpg_western_javelin_2_t3_guard" />
       <AvailablePiece id="crpg_eastern_javelin_1_t2_guard" />
       <AvailablePiece id="crpg_western_javelin_1_t2_guard" />
-      <AvailablePiece id="crpg_khuzait_polearm_2_t5_guard" />
       <AvailablePiece id="crpg_empire_polearm_2_t5_guard" />
-      <AvailablePiece id="crpg_vlandia_polearm_1_t5_guard" />
       <AvailablePiece id="crpg_easter_polesword_t4_guard" />
       <AvailablePiece id="crpg_sturgia_polearm_1_t5_guard" />
       <AvailablePiece id="crpg_billhook_polearm_t2_guard" />
@@ -2080,12 +2072,8 @@
       <AvailablePiece id="crpg_easter_polesword_t4_handle" />
       <AvailablePiece id="crpg_northern_spear_3_t4_handle" />
       <AvailablePiece id="crpg_eastern_spear_4_t4_handle" />
-      <AvailablePiece id="crpg_khuzait_polearm_1_t4_handle" />
-      <AvailablePiece id="crpg_empire_polearm_1_t4_handle" />
       <AvailablePiece id="crpg_empire_lance_1_t3_handle" />
-      <AvailablePiece id="crpg_khuzait_polearm_2_t5_handle" />
       <AvailablePiece id="crpg_empire_polearm_2_t5_handle" />
-      <AvailablePiece id="crpg_vlandia_polearm_1_t5_handle" />
       <AvailablePiece id="crpg_battania_polearm_1_t5_handle" />
       <AvailablePiece id="crpg_eastern_spear_5_t5_handle" />
       <AvailablePiece id="crpg_military_fork_t2_handle" />
@@ -2124,11 +2112,9 @@
       <AvailablePiece id="crpg_eastern_spear_5_t5_blade" />
       <AvailablePiece id="crpg_military_fork_t2_blade" />
       <AvailablePiece id="crpg_military_fork_pike_t3_blade" />
-      <AvailablePiece id="crpg_khuzait_polearm_2_t5_blade" />
       <AvailablePiece id="crpg_empire_lance_1_t3_blade" />
       <AvailablePiece id="crpg_easter_polesword_t4_blade" />
       <AvailablePiece id="crpg_vlandia_lance_1_t3_blade" />
-      <AvailablePiece id="crpg_khuzait_polearm_1_t4_blade" />
       <AvailablePiece id="crpg_empire_polearm_2_t5_blade" />
       <AvailablePiece id="crpg_western_javelin_1_t2_blade" />
       <AvailablePiece id="crpg_imperial_throwing_spear_1_t4_blade" />
@@ -2153,7 +2139,6 @@
       <AvailablePiece id="crpg_highland_spear_3_t3_blade" />
       <AvailablePiece id="crpg_western_spear_4_t3_blade" />
       <AvailablePiece id="crpg_western_spear_3_t3_blade" />
-      <AvailablePiece id="crpg_empire_polearm_1_t4_blade" />
       <AvailablePiece id="crpg_empire_lance_3_t5_blade" />
       <AvailablePiece id="crpg_vlandia_pike_1_t5_blade" />
       <AvailablePiece id="crpg_vlandia_lance_3_t5_blade" />
@@ -2164,7 +2149,6 @@
       <AvailablePiece id="crpg_triangluar_spear_t3_blade" />
       <AvailablePiece id="crpg_western_javelin_2_t3_blade" />
       <AvailablePiece id="crpg_western_spear_1_t2_blade" />
-      <AvailablePiece id="crpg_vlandia_polearm_1_t5_blade" />
     </AvailablePieces>
   </WeaponDescription>
   <WeaponDescription id="crpg_OneHandedPolearm_JavelinAlternative" weapon_class="OneHandedPolearm" item_usage_features="onehanded_polearm:block:shield:thrust">


### PR DESCRIPTION
Balanced the following weapons:

- Glaive
- Long Glaive
- Voulge (BonusAgainstShield included in Tier)
- Menavlion
- Scythe

One concern I had, was that adding the BonusAgainstShield flag to Voulge also seems to apply to its 1h mode. Is there a way to do this without its 1h mode including the flag?