### PR TITLE
1h Swords Neutral initial stats pass

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2822,7 +2822,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.2">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.1">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -2832,7 +2832,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.12">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.1">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -2847,7 +2847,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_pommel" name="{=HmsEarnz}Teardrop Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_9" culture="Culture.sturgia" length="4.744" weight="0.2">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_pommel" name="{=HmsEarnz}Teardrop Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_9" culture="Culture.sturgia" length="4.744" weight="0.01">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -2975,7 +2975,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.150">
+  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.1">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3005,12 +3005,12 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.14">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.1">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.14">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.11">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3041,7 +3041,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.15">
+  <CraftingPiece id="crpg_falchion_sword_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.05">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3295,7 +3295,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_sword_t4_pommel" name="{=aZp1ur9Q}Chalice Pommel" tier="2" piece_type="Pommel" mesh="empire_pommel_1" culture="Culture.empire" length="2.2" weight="0.111">
+  <CraftingPiece id="crpg_pointed_falchion_sword_t4_pommel" name="{=aZp1ur9Q}Chalice Pommel" tier="2" piece_type="Pommel" mesh="empire_pommel_1" culture="Culture.empire" length="2.2" weight="0.15">
     <BuildData next_piece_offset="0.2" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3311,7 +3311,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.14">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.1">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3371,7 +3371,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_sword_t1_handle" name="{=DkhuNoTH}Wooden One Handed Grip" tier="1" piece_type="Handle" mesh="wood_grip_1" length="15" weight="0.045" CraftingCost="75" is_default="true">
+  <CraftingPiece id="crpg_wooden_sword_t1_handle" name="{=DkhuNoTH}Wooden One Handed Grip" tier="1" piece_type="Handle" mesh="wood_grip_1" length="15" weight="0.1" CraftingCost="75" is_default="true">
     <BuildData piece_offset="0" previous_piece_offset="0.4" next_piece_offset="0.3" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -3419,7 +3419,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.2">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.24">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3443,7 +3443,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.150">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.3">
     <BuildData piece_offset="-1.98" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3461,7 +3461,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_handle" name="{=tRJC72Qh}Leather Crossed One Handed" tier="3" piece_type="Handle" mesh="sturgian_grip_35" culture="Culture.sturgia" length="15" weight="0.30">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_handle" name="{=tRJC72Qh}Leather Crossed One Handed" tier="3" piece_type="Handle" mesh="sturgian_grip_35" culture="Culture.sturgia" length="15" weight="0.38">
     <BuildData piece_offset="-1" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3654,7 +3654,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.20">
+  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.15">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3672,7 +3672,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.2">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.02">
     <BuildData piece_offset="-1" previous_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3696,13 +3696,13 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.1">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.43">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_handle" name="{=dBVMNui8}Iron Reinforced Horn Two Handed Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_18" culture="Culture.vlandia" length="26.1" weight="0.14">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_handle" name="{=dBVMNui8}Iron Reinforced Horn Two Handed Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_18" culture="Culture.vlandia" length="26.1" weight="0.39">
     <BuildData piece_offset="-0.36" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="2" />
@@ -3720,7 +3720,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_handle" name="{=BL96pnde}Rough Leather One Handed Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_5" culture="Culture.aserai" length="15.857" weight="0.105">
+  <CraftingPiece id="crpg_falchion_sword_t2_handle" name="{=BL96pnde}Rough Leather One Handed Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_5" culture="Culture.aserai" length="15.857" weight="0.3">
     <BuildData piece_offset="-0.39" previous_piece_offset="0" next_piece_offset="-0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3949,7 +3949,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_sword_t4_handle" name="{=H2xibh6p}Studded Imperial Grip" tier="4" piece_type="Handle" mesh="empire_grip_5" culture="Culture.empire" length="15" weight="0.12">
+  <CraftingPiece id="crpg_pointed_falchion_sword_t4_handle" name="{=H2xibh6p}Studded Imperial Grip" tier="4" piece_type="Handle" mesh="empire_grip_5" culture="Culture.empire" length="15" weight="0.47">
     <BuildData piece_offset="0" next_piece_offset="0.91" previous_piece_offset="0.8" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -4094,7 +4094,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.2">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.22">
     <BuildData next_piece_offset="1.9" previous_piece_offset="-0.4" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4220,14 +4220,14 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_sword_t4_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.046">
+  <CraftingPiece id="crpg_pointed_falchion_sword_t4_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.26">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="2" />
     <Materials>
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.046">
+  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.4">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4283,7 +4283,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.19">
+  <CraftingPiece id="crpg_falchion_sword_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.2">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4381,7 +4381,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_guard" name="{=mm6b54ZD}Wide Concave Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_3" culture="Culture.sturgia" length="1.817" weight="0.27">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_guard" name="{=mm6b54ZD}Wide Concave Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_3" culture="Culture.sturgia" length="1.817" weight="0.28">
     <BuildData next_piece_offset="0.5" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4402,7 +4402,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.25">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.02">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4444,7 +4444,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_guard" name="{=NLs9M1D6}Eastern Simple Oval Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_6" culture="Culture.khuzait" length="0.155" weight="0.10">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_guard" name="{=NLs9M1D6}Eastern Simple Oval Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_6" culture="Culture.khuzait" length="0.155" weight="0.2">
     <BuildData next_piece_offset="0.1" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4500,7 +4500,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.172">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.3">
     <BuildData next_piece_offset="0.4" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4786,10 +4786,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_blade" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.5">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_blade" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.24">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="0.735" />
-      <Swing damage_type="Cut" damage_factor="1.295" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="4" />
@@ -5036,28 +5036,28 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.9350001">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.33">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.9625" />
-      <Swing damage_type="Cut" damage_factor="1.365" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_sword_t4_blade" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.4" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_pointed_falchion_sword_t4_blade" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.11" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="1.575" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_blade" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="1.4">
+  <CraftingPiece id="crpg_cleaver_sword_t3_blade" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="1.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="0.8049999" />
-      <Swing damage_type="Cut" damage_factor="1.295" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -5086,9 +5086,9 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.75" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.27" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
@@ -5119,10 +5119,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="1.3">
+  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="1.02">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
-      <Thrust damage_type="Pierce" damage_factor="0.63" />
-      <Swing damage_type="Cut" damage_factor="1.085" />
+      <Thrust damage_type="Pierce" damage_factor="0.9" />
+      <Swing damage_type="Cut" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5162,10 +5162,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.3">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.29">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.225" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5174,10 +5174,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.3">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.27">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.225" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5502,10 +5502,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.08">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.16">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="0.84" />
-      <Swing damage_type="Cut" damage_factor="1.295" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -5716,10 +5716,10 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_sword_t1_blade" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="0.4" is_hidden="true" CraftingCost="75">
+  <CraftingPiece id="crpg_wooden_sword_t1_blade" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="0.7" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Blunt" damage_factor="0.28" />
-      <Swing damage_type="Blunt" damage_factor="0.525" />
+      <Thrust damage_type="Blunt" damage_factor="0.4" />
+      <Swing damage_type="Blunt" damage_factor="0.8" />
     </BladeData>
     <Flags>
       <Flag name="NoBlood" />

--- a/items.json
+++ b/items.json
@@ -6564,9 +6564,9 @@
     "name": "Broad Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 227,
-    "weight": 2.14,
-    "tier": 0.9088541,
+    "price": 4563,
+    "weight": 1.94,
+    "tier": 7.555654,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6577,18 +6577,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.25,
-        "handling": 82,
+        "balance": 0.42,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 12,
+        "thrustSpeed": 87,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 82
       }
     ]
   },
@@ -7198,12 +7198,12 @@
   },
   {
     "id": "crpg_cleaver_sword_t3",
-    "name": "Cleaver",
+    "name": "Iron Cleaver",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 317,
-    "weight": 1.8,
-    "tier": 1.23877752,
+    "price": 2910,
+    "weight": 2.14,
+    "tier": 5.813064,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7213,19 +7213,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 105,
-        "balance": 0.42,
-        "handling": 86,
+        "length": 99,
+        "balance": 0.36,
+        "handling": 85,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 12,
+        "thrustSpeed": 85,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 80
       }
     ]
   },
@@ -7922,9 +7922,9 @@
     "name": "Dawnbreaker",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 333,
-    "weight": 1.84,
-    "tier": 1.29404223,
+    "price": 6466,
+    "weight": 1.89,
+    "tier": 9.206009,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7936,19 +7936,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 98,
-        "balance": 0.51,
+        "length": 102,
+        "balance": 0.43,
         "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 12,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 83
       }
     ]
   },
@@ -11066,12 +11066,12 @@
   },
   {
     "id": "crpg_falchion_sword_t2",
-    "name": "Falchion",
+    "name": "Iron Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 345,
-    "weight": 1.69,
-    "tier": 1.33295643,
+    "price": 3104,
+    "weight": 1.97,
+    "tier": 6.03931332,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11083,19 +11083,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 71,
-        "balance": 0.88,
-        "handling": 100,
+        "length": 97,
+        "balance": 0.53,
+        "handling": 94,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 6,
+        "thrustDamage": 9,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 10,
+        "thrustSpeed": 87,
+        "swingDamage": 24,
         "swingDamageType": "Cut",
-        "swingSpeed": 96
+        "swingSpeed": 85
       }
     ]
   },
@@ -21716,9 +21716,9 @@
     "name": "Pointed Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 463,
-    "weight": 1.68,
-    "tier": 1.69683087,
+    "price": 4908,
+    "weight": 1.96,
+    "tier": 7.877381,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21728,19 +21728,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 108,
-        "balance": 0.41,
-        "handling": 85,
+        "length": 104,
+        "balance": 0.53,
+        "handling": 88,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 15,
+        "thrustSpeed": 87,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -24604,9 +24604,9 @@
     "name": "Star Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 154,
-    "weight": 2.3,
-    "tier": 0.5932474,
+    "price": 5015,
+    "weight": 2.01,
+    "tier": 7.97491,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24616,19 +24616,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
-        "balance": 0.01,
-        "handling": 76,
+        "length": 108,
+        "balance": 0.36,
+        "handling": 84,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 14,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 70
+        "swingSpeed": 80
       }
     ]
   },
@@ -27209,9 +27209,9 @@
     "name": "Scalpel",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 363,
-    "weight": 1.47,
-    "tier": 1.391722,
+    "price": 6651,
+    "weight": 1.86,
+    "tier": 9.352082,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27221,19 +27221,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 120,
-        "balance": 0.42,
+        "length": 110,
+        "balance": 0.44,
         "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 12,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 83
       }
     ]
   },
@@ -28051,9 +28051,9 @@
     "name": "Tyrhung",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 335,
-    "weight": 1.95,
-    "tier": 1.2996794,
+    "price": 6993,
+    "weight": 1.49,
+    "tier": 9.618001,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -28065,19 +28065,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 96,
-        "balance": 0.52,
-        "handling": 89,
+        "length": 107,
+        "balance": 0.46,
+        "handling": 88,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 12,
+        "thrustSpeed": 90,
+        "swingDamage": 26,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 83
       }
     ]
   },
@@ -30796,9 +30796,9 @@
     "name": "Winds Fury",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 694,
-    "weight": 1.39,
-    "tier": 2.30155087,
+    "price": 6458,
+    "weight": 2.05,
+    "tier": 9.19887352,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30808,19 +30808,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 107,
-        "balance": 0.71,
-        "handling": 90,
+        "length": 116,
+        "balance": 0.25,
+        "handling": 83,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 13,
+        "thrustSpeed": 86,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 77
       }
     ]
   },
@@ -30986,9 +30986,9 @@
     "name": "Wooden Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 333,
-    "weight": 0.58,
-    "tier": 1.29523945,
+    "price": 583,
+    "weight": 0.97,
+    "tier": 2.026218,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30999,19 +30999,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 1.0,
-        "handling": 107,
+        "balance": 0.99,
+        "handling": 99,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon",
           "NoBlood"
         ],
-        "thrustDamage": 2,
+        "thrustDamage": 4,
         "thrustDamageType": "Blunt",
-        "thrustSpeed": 101,
-        "swingDamage": 5,
+        "thrustSpeed": 97,
+        "swingDamage": 8,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 99
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -125,7 +125,7 @@
   </Item>
   <CraftedItem id="crpg_winds_fury_sword_t3" name="{=vDvj5zkG}Winds Fury" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_winds_fury_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_winds_fury_sword_t3_blade" Type="Blade" scale_factor="109" />
       <Piece id="crpg_winds_fury_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_winds_fury_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_winds_fury_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -133,7 +133,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_tyrhung_sword_t3" name="{=TbFLTHHm}Tyrhung" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_tyrhung_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_tyrhung_sword_t3_blade" Type="Blade" scale_factor="113" />
       <Piece id="crpg_tyrhung_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_tyrhung_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_tyrhung_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -141,15 +141,15 @@
   </CraftedItem>
   <CraftedItem id="crpg_the_scalpel_sword_t3" name="{=LzqugHen}Scalpel" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_the_scalpel_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_the_scalpel_sword_t3_blade" Type="Blade" scale_factor="91" />
       <Piece id="crpg_the_scalpel_sword_t3_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_the_scalpel_sword_t3_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_the_scalpel_sword_t3_handle" Type="Handle" scale_factor="94" />
       <Piece id="crpg_the_scalpel_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_dawnbreaker_sword_t3" name="{=J3erdO1b}Dawnbreaker" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_dawnbreaker_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_dawnbreaker_sword_t3_blade" Type="Blade" scale_factor="105" />
       <Piece id="crpg_dawnbreaker_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_dawnbreaker_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_dawnbreaker_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -848,10 +848,10 @@
       <Piece id="crpg_battania_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falchion_sword_t2" name="{=IM2SamZ8}Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_falchion_sword_t2" name="{=IM2SamZ8}Iron Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_falchion_sword_t2_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_falchion_sword_t2_guard" Type="Guard" scale_factor="90" />
+      <Piece id="crpg_falchion_sword_t2_blade" Type="Blade" scale_factor="142" />
+      <Piece id="crpg_falchion_sword_t2_guard" Type="Guard" scale_factor="95" />
       <Piece id="crpg_falchion_sword_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_falchion_sword_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
@@ -962,7 +962,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_star_falchion_sword_t3" name="{=qZOpdQVx}Star Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_star_falchion_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_star_falchion_sword_t3_blade" Type="Blade" scale_factor="97" />
       <Piece id="crpg_star_falchion_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_star_falchion_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_star_falchion_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1000,9 +1000,9 @@
       <Piece id="crpg_narrow_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cleaver_sword_t3" name="{=mfeM775z}Cleaver" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_cleaver_sword_t3" name="{=mfeM775z}Iron Cleaver" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_cleaver_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_cleaver_sword_t3_blade" Type="Blade" scale_factor="93" />
       <Piece id="crpg_cleaver_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_cleaver_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_cleaver_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1106,7 +1106,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_pointed_falchion_sword_t4" name="{=tQw4Zfwu}Pointed Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_pointed_falchion_sword_t4_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_pointed_falchion_sword_t4_blade" Type="Blade" scale_factor="97" />
       <Piece id="crpg_pointed_falchion_sword_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_pointed_falchion_sword_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_pointed_falchion_sword_t4_pommel" Type="Pommel" scale_factor="100" />


### PR DESCRIPTION
Initial pass on stats for all neutral culture 1h swords:

Winds Fury - changed to a cavalry sword so that neutral has one and so one of the unique tournament trophy swords is one
Scalpel - cutting trophy sword
Tyrhung - thrusting trophy sword
Dawnbreaker - balanced trophy sword
Star Falchion
Pointed Falchion
Broad Falchion
Falchion - renamed to Iron Falchion to fit lineups better
Cleaver - renamed to Iron Cleaver to fit lineups
Wooden Sword
 
Following swords arent included in this patch because they will be changed to other cultures in those cultures' respective patches:

Broad Arming Sword - moving to Vlandia
Short Sword - moving to Vlandia

Narrow Sword - Moving to Sturgia
Simple Bastard Sword - Moving to Sturgia