### PR TITLE
Update Light Rider/Cav/Plane Lance to new standard

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1355,7 +1355,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_empire_lance_1_t3_blade" name="{=OryiZr9d}Kontarion" tier="3" piece_type="Blade" mesh="spear_blade_23" length="42" weight="0.352" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1624,7 +1624,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_lance_1_t3_blade" name="{=ZUp9mm79}Jagged Spear Head" tier="3" piece_type="Blade" mesh="spear_blade_35" length="41" weight="0.3056" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_5_1" holster_body_name="bo_throwing_spear_quiver_5_1" holster_mesh_length="96.7">
-      <Thrust damage_type="Pierce" damage_factor="0.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1763,7 +1763,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_vlandia_lance_1_t3_blade" name="{=uwG8iwBc}Long Grassland Spear" tier="3" piece_type="Blade" mesh="spear_blade_20" length="46" weight="0.3592" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.735" />
+      <Thrust damage_type="Pierce" damage_factor="1.735" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />

--- a/items.json
+++ b/items.json
@@ -10034,9 +10034,9 @@
     "name": "Light Cavalry Lance",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 164,
-    "weight": 1.95,
-    "tier": 0.3294393,
+    "price": 878,
+    "weight": 2.73,
+    "tier": 1.60796309,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10046,20 +10046,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 179,
+        "length": 250,
         "balance": 0.0,
-        "handling": 63,
+        "handling": 51,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 75,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 25
+        "swingSpeed": 13
       },
       {
         "class": "TwoHandedPolearm",
@@ -10067,9 +10067,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 179,
-        "balance": 0.07,
-        "handling": 60,
+        "length": 250,
+        "balance": 0.0,
+        "handling": 47,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10077,12 +10077,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 84,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 72
+        "swingSpeed": 50
       },
       {
         "class": "TwoHandedPolearm",
@@ -10090,20 +10090,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 179,
+        "length": 250,
         "balance": 0.0,
-        "handling": 63,
+        "handling": 51,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 75,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 25
+        "swingSpeed": 13
       }
     ]
   },
@@ -14908,9 +14908,9 @@
     "name": "Light Steppe Rider Lance",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 159,
-    "weight": 1.91,
-    "tier": 0.316338,
+    "price": 825,
+    "weight": 2.67,
+    "tier": 1.53338468,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -14920,20 +14920,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 198,
+        "length": 277,
         "balance": 0.0,
-        "handling": 60,
+        "handling": 48,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 82,
+        "thrustSpeed": 75,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 18
+        "swingSpeed": 12
       },
       {
         "class": "TwoHandedPolearm",
@@ -14941,9 +14941,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 198,
+        "length": 277,
         "balance": 0.0,
-        "handling": 56,
+        "handling": 44,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -14951,12 +14951,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 83,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 67
+        "swingSpeed": 46
       }
     ]
   },
@@ -28704,9 +28704,9 @@
     "name": "Light Lance",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 156,
-    "weight": 2.12,
-    "tier": 0.308681756,
+    "price": 696,
+    "weight": 2.81,
+    "tier": 1.34394765,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28716,20 +28716,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 208,
+        "length": 277,
         "balance": 0.0,
-        "handling": 57,
+        "handling": 46,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 80,
+        "thrustSpeed": 73,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 16
+        "swingSpeed": 11
       },
       {
         "class": "TwoHandedPolearm",
@@ -28737,9 +28737,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 208,
+        "length": 277,
         "balance": 0.0,
-        "handling": 53,
+        "handling": 42,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28747,12 +28747,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 82,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 62
+        "swingSpeed": 42
       },
       {
         "class": "TwoHandedPolearm",
@@ -28760,20 +28760,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 208,
+        "length": 277,
         "balance": 0.0,
-        "handling": 57,
+        "handling": 46,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 80,
+        "thrustSpeed": 73,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 16
+        "swingSpeed": 11
       },
       {
         "class": "TwoHandedPolearm",
@@ -28781,9 +28781,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 208,
+        "length": 277,
         "balance": 0.0,
-        "handling": 53,
+        "handling": 42,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28791,12 +28791,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 82,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 62
+        "swingSpeed": 42
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -727,21 +727,21 @@
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_lance_1_t3" name="{=j4XraSN6}Light Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_vlandia_lance_1_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_vlandia_lance_1_t3_handle" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_vlandia_lance_1_t3_blade" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_vlandia_lance_1_t3_handle" Type="Handle" scale_factor="144" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_empire_lance_1_t3" name="{=TQ1MVhIX}Light Cavalry Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_empire_lance_1_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_empire_lance_1_t3_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_empire_lance_1_t3_blade" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_empire_lance_1_t3_handle" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_khuzait_lance_1_t3" name="{=UWvOndG0}Light Steppe Rider Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_khuzait_lance_1_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_khuzait_lance_1_t3_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_khuzait_lance_1_t3_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_khuzait_lance_1_t3_blade" Type="Blade" scale_factor="140" />
+      <Piece id="crpg_khuzait_lance_1_t3_guard" Type="Guard" scale_factor="140" />
+      <Piece id="crpg_khuzait_lance_1_t3_handle" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_aserai_lance_1_t5" name="{=hsRwbHSk}Mamluke Lance" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">


### PR DESCRIPTION
Namidaka — Yesterday at 11:22 PM
remove couchable from all lance.
Change the scale factor of 2 or 3 lances to make the length something between 250 and 280. Make sure they have low thrust speed and low damage (maybe 18 damage?). Give them couch 

Updated Light Lance, Light Steppe Rider Lance, Light Cavalry Lance to 250-280 range, provided couching, and 17p. Removed couching from rest of lances.