### PR TITLE
1h Swords Battania update to new tiers

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -3074,7 +3074,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.001">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.01">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3762,7 +3762,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.001">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.01">
     <BuildData piece_offset="-0.22" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron4" count="2" />
@@ -4107,7 +4107,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.001">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.01">
     <BuildData next_piece_offset="1.8" previous_piece_offset="-0.3" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4854,7 +4854,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.28">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="2.8" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2773,7 +2773,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_pommel" name="{=Oz6xANFb}Highland Ornamental Pommel" tier="4" piece_type="Pommel" mesh="battania_noble_pommel_1" culture="Culture.battania" length="4.1" weight="0.12">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_pommel" name="{=Oz6xANFb}Highland Ornamental Pommel" tier="4" piece_type="Pommel" mesh="battania_noble_pommel_1" culture="Culture.battania" length="4.1" weight="0.1">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -2893,7 +2893,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_pommel" name="{=OW7w3Mth}Fian's Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_5" culture="Culture.battania" length="10" weight="0.315">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_pommel" name="{=OW7w3Mth}Fian's Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_5" culture="Culture.battania" length="10" weight="0.35">
     <BuildData next_piece_offset="0.2" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3074,12 +3074,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.14">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.001">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.14">
+  <CraftingPiece id="crpg_battania_sword_5_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.1">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3089,22 +3089,22 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_4_t4_pommel" name="{=RBoqow67}Egg Pommel" tier="4" piece_type="Pommel" mesh="battania_pommel_4" culture="Culture.battania" length="6.6" weight="0.181">
+  <CraftingPiece id="crpg_battania_sword_4_t4_pommel" name="{=RBoqow67}Egg Pommel" tier="4" piece_type="Pommel" mesh="battania_pommel_4" culture="Culture.battania" length="6.6" weight="0.1">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.140">
+  <CraftingPiece id="crpg_battania_sword_3_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.1">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.140">
+  <CraftingPiece id="crpg_battania_sword_2_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.1">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_1_t2_pommel" name="{=dgjXkbuA}Owlseye Pommel" tier="2" piece_type="Pommel" mesh="battania_pommel_1" culture="Culture.battania" length="4.027" weight="0.12">
+  <CraftingPiece id="crpg_battania_sword_1_t2_pommel" name="{=dgjXkbuA}Owlseye Pommel" tier="2" piece_type="Pommel" mesh="battania_pommel_1" culture="Culture.battania" length="4.027" weight="0.1">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3376,7 +3376,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_handle" name="{=d2kOHsY7}Decorated Broadsword Grip" tier="4" piece_type="Handle" mesh="battania_noble_grip_1" culture="Culture.battania" length="14.7" weight="0.225">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_handle" name="{=d2kOHsY7}Decorated Broadsword Grip" tier="4" piece_type="Handle" mesh="battania_noble_grip_1" culture="Culture.battania" length="14.7" weight="0.13">
     <BuildData piece_offset="0" previous_piece_offset="0.1" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -3750,43 +3750,43 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.225" item_holster_pos_shift="0,0,-0.03">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.4" item_holster_pos_shift="0,0,-0.03">
     <BuildData piece_offset="-1.88" previous_piece_offset="0.1" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.225" item_holster_pos_shift="0,0,-0.03">
+  <CraftingPiece id="crpg_battania_sword_5_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.15" item_holster_pos_shift="0,0,-0.03">
     <BuildData piece_offset="-1.88" previous_piece_offset="0.1" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.1">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.001">
     <BuildData piece_offset="-0.22" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_4_t4_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.1">
+  <CraftingPiece id="crpg_battania_sword_4_t4_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.3">
     <BuildData piece_offset="-0.22" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_handle" name="{=gZzEkk5t}Highland Fine Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_8" culture="Culture.battania" length="25" weight="0.225">
+  <CraftingPiece id="crpg_battania_sword_3_t3_handle" name="{=gZzEkk5t}Highland Fine Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_8" culture="Culture.battania" length="25" weight="0.1">
     <BuildData piece_offset="0" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_handle" name="{=62biJ5O5}Highland Fine Leather One Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_3" culture="Culture.battania" length="15" weight="0.225">
+  <CraftingPiece id="crpg_battania_sword_2_t3_handle" name="{=62biJ5O5}Highland Fine Leather One Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_3" culture="Culture.battania" length="15" weight="0.6">
     <BuildData piece_offset="0" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_1_t2_handle" name="{=uvmvs2SP}Tall Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_3" culture="Culture.aserai" length="19.855" weight="0.165">
+  <CraftingPiece id="crpg_battania_sword_1_t2_handle" name="{=uvmvs2SP}Tall Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_3" culture="Culture.aserai" length="19.855" weight="0.1">
     <BuildData piece_offset="-2.18" previous_piece_offset="0.2" next_piece_offset="0.2" />
     <Materials>
       <Material id="Iron2" count="3" />
@@ -4107,21 +4107,21 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.298">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.001">
     <BuildData next_piece_offset="1.8" previous_piece_offset="-0.3" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.097">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.1">
     <BuildData next_piece_offset="0.6" />
     <StatContributions armor_bonus="3" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.097">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.23">
     <BuildData next_piece_offset="0.6" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4296,7 +4296,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_guard" name="{=61A1VUw8}Knobbed Bronze Guard" tier="5" piece_type="Guard" mesh="battania_guard_9" culture="Culture.battania" length="5.3" weight="0.097">
+  <CraftingPiece id="crpg_battania_sword_5_t5_guard" name="{=61A1VUw8}Knobbed Bronze Guard" tier="5" piece_type="Guard" mesh="battania_guard_9" culture="Culture.battania" length="5.3" weight="0.1">
     <BuildData next_piece_offset="1.8" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4317,14 +4317,14 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_guard" name="{=NuXH8rip}Layered Bronze Guard" tier="1" piece_type="Guard" mesh="battania_guard_8" culture="Culture.battania" length="2.6" weight="0.086">
+  <CraftingPiece id="crpg_battania_sword_3_t3_guard" name="{=NuXH8rip}Layered Bronze Guard" tier="1" piece_type="Guard" mesh="battania_guard_8" culture="Culture.battania" length="2.6" weight="0.1">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_1_t2_guard" name="{=artqaNEi}Knobbed Iron Guard" tier="1" piece_type="Guard" mesh="battania_guard_7" culture="Culture.battania" length="5.7" weight="0.300">
+  <CraftingPiece id="crpg_battania_sword_1_t2_guard" name="{=artqaNEi}Knobbed Iron Guard" tier="1" piece_type="Guard" mesh="battania_guard_7" culture="Culture.battania" length="5.7" weight="0.1">
     <BuildData next_piece_offset="1.8" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4338,7 +4338,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_guard" name="{=AkfEFzkk}Bowl Guard" tier="2" piece_type="Guard" mesh="battania_guard_6" culture="Culture.battania" length="5.7" weight="0.295">
+  <CraftingPiece id="crpg_battania_sword_2_t3_guard" name="{=AkfEFzkk}Bowl Guard" tier="2" piece_type="Guard" mesh="battania_guard_6" culture="Culture.battania" length="5.7" weight="0.1">
     <BuildData next_piece_offset="1.8" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4352,7 +4352,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_4_t4_guard" name="{=sq7G99xP}Crown Guard" tier="4" piece_type="Guard" mesh="battania_guard_3" culture="Culture.battania" length="2.8" weight="0.112">
+  <CraftingPiece id="crpg_battania_sword_4_t4_guard" name="{=sq7G99xP}Crown Guard" tier="4" piece_type="Guard" mesh="battania_guard_3" culture="Culture.battania" length="2.8" weight="0.1">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4674,10 +4674,10 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_blade" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.5">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_blade" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.565">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.4" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4830,7 +4830,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBcrpg_battania_noble_sword_2_t5_bladeF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="0.945" />
       <Swing damage_type="Cut" damage_factor="1.26" />
@@ -4854,10 +4854,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.8">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.28">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4866,9 +4866,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_blade" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="1.05">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_blade" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -5197,10 +5197,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.06">
+  <CraftingPiece id="crpg_battania_sword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5221,10 +5221,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_blade" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.98">
+  <CraftingPiece id="crpg_battania_sword_5_t5_blade" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="1.4">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5233,10 +5233,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_blade" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="1.15">
+  <CraftingPiece id="crpg_battania_sword_2_t3_blade" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="1.4" />
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5257,10 +5257,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_blade" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.03">
+  <CraftingPiece id="crpg_battania_sword_3_t3_blade" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.55">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.4" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="1.1" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5269,10 +5269,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_4_t4_blade" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.05">
+  <CraftingPiece id="crpg_battania_sword_4_t4_blade" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.28">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />

--- a/items.json
+++ b/items.json
@@ -4522,9 +4522,9 @@
     "name": "Engraved Backsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7974,
-    "weight": 1.68,
-    "tier": 10.3465776,
+    "price": 7530,
+    "weight": 1.84,
+    "tier": 10.0222273,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4537,15 +4537,15 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 109,
-        "balance": 0.48,
-        "handling": 82,
+        "balance": 0.49,
+        "handling": 81,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 87,
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 84
@@ -4554,12 +4554,12 @@
   },
   {
     "id": "crpg_battania_noble_sword_2_t5",
-    "name": "Highland Fine Steel Blade",
+    "name": "Highland Pointed Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 17266,
-    "weight": 1.44,
-    "tier": 15.7561636,
+    "price": 5695,
+    "weight": 1.45,
+    "tier": 8.570821,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4572,18 +4572,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.75,
-        "handling": 95,
+        "balance": 0.47,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 30,
+        "thrustSpeed": 91,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 84
       }
     ]
   },
@@ -4592,9 +4592,9 @@
     "name": "Decorated Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7982,
-    "weight": 1.88,
-    "tier": 10.3518448,
+    "price": 7564,
+    "weight": 1.84,
+    "tier": 10.0474939,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4607,18 +4607,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.31,
-        "handling": 84,
+        "balance": 0.28,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 78
       }
     ]
   },
@@ -4740,9 +4740,9 @@
     "name": "Ridged Iron Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7212,
-    "weight": 1.68,
-    "tier": 9.785129,
+    "price": 3359,
+    "weight": 2.0,
+    "tier": 6.326738,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4754,30 +4754,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 95,
-        "balance": 0.66,
-        "handling": 92,
+        "length": 97,
+        "balance": 0.3,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 78
       }
     ]
   },
   {
     "id": "crpg_battania_sword_2_t3",
-    "name": "Broad Ridged Shortsword",
+    "name": "Fine Steel Broad Shortsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4093,
-    "weight": 1.92,
-    "tier": 7.09823465,
+    "price": 5702,
+    "weight": 2.01,
+    "tier": 8.577124,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4790,29 +4790,29 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.66,
-        "handling": 95,
+        "balance": 0.68,
+        "handling": 96,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 25,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 90
       }
     ]
   },
   {
     "id": "crpg_battania_sword_3_t3",
-    "name": "Broadsword",
+    "name": "Steel Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 12347,
-    "weight": 1.51,
-    "tier": 13.1489506,
+    "price": 4617,
+    "weight": 1.96,
+    "tier": 7.60711956,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4824,19 +4824,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 98,
-        "balance": 0.69,
-        "handling": 92,
+        "length": 101,
+        "balance": 0.28,
+        "handling": 84,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 78
       }
     ]
   },
@@ -4845,9 +4845,9 @@
     "name": "Fine Steel Cavalry Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 6689,
-    "weight": 1.55,
-    "tier": 9.38228,
+    "price": 5585,
+    "weight": 1.93,
+    "tier": 8.477069,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4857,19 +4857,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 117,
-        "balance": 0.45,
-        "handling": 85,
+        "length": 120,
+        "balance": 0.23,
+        "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 31,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 76
       }
     ]
   },
@@ -4878,9 +4878,9 @@
     "name": "Highland Broad Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 18516,
-    "weight": 1.53,
-    "tier": 16.3566875,
+    "price": 6256,
+    "weight": 1.96,
+    "tier": 9.0364,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4892,19 +4892,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 99,
-        "balance": 0.69,
-        "handling": 92,
+        "length": 104,
+        "balance": 0.29,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 13,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 78
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -4558,7 +4558,7 @@
     "culture": "Battania",
     "type": "OneHandedWeapon",
     "price": 5695,
-    "weight": 1.45,
+    "weight": 1.44,
     "tier": 8.570821,
     "requirement": 0,
     "flags": [
@@ -4572,7 +4572,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.47,
+        "balance": 0.48,
         "handling": 88,
         "bodyArmor": 5,
         "flags": [

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -842,7 +842,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_battania_sword_1_t2" name="{=habJjtmv}Ridged Iron Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_1_t2_blade" Type="Blade" scale_factor="103" />
+      <Piece id="crpg_battania_sword_1_t2_blade" Type="Blade" scale_factor="106" />
       <Piece id="crpg_battania_sword_1_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_1_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
@@ -944,7 +944,7 @@
       <Piece id="crpg_sturgia_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_battania_sword_2_t3" name="{=HwO0AYul}Broad Ridged Shortsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_battania_sword_2_t3" name="{=HwO0AYul}Fine Steel Broad Shortsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_battania_sword_2_t3_blade" Type="Blade" scale_factor="110" />
       <Piece id="crpg_battania_sword_2_t3_guard" Type="Guard" scale_factor="100" />
@@ -952,9 +952,9 @@
       <Piece id="crpg_battania_sword_2_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_battania_sword_3_t3" name="{=8jEDX9J4}Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_battania_sword_3_t3" name="{=8jEDX9J4}Steel Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_3_t3_blade" Type="Blade" scale_factor="103" />
+      <Piece id="crpg_battania_sword_3_t3_blade" Type="Blade" scale_factor="107" />
       <Piece id="crpg_battania_sword_3_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_3_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1098,7 +1098,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_battania_sword_4_t4" name="{=57jpWo7g}Fine Steel Cavalry Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_4_t4_blade" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_battania_sword_4_t4_blade" Type="Blade" scale_factor="112" />
       <Piece id="crpg_battania_sword_4_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_4_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_4_t4_pommel" Type="Pommel" scale_factor="100" />
@@ -1170,7 +1170,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_battania_sword_5_t5" name="{=l9kAJ1Xh}Highland Broad Blade" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_5_t5_blade" Type="Blade" scale_factor="109" />
+      <Piece id="crpg_battania_sword_5_t5_blade" Type="Blade" scale_factor="115" />
       <Piece id="crpg_battania_sword_5_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_5_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_5_t5_pommel" Type="Pommel" scale_factor="100" />
@@ -1328,7 +1328,7 @@
       <Piece id="crpg_battania_noble_sword_1_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_battania_noble_sword_2_t5" name="{=finesteelbladeweapon}Highland Fine Steel Blade" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_battania_noble_sword_2_t5" name="{=finesteelbladeweapon}Highland Pointed Blade" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_battania_noble_sword_2_t5_blade" Type="Blade" scale_factor="113" />
       <Piece id="crpg_battania_noble_sword_2_t5_guard" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
All battania 1h swords given a thorough rebalance with new tier formula

Engraved Backsword
Decorated Broadsword
Highland Broad Blade
Broad Ridged Shortsword renamed to Fine Steel Broad Shortsword to fit in the lineup of broadswords better
Highland Fine Steel Blade renamed to Highland Highland Pointed Blade to indicate thrust specialty
Fine Steel Cavalry Broadsword
Broadsword renamed to Steel Broadsword to fit in the lineup of broadswords better
Ridged Iron Broadsword