### PR TITLE
1h Swords Tier Update

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2822,7 +2822,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.1">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.04">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -2832,7 +2832,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.1">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.15">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -2975,7 +2975,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.1">
+  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.02">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3005,12 +3005,12 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.1">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.06">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.11">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_pommel" name="{=RWm1h40B}Highland Pommel" tier="3" piece_type="Pommel" mesh="cleaver_pommel_2" culture="Culture.aserai" length="6.692" weight="0.02">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3030,18 +3030,18 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_back_sword_t2_pommel" name="{=WkLj6xAo}Trapezoid Pommel" tier="1" piece_type="Pommel" mesh="cleaver_pommel_1" length="5.255" weight="0.1">
+  <CraftingPiece id="crpg_simple_back_sword_t2_pommel" name="{=WkLj6xAo}Trapezoid Pommel" tier="1" piece_type="Pommel" mesh="cleaver_pommel_1" length="5.255" weight="0.05">
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
     <BuildData next_piece_offset="-0.2" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_pommel" name="{=wfK63ZQn}Saber Pommel" tier="1" piece_type="Pommel" mesh="aserai_pommel_2" culture="Culture.aserai" length="4.841" weight="0.12">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_pommel" name="{=wfK63ZQn}Saber Pommel" tier="1" piece_type="Pommel" mesh="aserai_pommel_2" culture="Culture.aserai" length="4.841" weight="0.09">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.05">
+  <CraftingPiece id="crpg_falchion_sword_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.25">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3162,7 +3162,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_pommel" name="{=1pvLe1Mh}Simple Ild Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_3" culture="Culture.khuzait" length="1.741" weight="0.12">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_pommel" name="{=1pvLe1Mh}Simple Ild Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_3" culture="Culture.khuzait" length="1.741" weight="0.1">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3311,7 +3311,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.1">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.03">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3419,7 +3419,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.24">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.14">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3443,7 +3443,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.3">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.33">
     <BuildData piece_offset="-1.98" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3461,7 +3461,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_handle" name="{=tRJC72Qh}Leather Crossed One Handed" tier="3" piece_type="Handle" mesh="sturgian_grip_35" culture="Culture.sturgia" length="15" weight="0.38">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_handle" name="{=tRJC72Qh}Leather Crossed One Handed" tier="3" piece_type="Handle" mesh="sturgian_grip_35" culture="Culture.sturgia" length="15" weight="0.39">
     <BuildData piece_offset="-1" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3654,7 +3654,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.15">
+  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.45">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3678,7 +3678,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.4">
+  <CraftingPiece id="crpg_broad_ild_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.48">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3696,25 +3696,25 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.43">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.45">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_handle" name="{=dBVMNui8}Iron Reinforced Horn Two Handed Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_18" culture="Culture.vlandia" length="26.1" weight="0.39">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_handle" name="{=dBVMNui8}Iron Reinforced Horn Two Handed Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_18" culture="Culture.vlandia" length="26.1" weight="0.44">
     <BuildData piece_offset="-0.36" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_back_sword_t2_handle" name="{=Q9Gfv68h}Two Handed Saber Grip" tier="2" piece_type="Handle" mesh="khuzait_grip_16" culture="Culture.khuzait" length="27" weight="0.55">
+  <CraftingPiece id="crpg_simple_back_sword_t2_handle" name="{=Q9Gfv68h}Two Handed Saber Grip" tier="2" piece_type="Handle" mesh="khuzait_grip_16" culture="Culture.khuzait" length="27" weight="0.6">
     <BuildData piece_offset="-0.04" previous_piece_offset="0.2" next_piece_offset="0" />
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_handle" name="{=aj59KGOS}Rough Leather Two Handed Grip" tier="2" piece_type="Handle" mesh="aserai_grip_23" culture="Culture.aserai" length="25" weight="0.46">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_handle" name="{=aj59KGOS}Rough Leather Two Handed Grip" tier="2" piece_type="Handle" mesh="aserai_grip_23" culture="Culture.aserai" length="25" weight="0.47">
     <BuildData piece_offset="-0.95" previous_piece_offset="0.2" next_piece_offset="0" />
     <Materials>
       <Material id="Iron2" count="2" />
@@ -3775,7 +3775,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_handle" name="{=gZzEkk5t}Highland Fine Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_8" culture="Culture.battania" length="25" weight="0.1">
+  <CraftingPiece id="crpg_battania_sword_3_t3_handle" name="{=gZzEkk5t}Highland Fine Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_8" culture="Culture.battania" length="25" weight="0.08">
     <BuildData piece_offset="0" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="2" />
@@ -3865,13 +3865,13 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_handle" name="{=OlUuoUBe}Eastern Iron Bound Fine Leather Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_2" culture="Culture.khuzait" length="15.1" weight="0.48">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_handle" name="{=OlUuoUBe}Eastern Iron Bound Fine Leather Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_2" culture="Culture.khuzait" length="15.1" weight="0.58">
     <BuildData piece_offset="-0.04" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_1_t2_handle" name="{=3ZyRhmke}Short Saber Grip" tier="2" piece_type="Handle" mesh="khuzait_grip_7" culture="Culture.khuzait" length="15.1" weight="0.32">
+  <CraftingPiece id="crpg_khuzait_sword_1_t2_handle" name="{=3ZyRhmke}Short Saber Grip" tier="2" piece_type="Handle" mesh="khuzait_grip_7" culture="Culture.khuzait" length="15.1" weight="0.24">
     <BuildData piece_offset="-0.04" previous_piece_offset="0.2" next_piece_offset="0" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -4094,14 +4094,14 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.22">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.23">
     <BuildData next_piece_offset="1.9" previous_piece_offset="-0.4" />
     <StatContributions armor_bonus="4" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.2">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.13">
     <BuildData next_piece_offset="1.9" previous_piece_offset="-0.4" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4227,7 +4227,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.4">
+  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.32">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4248,7 +4248,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_sword_t3_guard" name="{=CiZRwdet}Eastern Flat Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_1" culture="Culture.khuzait" length="1.456" weight="0.25">
+  <CraftingPiece id="crpg_broad_ild_sword_t3_guard" name="{=CiZRwdet}Eastern Flat Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_1" culture="Culture.khuzait" length="1.456" weight="0.29">
     <BuildData next_piece_offset="0.5" />
     <StatContributions armor_bonus="1" />
     <Materials>
@@ -4269,21 +4269,21 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_back_sword_t2_guard" name="{=JanWod6k}Narrow Warsword Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_7" culture="Culture.sturgia" length="2.4" weight="0.45">
+  <CraftingPiece id="crpg_simple_back_sword_t2_guard" name="{=JanWod6k}Narrow Warsword Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_7" culture="Culture.sturgia" length="2.4" weight="0.42">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_guard" name="{=gPXRnvas}Disc Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_3" culture="Culture.empire" length="1.207" weight="0.22">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_guard" name="{=gPXRnvas}Disc Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_3" culture="Culture.empire" length="1.207" weight="0.2">
     <BuildData next_piece_offset="0.4" />
     <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.2">
+  <CraftingPiece id="crpg_falchion_sword_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.15">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4318,7 +4318,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_guard" name="{=NuXH8rip}Layered Bronze Guard" tier="1" piece_type="Guard" mesh="battania_guard_8" culture="Culture.battania" length="2.6" weight="0.1">
+  <CraftingPiece id="crpg_battania_sword_3_t3_guard" name="{=NuXH8rip}Layered Bronze Guard" tier="1" piece_type="Guard" mesh="battania_guard_8" culture="Culture.battania" length="2.6" weight="0.06">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="1" />
     <Materials>
@@ -4381,7 +4381,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_guard" name="{=mm6b54ZD}Wide Concave Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_3" culture="Culture.sturgia" length="1.817" weight="0.28">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_guard" name="{=mm6b54ZD}Wide Concave Guard" tier="2" piece_type="Guard" mesh="sturgian_guard_3" culture="Culture.sturgia" length="1.817" weight="0.31">
     <BuildData next_piece_offset="0.5" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4444,21 +4444,21 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_guard" name="{=NLs9M1D6}Eastern Simple Oval Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_6" culture="Culture.khuzait" length="0.155" weight="0.2">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_guard" name="{=NLs9M1D6}Eastern Simple Oval Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_6" culture="Culture.khuzait" length="0.155" weight="0.22">
     <BuildData next_piece_offset="0.1" />
     <StatContributions armor_bonus="2" />
     <Materials>
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_guard" name="{=nKb9goqQ}Thin Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_5" length="1.846" weight="0.26">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_guard" name="{=nKb9goqQ}Thin Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_5" length="1.846" weight="0.44">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="3" />
     <Materials>
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_1_t2_guard" name="{=6BMAGMRu}Flat Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_4" culture="Culture.khuzait" length="0.5" weight="0.22">
+  <CraftingPiece id="crpg_khuzait_sword_1_t2_guard" name="{=6BMAGMRu}Flat Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_4" culture="Culture.khuzait" length="0.5" weight="0.17">
     <BuildData next_piece_offset="0.1" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4500,7 +4500,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.3">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.37">
     <BuildData next_piece_offset="0.4" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4786,10 +4786,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_sword_t3_blade" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.24">
+  <CraftingPiece id="crpg_broad_falchion_sword_t3_blade" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.22">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="4" />
@@ -4855,7 +4855,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.25">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.22">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="2.8" />
@@ -4906,7 +4906,7 @@
   <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_blade" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.96">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
@@ -5036,17 +5036,17 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.33">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.34">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_sword_t4_blade" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.11" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_pointed_falchion_sword_t4_blade" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.03" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
@@ -5057,7 +5057,7 @@
   <CraftingPiece id="crpg_cleaver_sword_t3_blade" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="1.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -5086,9 +5086,9 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_sword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.27" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_falchion_sword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.29" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
@@ -5107,10 +5107,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="1.24">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="1.16">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5119,10 +5119,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="1.02">
+  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.915">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
-      <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Cut" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5162,9 +5162,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.29">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.31">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -5198,10 +5198,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.6">
+  <CraftingPiece id="crpg_battania_sword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.52">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5224,8 +5224,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_battania_sword_5_t5_blade" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="1.4">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.3" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5237,7 +5237,7 @@
   <CraftingPiece id="crpg_battania_sword_2_t3_blade" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5258,10 +5258,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_3_t3_blade" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.55">
+  <CraftingPiece id="crpg_battania_sword_3_t3_blade" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.44">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.1" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5272,8 +5272,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_battania_sword_4_t4_blade" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.28">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -5360,10 +5360,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_back_sword_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="1.01" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_simple_back_sword_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="1.02" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="0" />
-      <Swing damage_type="Cut" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5372,10 +5372,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_1_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="1.26">
+  <CraftingPiece id="crpg_khuzait_sword_1_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="1.27">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5384,10 +5384,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_sword_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.3">
+  <CraftingPiece id="crpg_broad_ild_sword_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.23">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5396,10 +5396,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.26">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.16">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5410,8 +5410,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_2_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.45">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5422,8 +5422,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_5_t4_blade" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5434,8 +5434,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_4_t4_blade" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="1.06">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5502,7 +5502,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.16">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.0" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -5718,8 +5718,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_wooden_sword_t1_blade" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="0.7" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Blunt" damage_factor="0.4" />
-      <Swing damage_type="Blunt" damage_factor="0.8" />
+      <Thrust damage_type="Blunt" damage_factor="1.0" />
+      <Swing damage_type="Blunt" damage_factor="1.1" />
     </BladeData>
     <Flags>
       <Flag name="NoBlood" />

--- a/items.json
+++ b/items.json
@@ -4557,9 +4557,9 @@
     "name": "Highland Pointed Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4344,
-    "weight": 1.44,
-    "tier": 7.34589672,
+    "price": 5532,
+    "weight": 1.41,
+    "tier": 8.431032,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4572,18 +4572,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.48,
-        "handling": 88,
+        "balance": 0.51,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 92,
         "swingDamage": 28,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 85
       }
     ]
   },
@@ -4740,9 +4740,9 @@
     "name": "Ridged Iron Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1581,
-    "weight": 2.0,
-    "tier": 4.002761,
+    "price": 2856,
+    "weight": 1.96,
+    "tier": 5.748748,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4754,17 +4754,17 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
+        "length": 100,
         "balance": 0.3,
         "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 32,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 78
       }
@@ -4775,9 +4775,9 @@
     "name": "Fine Steel Broad Shortsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4356,
+    "price": 5756,
     "weight": 2.01,
-    "tier": 7.35670471,
+    "tier": 8.6228,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4799,7 +4799,7 @@
         "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 90
       }
@@ -4810,9 +4810,9 @@
     "name": "Steel Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 2888,
-    "weight": 1.96,
-    "tier": 5.78682661,
+    "price": 4697,
+    "weight": 1.82,
+    "tier": 7.68206167,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4824,19 +4824,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 101,
-        "balance": 0.28,
+        "length": 104,
+        "balance": 0.31,
         "handling": 84,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 11,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 34,
+        "thrustSpeed": 88,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 79
       }
     ]
   },
@@ -4845,9 +4845,9 @@
     "name": "Fine Steel Cavalry Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4182,
+    "price": 5639,
     "weight": 1.93,
-    "tier": 7.18606949,
+    "tier": 8.523225,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4864,10 +4864,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 34,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }
@@ -4878,9 +4878,9 @@
     "name": "Highland Broad Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5228,
+    "price": 6274,
     "weight": 1.96,
-    "tier": 8.165652,
+    "tier": 9.051581,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4899,10 +4899,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 36,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
         "swingSpeed": 78
       }
@@ -6561,12 +6561,12 @@
   },
   {
     "id": "crpg_broad_falchion_sword_t3",
-    "name": "Broad Falchion",
+    "name": "Pointed Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 2823,
-    "weight": 1.94,
-    "tier": 5.708791,
+    "price": 4727,
+    "weight": 1.9,
+    "tier": 7.70963955,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6577,18 +6577,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.42,
-        "handling": 86,
+        "balance": 0.44,
+        "handling": 87,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 29,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 83
       }
     ]
   },
@@ -6597,9 +6597,9 @@
     "name": "Broad Ild",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3051,
-    "weight": 1.74,
-    "tier": 5.97853851,
+    "price": 4435,
+    "weight": 1.78,
+    "tier": 7.43314266,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6612,16 +6612,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.62,
-        "handling": 89,
+        "balance": 0.63,
+        "handling": 90,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 28,
+        "thrustSpeed": 88,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 88
       }
@@ -7201,9 +7201,9 @@
     "name": "Iron Cleaver",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 1216,
-    "weight": 2.14,
-    "tier": 3.37917137,
+    "price": 2703,
+    "weight": 2.28,
+    "tier": 5.5636034,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7215,7 +7215,7 @@
         "stackAmount": 0,
         "length": 99,
         "balance": 0.36,
-        "handling": 85,
+        "handling": 86,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -7223,7 +7223,7 @@
         "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 29,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 80
       }
@@ -7922,9 +7922,9 @@
     "name": "Dawnbreaker",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 5583,
-    "weight": 1.89,
-    "tier": 8.47506,
+    "price": 6723,
+    "weight": 1.68,
+    "tier": 9.408814,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7937,18 +7937,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.43,
+        "balance": 0.48,
         "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 89,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 84
       }
     ]
   },
@@ -11069,9 +11069,9 @@
     "name": "Iron Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 1367,
-    "weight": 1.97,
-    "tier": 3.64733052,
+    "price": 3099,
+    "weight": 1.98,
+    "tier": 6.033213,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11084,18 +11084,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.53,
-        "handling": 94,
+        "balance": 0.56,
+        "handling": 92,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -15367,9 +15367,9 @@
     "name": "Lion Imprinted Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 6460,
+    "price": 6929,
     "weight": 1.85,
-    "tier": 9.200806,
+    "tier": 9.568593,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15386,7 +15386,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 29,
@@ -15526,9 +15526,9 @@
     "name": "Iron Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 1725,
-    "weight": 2.02,
-    "tier": 4.22751474,
+    "price": 3607,
+    "weight": 1.9,
+    "tier": 6.595388,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15541,18 +15541,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.49,
+        "balance": 0.51,
         "handling": 91,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 13,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 26,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 85
       }
     ]
   },
@@ -15561,9 +15561,9 @@
     "name": "Straight Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3775,
+    "price": 5111,
     "weight": 1.41,
-    "tier": 6.77307,
+    "tier": 8.06125,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15582,10 +15582,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 85
       }
@@ -15596,9 +15596,9 @@
     "name": "Fine Steel Cavalry Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 4136,
-    "weight": 2.18,
-    "tier": 7.14033365,
+    "price": 5496,
+    "weight": 2.37,
+    "tier": 8.400139,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15610,19 +15610,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 115,
-        "balance": 0.29,
-        "handling": 83,
+        "length": 117,
+        "balance": 0.26,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 34,
+        "thrustSpeed": 84,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 77
       }
     ]
   },
@@ -15631,9 +15631,9 @@
     "name": "Fine Steel Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 4065,
+    "price": 5660,
     "weight": 1.92,
-    "tier": 7.0694685,
+    "tier": 8.541162,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15652,10 +15652,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 28,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
@@ -15666,9 +15666,9 @@
     "name": "Heavy Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3479,
+    "price": 5095,
     "weight": 2.0,
-    "tier": 6.458037,
+    "tier": 8.047001,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15687,10 +15687,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 31,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }
@@ -21713,12 +21713,12 @@
   },
   {
     "id": "crpg_pointed_falchion_sword_t4",
-    "name": "Pointed Falchion",
+    "name": "Broad Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 3250,
-    "weight": 1.96,
-    "tier": 6.20531273,
+    "price": 4647,
+    "weight": 1.88,
+    "tier": 7.63501453,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21729,8 +21729,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.59,
+        "handling": 89,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -21740,7 +21740,7 @@
         "thrustSpeed": 87,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -23325,9 +23325,9 @@
     "name": "Simple Scimitar",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 440,
-    "weight": 2.1,
-    "tier": 1.63083911,
+    "price": 1637,
+    "weight": 2.08,
+    "tier": 4.090324,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23340,18 +23340,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.56,
-        "handling": 91,
+        "balance": 0.58,
+        "handling": 92,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 21,
+        "thrustSpeed": 86,
+        "swingDamage": 25,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 87
       }
     ]
   },
@@ -23419,9 +23419,9 @@
     "name": "Simple Saber ",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 851,
-    "weight": 2.1,
-    "tier": 2.658482,
+    "price": 2490,
+    "weight": 1.98,
+    "tier": 5.296025,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23434,18 +23434,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.44,
-        "handling": 88,
+        "balance": 0.53,
+        "handling": 90,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 13,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 25,
+        "thrustSpeed": 87,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -24604,9 +24604,9 @@
     "name": "Star Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 3389,
-    "weight": 2.01,
-    "tier": 6.35991859,
+    "price": 4834,
+    "weight": 2.02,
+    "tier": 7.809658,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24618,7 +24618,7 @@
         "stackAmount": 0,
         "length": 108,
         "balance": 0.36,
-        "handling": 84,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -24626,7 +24626,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 33,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 80
       }
@@ -27209,9 +27209,9 @@
     "name": "Scalpel",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 5903,
-    "weight": 1.86,
-    "tier": 8.746144,
+    "price": 6686,
+    "weight": 1.9,
+    "tier": 9.379641,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27222,7 +27222,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.44,
+        "balance": 0.48,
         "handling": 84,
         "bodyArmor": 5,
         "flags": [
@@ -27233,7 +27233,7 @@
         "thrustSpeed": 87,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 84
       }
     ]
   },
@@ -30796,9 +30796,9 @@
     "name": "Winds Fury",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 5567,
+    "price": 6680,
     "weight": 2.05,
-    "tier": 8.461927,
+    "tier": 9.375411,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30809,13 +30809,13 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 116,
-        "balance": 0.25,
-        "handling": 83,
+        "balance": 0.26,
+        "handling": 84,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 86,
         "swingDamage": 34,
@@ -30986,9 +30986,9 @@
     "name": "Wooden Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 118,
+    "price": 605,
     "weight": 0.97,
-    "tier": 0.410555929,
+    "tier": 2.08304358,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31006,10 +31006,10 @@
           "MeleeWeapon",
           "NoBlood"
         ],
-        "thrustDamage": 4,
+        "thrustDamage": 10,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 97,
-        "swingDamage": 8,
+        "swingDamage": 11,
         "swingDamageType": "Blunt",
         "swingSpeed": 99
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -842,7 +842,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_battania_sword_1_t2" name="{=habJjtmv}Ridged Iron Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_1_t2_blade" Type="Blade" scale_factor="106" />
+      <Piece id="crpg_battania_sword_1_t2_blade" Type="Blade" scale_factor="109" />
       <Piece id="crpg_battania_sword_1_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_1_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
@@ -922,7 +922,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_khuzait_sword_3_t3" name="{=eaALL6uO}Fine Steel Cavalry Saber" crafting_template="crpg_OneHandedSword" culture="Culture.khuzait" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_khuzait_sword_3_t3_blade" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_khuzait_sword_3_t3_blade" Type="Blade" scale_factor="108" />
       <Piece id="crpg_khuzait_sword_3_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_khuzait_sword_3_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_khuzait_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -954,7 +954,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_battania_sword_3_t3" name="{=8jEDX9J4}Steel Broadsword" crafting_template="crpg_OneHandedSword" culture="Culture.battania" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_battania_sword_3_t3_blade" Type="Blade" scale_factor="107" />
+      <Piece id="crpg_battania_sword_3_t3_blade" Type="Blade" scale_factor="110" />
       <Piece id="crpg_battania_sword_3_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_battania_sword_3_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_battania_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -968,7 +968,7 @@
       <Piece id="crpg_star_falchion_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_broad_falchion_sword_t3" name="{=ktJ6crBs}Broad Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_broad_falchion_sword_t3" name="{=ktJ6crBs}Pointed Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_broad_falchion_sword_t3_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_broad_falchion_sword_t3_guard" Type="Guard" scale_factor="100" />
@@ -1104,7 +1104,7 @@
       <Piece id="crpg_battania_sword_4_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pointed_falchion_sword_t4" name="{=tQw4Zfwu}Pointed Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_pointed_falchion_sword_t4" name="{=tQw4Zfwu}Broad Falchion" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pointed_falchion_sword_t4_blade" Type="Blade" scale_factor="97" />
       <Piece id="crpg_pointed_falchion_sword_t4_guard" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Tier update for all previously balanced 1h swords from battania, khuzait, and neutral cultures.

also swapped the names:
Pointed Falchion - renamed to Broad Falchion because it cannot thrust
Broad Falchion - Renamed to Pointed Falchion because it can thrust