### PR TITLE
Change lower tier 2h class

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -4827,10 +4827,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="116.3" weight="1.13">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="1.145" />
+      <Swing damage_type="Cut" damage_factor="1.76" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5182,10 +5182,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_2hsword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.5">
+  <CraftingPiece id="crpg_battania_2hsword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="81.2" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="0.77" />
-      <Swing damage_type="Cut" damage_factor="1.085" />
+      <Thrust damage_type="Pierce" damage_factor="0.83" />
+      <Swing damage_type="Cut" damage_factor="1.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5604,10 +5604,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_justicier_2hsword_blade" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.94">
+  <CraftingPiece id="crpg_justicier_2hsword_blade" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="96" weight="1.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.19" />
+      <Swing damage_type="Cut" damage_factor="2.09" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5700,7 +5700,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_2hsword_t1_blade" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="0.4" is_hidden="true" CraftingCost="75">
+  <CraftingPiece id="crpg_wooden_2hsword_t1_blade" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="99" weight="0.37" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Blunt" damage_factor="0.28" />
       <Swing damage_type="Blunt" damage_factor="0.525" />

--- a/items.json
+++ b/items.json
@@ -3022,9 +3022,9 @@
     "name": "Iron Broadsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 413,
-    "weight": 1.99,
-    "tier": 0.9730627,
+    "price": 2256,
+    "weight": 1.0,
+    "tier": 3.40120435,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3037,19 +3037,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.9,
-        "handling": 89,
+        "balance": 1.0,
+        "handling": 95,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 8,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 10,
+        "thrustSpeed": 102,
+        "swingDamage": 15,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 112
       }
     ]
   },
@@ -14370,9 +14370,9 @@
     "name": "Justicier",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1253,
-    "weight": 1.41,
-    "tier": 2.29706454,
+    "price": 2191,
+    "weight": 2.16,
+    "tier": 3.3385694,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -14384,9 +14384,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 105,
-        "balance": 1.0,
-        "handling": 92,
+        "length": 109,
+        "balance": 0.71,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -14394,10 +14394,10 @@
         ],
         "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 11,
+        "thrustSpeed": 92,
+        "swingDamage": 20,
         "swingDamageType": "Cut",
-        "swingSpeed": 104
+        "swingSpeed": 91
       }
     ]
   },
@@ -29745,9 +29745,9 @@
     "name": "Tapered Two-Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 780,
-    "weight": 1.67,
-    "tier": 1.62976027,
+    "price": 2281,
+    "weight": 1.6,
+    "tier": 3.42552114,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29759,19 +29759,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
-        "balance": 0.53,
-        "handling": 87,
+        "length": 133,
+        "balance": 0.19,
+        "handling": 76,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 12,
+        "swingDamage": 17,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 75
       },
       {
         "class": "TwoHandedSword",
@@ -29779,20 +29779,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
-        "balance": 1.0,
-        "handling": 91,
+        "length": 133,
+        "balance": 0.77,
+        "handling": 84,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 96,
-        "swingDamage": 12,
+        "swingDamage": 17,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 93
       },
       {
         "class": "OneHandedSword",
@@ -29800,19 +29800,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
-        "balance": 0.53,
-        "handling": 87,
+        "length": 133,
+        "balance": 0.19,
+        "handling": 76,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 12,
+        "swingDamage": 17,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 75
       }
     ]
   },
@@ -30930,9 +30930,9 @@
     "name": "Wooden Twohander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 602,
-    "weight": 0.55,
-    "tier": 1.33279145,
+    "price": 636,
+    "weight": 0.52,
+    "tier": 1.39118755,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30942,9 +30942,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 104,
+        "length": 116,
         "balance": 1.0,
-        "handling": 106,
+        "handling": 104,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon",
@@ -30955,7 +30955,7 @@
         "thrustSpeed": 101,
         "swingDamage": 5,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 108
       },
       {
         "class": "TwoHandedSword",
@@ -30963,9 +30963,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 104,
+        "length": 116,
         "balance": 1.0,
-        "handling": 100,
+        "handling": 99,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon",
@@ -30977,7 +30977,7 @@
         "thrustSpeed": 108,
         "swingDamage": 5,
         "swingDamageType": "Blunt",
-        "swingSpeed": 118
+        "swingSpeed": 117
       },
       {
         "class": "OneHandedSword",
@@ -30985,9 +30985,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 104,
+        "length": 116,
         "balance": 1.0,
-        "handling": 106,
+        "handling": 104,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon",
@@ -30998,7 +30998,7 @@
         "thrustSpeed": 101,
         "swingDamage": 5,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 108
       }
     ]
   },


### PR DESCRIPTION
rework wooden 2h into a mid-length tier1 weapon. Justicier (aim for higher damage), Iron Broadsword (aim to faster swing), and Tapered 2h (aim for longer length) are set to around tier 3 for new players, with 3 different styles.