### PR TITLE
1h swords vlandia

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2800,12 +2800,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_pommel" name="{=Udo97SZC}Western Decorated Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_3" culture="Culture.vlandia" length="5" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_pommel" name="{=Udo97SZC}Western Decorated Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_3" culture="Culture.vlandia" length="5" weight="0.12">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_pommel" name="{=h4DmfRfb}Knightly Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_2" culture="Culture.vlandia" length="10" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_pommel" name="{=h4DmfRfb}Knightly Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_2" culture="Culture.vlandia" length="10" weight="0.3">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -2949,12 +2949,12 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_1" culture="Culture.vlandia" length="7.1" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_1" culture="Culture.vlandia" length="7.1" weight="0.28">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_pommel" name="{=gTMThdRJ}Lordly Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_4" culture="Culture.vlandia" length="6" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_pommel" name="{=gTMThdRJ}Lordly Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_4" culture="Culture.vlandia" length="6" weight="0.5">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -2980,7 +2980,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_sword_t3_pommel" name="{=yzsneaL6}Rimmed Wheel Pommel" tier="3" piece_type="Pommel" mesh="vlandian_pommel_8" culture="Culture.vlandia" length="7.77" weight="0.24">
+  <CraftingPiece id="crpg_short_sword_t3_pommel" name="{=yzsneaL6}Rimmed Wheel Pommel" tier="3" piece_type="Pommel" mesh="vlandian_pommel_8" culture="Culture.vlandia" length="7.77" weight="0.45">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3306,7 +3306,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.14">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.02">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3322,13 +3322,13 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_arming_sword_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.12">
+  <CraftingPiece id="crpg_broad_arming_sword_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.35">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.12">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.05">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -3345,7 +3345,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_2_t3_pommel" name="{=booEob1z}Disc Pommel" tier="2" piece_type="Pommel" mesh="vlandian_pommel_6" culture="Culture.vlandia" length="5.7" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_sword_2_t3_pommel" name="{=booEob1z}Disc Pommel" tier="2" piece_type="Pommel" mesh="vlandian_pommel_6" culture="Culture.vlandia" length="5.7" weight="0.03">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3355,7 +3355,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_1_t2_pommel" name="{=joN8ZeJ6}Wheel Pommel" tier="2" piece_type="Pommel" mesh="vlandian_pommel_1" culture="Culture.vlandia" length="5.189" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_sword_1_t2_pommel" name="{=joN8ZeJ6}Wheel Pommel" tier="2" piece_type="Pommel" mesh="vlandian_pommel_1" culture="Culture.vlandia" length="5.189" weight="0.35">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3570,7 +3570,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.270">
+  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3612,19 +3612,19 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.01">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.08">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_handle" name="{=3VoW9qZs}Gold Bound Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_3" culture="Culture.vlandia" length="17.5" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_handle" name="{=3VoW9qZs}Gold Bound Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_3" culture="Culture.vlandia" length="17.5" weight="0.12">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3636,7 +3636,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_arming_sword_t4_handle" name="{=4TvA6YaC}Marbled Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_noble_grip_2" culture="Culture.vlandia" length="17.5" weight="0.2">
+  <CraftingPiece id="crpg_broad_arming_sword_t4_handle" name="{=4TvA6YaC}Marbled Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_noble_grip_2" culture="Culture.vlandia" length="17.5" weight="0.05">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -3666,7 +3666,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.2">
+  <CraftingPiece id="crpg_short_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.08">
     <BuildData piece_offset="-1" previous_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3973,31 +3973,31 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_handle" name="{=tq5XGebt}Bronze Bound Fine Leather Covered Two Handed Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_20" culture="Culture.vlandia" length="19.8" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_handle" name="{=tq5XGebt}Bronze Bound Fine Leather Covered Two Handed Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_20" culture="Culture.vlandia" length="19.8" weight="0.31">
     <BuildData piece_offset="-4.5" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_handle" name="{=2MNfdGZQ}Fine Leather Covered Reinforced Horn Longsword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_10" culture="Culture.vlandia" length="25.2" weight="0.17" item_holster_pos_shift="0,0,-0.02">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_handle" name="{=2MNfdGZQ}Fine Leather Covered Reinforced Horn Longsword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_10" culture="Culture.vlandia" length="25.2" weight="0.05" item_holster_pos_shift="0,0,-0.02">
     <BuildData piece_offset="-4.59" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_handle" name="{=3wXjMEwI}Segmented Leather Covered Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_4" culture="Culture.vlandia" length="15.2" weight="0.1">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_handle" name="{=3wXjMEwI}Segmented Leather Covered Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_4" culture="Culture.vlandia" length="15.2" weight="0.3">
     <BuildData piece_offset="-0.09" previous_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_2_t3_handle" name="{=CE1IQiEU}Spiral Fine Leather Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_21" culture="Culture.vlandia" length="15.4" weight="0.2">
+  <CraftingPiece id="crpg_vlandia_sword_2_t3_handle" name="{=CE1IQiEU}Spiral Fine Leather Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_21" culture="Culture.vlandia" length="15.4" weight="0.37">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_1_t2_handle" name="{=RWljioj5}Iron And Leather Bound Horn One Handed Grip" tier="2" piece_type="Handle" mesh="vlandian_grip_2" culture="Culture.vlandia" length="15.05" weight="0.1">
+  <CraftingPiece id="crpg_vlandia_sword_1_t2_handle" name="{=RWljioj5}Iron And Leather Bound Horn One Handed Grip" tier="2" piece_type="Handle" mesh="vlandian_grip_2" culture="Culture.vlandia" length="15.05" weight="0.12">
     <BuildData piece_offset="-0.02" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -4031,7 +4031,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_guard" name="{=5KvdG6ep}Knightly Golden Crescent Shaped Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_4" culture="Culture.vlandia" length="2" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_guard" name="{=5KvdG6ep}Knightly Golden Crescent Shaped Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_4" culture="Culture.vlandia" length="2" weight="0.09">
     <BuildData next_piece_offset="0.2" previous_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4185,21 +4185,21 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_guard" name="{=6Da4uzZO}Engraved Wide Knightly Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_1" culture="Culture.vlandia" length="2.6" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_guard" name="{=6Da4uzZO}Engraved Wide Knightly Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_1" culture="Culture.vlandia" length="2.6" weight="0.05">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.01">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.1">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4577,21 +4577,21 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_guard" name="{=az6t2tOm}Ridged Western Guard" tier="5" piece_type="Guard" mesh="vlandian_guard_8" culture="Culture.vlandia" length="1.42" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_guard" name="{=az6t2tOm}Ridged Western Guard" tier="5" piece_type="Guard" mesh="vlandian_guard_8" culture="Culture.vlandia" length="1.42" weight="0.25">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_arming_sword_t4_guard" name="{=do4vZhh4}Tapered Thin Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_4" culture="Culture.vlandia" length="1.152" weight="0.20">
+  <CraftingPiece id="crpg_broad_arming_sword_t4_guard" name="{=do4vZhh4}Tapered Thin Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_4" culture="Culture.vlandia" length="1.152" weight="0.03">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_guard" name="{=do4vZhh4}Tapered Thin Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_4" culture="Culture.vlandia" length="1.152" weight="0.20">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_guard" name="{=do4vZhh4}Tapered Thin Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_4" culture="Culture.vlandia" length="1.152" weight="0.03">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4612,21 +4612,21 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_guard" name="{=xoSaQWhX}Western Crescent Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_5" culture="Culture.vlandia" length="0.9" weight="0.20">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_guard" name="{=xoSaQWhX}Western Crescent Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_5" culture="Culture.vlandia" length="0.9" weight="0.21">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_sword_t3_guard" name="{=dpft1I1B}Thin Western Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_2" culture="Culture.vlandia" length="2.809" weight="0.15">
+  <CraftingPiece id="crpg_short_sword_t3_guard" name="{=dpft1I1B}Thin Western Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_2" culture="Culture.vlandia" length="2.809" weight="0.05">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_2_t3_guard" name="{=dpft1I1B}Thin Western Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_2" culture="Culture.vlandia" length="2.809" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_sword_2_t3_guard" name="{=dpft1I1B}Thin Western Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_2" culture="Culture.vlandia" length="2.809" weight="0.26">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4640,7 +4640,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_1_t2_guard" name="{=XI5QgznO}Tapered Cleaver Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_2" culture="Culture.aserai" length="1.289" weight="0.058">
+  <CraftingPiece id="crpg_vlandia_sword_1_t2_guard" name="{=XI5QgznO}Tapered Cleaver Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_2" culture="Culture.aserai" length="1.289" weight="0.08">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4711,10 +4711,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_blade" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.8">
+  <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_blade" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="1.17">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4723,10 +4723,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.0">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.36">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.12" />
-      <Swing damage_type="Cut" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4965,10 +4965,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_blade" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="1.17">
+  <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_blade" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="1.27">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.435" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4977,10 +4977,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_blade" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="1.04">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_blade" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="1.13">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.68756" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5007,10 +5007,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_arming_sword_t4_blade" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.15">
+  <CraftingPiece id="crpg_broad_arming_sword_t4_blade" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.28">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="0.98" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -5063,10 +5063,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_sword_t3_blade" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.9">
+  <CraftingPiece id="crpg_short_sword_t3_blade" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.99">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_9_scabbard_9">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5620,10 +5620,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_blade" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="0.9">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_blade" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="0.98" />
-      <Swing damage_type="Cut" damage_factor="1.365" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5644,19 +5644,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_blade" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.0">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_blade" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.59">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="0.98" />
-      <Swing damage_type="Cut" damage_factor="1.365" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_2_t3_blade" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="0.95">
+  <CraftingPiece id="crpg_vlandia_sword_2_t3_blade" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.34">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5683,19 +5683,19 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_blade" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.0125">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_blade" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.36">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.232" />
-      <Swing damage_type="Cut" damage_factor="1.44648" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_1_t2_blade" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.98">
+  <CraftingPiece id="crpg_vlandia_sword_1_t2_blade" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="1.37">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="0.8049999" />
-      <Swing damage_type="Cut" damage_factor="1.085" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -6463,7 +6463,7 @@
   {
     "id": "crpg_broad_arming_sword_t4",
     "name": "Iron Pointed Sword",
-    "culture": "Neutral",
+    "culture": "Vlandia",
     "type": "OneHandedWeapon",
     "price": 3553,
     "weight": 1.62,
@@ -23288,7 +23288,7 @@
   {
     "id": "crpg_short_sword_t3",
     "name": "Short Arming Sword",
-    "culture": "Neutral",
+    "culture": "Vlandia",
     "type": "OneHandedWeapon",
     "price": 4652,
     "weight": 1.95,

--- a/items.json
+++ b/items.json
@@ -6462,12 +6462,12 @@
   },
   {
     "id": "crpg_broad_arming_sword_t4",
-    "name": "Broad Arming Sword",
+    "name": "Iron Pointed Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 97,
-    "weight": 1.67,
-    "tier": 0.301037878,
+    "price": 3553,
+    "weight": 1.62,
+    "tier": 6.537773,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6477,17 +6477,17 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 109,
+        "length": 102,
         "balance": 0.53,
-        "handling": 88,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 13,
+        "thrustSpeed": 90,
+        "swingDamage": 25,
         "swingDamageType": "Cut",
         "swingSpeed": 85
       }
@@ -23287,12 +23287,12 @@
   },
   {
     "id": "crpg_short_sword_t3",
-    "name": "Short Sword",
+    "name": "Short Arming Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 159,
-    "weight": 1.49,
-    "tier": 0.615828633,
+    "price": 4652,
+    "weight": 1.95,
+    "tier": 7.64000845,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23304,19 +23304,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 66,
-        "balance": 1.0,
-        "handling": 104,
+        "length": 87,
+        "balance": 0.63,
+        "handling": 92,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 12,
+        "thrustSpeed": 87,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 103
+        "swingSpeed": 88
       }
     ]
   },
@@ -29079,9 +29079,9 @@
     "name": "Decorated Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 445,
-    "weight": 1.59,
-    "tier": 1.64699042,
+    "price": 7525,
+    "weight": 2.13,
+    "tier": 10.0186033,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29093,30 +29093,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.87,
-        "handling": 99,
+        "length": 96,
+        "balance": 0.43,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 16,
+        "thrustSpeed": 85,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 96
+        "swingSpeed": 82
       }
     ]
   },
   {
     "id": "crpg_vlandia_noble_sword_2_t5",
-    "name": "Arming Sword with Circle",
+    "name": "Fine Steel Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 169,
-    "weight": 1.67,
-    "tier": 0.6598569,
+    "price": 5533,
+    "weight": 1.95,
+    "tier": 8.432592,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29128,30 +29128,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 84,
-        "balance": 0.79,
-        "handling": 97,
+        "length": 100,
+        "balance": 0.42,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 14,
+        "thrustSpeed": 87,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 93
+        "swingSpeed": 82
       }
     ]
   },
   {
     "id": "crpg_vlandia_noble_sword_3_t5",
-    "name": "Gold Engraved Arming Sword",
+    "name": "Engraved Pointed Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 198,
-    "weight": 1.55,
-    "tier": 0.7867433,
+    "price": 7602,
+    "weight": 1.84,
+    "tier": 10.0759859,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29163,30 +29163,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 88,
-        "balance": 0.83,
-        "handling": 98,
+        "length": 103,
+        "balance": 0.34,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 11,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 14,
+        "thrustSpeed": 88,
+        "swingDamage": 26,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 80
       }
     ]
   },
   {
     "id": "crpg_vlandia_noble_sword_4_t5",
-    "name": "Crescent Guarded Arming Sword",
+    "name": "Crescent Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 317,
-    "weight": 1.37,
-    "tier": 1.24066675,
+    "price": 4527,
+    "weight": 2.03,
+    "tier": 7.521212,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29198,19 +29198,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 76,
-        "balance": 1.0,
-        "handling": 103,
+        "length": 95,
+        "balance": 0.49,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 14,
+        "thrustSpeed": 87,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 103
+        "swingSpeed": 84
       }
     ]
   },
@@ -29317,9 +29317,9 @@
     "name": "Iron Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 83,
-    "weight": 1.34,
-    "tier": 0.217346311,
+    "price": 2922,
+    "weight": 1.78,
+    "tier": 5.827276,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29331,133 +29331,100 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 103,
-        "balance": 0.75,
-        "handling": 92,
+        "length": 94,
+        "balance": 0.56,
+        "handling": 87,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 10,
-        "swingDamageType": "Cut",
-        "swingSpeed": 92
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandia_sword_2_t3",
-    "name": "Ridged Tipped Arming Sword",
-    "culture": "Vlandia",
-    "type": "OneHandedWeapon",
-    "price": 116,
-    "weight": 1.45,
-    "tier": 0.4044022,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 104,
-        "balance": 0.73,
-        "handling": 92,
-        "bodyArmor": 5,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 12,
-        "swingDamageType": "Cut",
-        "swingSpeed": 91
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandia_sword_3_t4",
-    "name": "Knightly Arming Sword",
-    "culture": "Vlandia",
-    "type": "OneHandedWeapon",
-    "price": 179,
-    "weight": 1.41,
-    "tier": 0.704860449,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 105,
-        "balance": 0.74,
-        "handling": 94,
-        "bodyArmor": 5,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 13,
-        "swingDamageType": "Cut",
-        "swingSpeed": 92
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandia_sword_4_t4",
-    "name": "Ridged Arming Sword",
-    "culture": "Vlandia",
-    "type": "OneHandedWeapon",
-    "price": 109,
-    "weight": 1.54,
-    "tier": 0.36755985,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 113,
-        "balance": 0.55,
-        "handling": 87,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 13,
+        "thrustSpeed": 88,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
     ]
   },
   {
-    "id": "crpg_vlandia_sword_5_t5",
-    "name": "Wide Fullered Broad Arming Sword",
+    "id": "crpg_vlandia_sword_2_t3",
+    "name": "Iron Cavalry Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 161,
-    "weight": 1.5,
-    "tier": 0.624971867,
+    "price": 3557,
+    "weight": 2.16,
+    "tier": 6.542375,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 115,
+        "balance": 0.22,
+        "handling": 84,
+        "bodyArmor": 5,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 85,
+        "swingDamage": 33,
+        "swingDamageType": "Cut",
+        "swingSpeed": 76
+      }
+    ]
+  },
+  {
+    "id": "crpg_vlandia_sword_3_t4",
+    "name": "Knightly Cavalry Sword",
+    "culture": "Vlandia",
+    "type": "OneHandedWeapon",
+    "price": 6910,
+    "weight": 2.11,
+    "tier": 9.55417252,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 117,
+        "balance": 0.25,
+        "handling": 84,
+        "bodyArmor": 5,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 85,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 77
+      }
+    ]
+  },
+  {
+    "id": "crpg_vlandia_sword_4_t4",
+    "name": "Narrow Arming Sword",
+    "culture": "Vlandia",
+    "type": "OneHandedWeapon",
+    "price": 5255,
+    "weight": 1.56,
+    "tier": 8.189362,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29467,19 +29434,52 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 105,
-        "balance": 0.66,
-        "handling": 89,
+        "length": 98,
+        "balance": 0.48,
+        "handling": 85,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 25,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 26,
+        "swingDamageType": "Cut",
+        "swingSpeed": 84
+      }
+    ]
+  },
+  {
+    "id": "crpg_vlandia_sword_5_t5",
+    "name": "Fine Steel Cavalry Sword",
+    "culture": "Vlandia",
+    "type": "OneHandedWeapon",
+    "price": 5197,
+    "weight": 2.06,
+    "tier": 8.138307,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 115,
+        "balance": 0.26,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 14,
+        "thrustSpeed": 85,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 77
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -802,7 +802,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_sword_1_t2" name="{=w9RLq82l}Iron Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_sword_1_t2_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_vlandia_sword_1_t2_blade" Type="Blade" scale_factor="90" />
       <Piece id="crpg_vlandia_sword_1_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_1_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
@@ -880,9 +880,9 @@
       <Piece id="crpg_iron_spatha_sword_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_sword_2_t3" name="{=ha3rVEzP}Ridged Tipped Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_sword_2_t3" name="{=ha3rVEzP}Iron Cavalry Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_sword_2_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_vlandia_sword_2_t3_blade" Type="Blade" scale_factor="112" />
       <Piece id="crpg_vlandia_sword_2_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_2_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_2_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -984,9 +984,9 @@
       <Piece id="crpg_broad_ild_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_sword_t3" name="{=cRCkC36E}Short Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_short_sword_t3" name="{=cRCkC36E}Short Arming Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_short_sword_t3_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_short_sword_t3_blade" Type="Blade" scale_factor="138" />
       <Piece id="crpg_short_sword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_short_sword_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_short_sword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1008,17 +1008,17 @@
       <Piece id="crpg_cleaver_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_sword_3_t4" name="{=8mpp8ZCL}Knightly Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_sword_3_t4" name="{=8mpp8ZCL}Knightly Cavalry Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_sword_3_t4_blade" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_vlandia_sword_3_t4_blade" Type="Blade" scale_factor="123" />
       <Piece id="crpg_vlandia_sword_3_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_3_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_3_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_sword_4_t4" name="{=ksxylfU4}Ridged Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_sword_4_t4" name="{=ksxylfU4}Narrow Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_sword_4_t4_blade" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_vlandia_sword_4_t4_blade" Type="Blade" scale_factor="90" />
       <Piece id="crpg_vlandia_sword_4_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_4_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_4_t4_pommel" Type="Pommel" scale_factor="100" />
@@ -1120,9 +1120,9 @@
       <Piece id="crpg_ridged_sabre_sword_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_broad_arming_sword_t4" name="{=b8AgXwbL}Broad Arming Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_broad_arming_sword_t4" name="{=b8AgXwbL}Iron Pointed Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_broad_arming_sword_t4_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_broad_arming_sword_t4_blade" Type="Blade" scale_factor="93" />
       <Piece id="crpg_broad_arming_sword_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_broad_arming_sword_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_broad_arming_sword_t4_pommel" Type="Pommel" scale_factor="100" />
@@ -1136,9 +1136,9 @@
       <Piece id="crpg_desert_long_sword_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_sword_5_t5" name="{=VAcSEseI}Wide Fullered Broad Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_sword_5_t5" name="{=VAcSEseI}Fine Steel Cavalry Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_sword_5_t5_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_vlandia_sword_5_t5_blade" Type="Blade" scale_factor="109" />
       <Piece id="crpg_vlandia_sword_5_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_5_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_sword_5_t5_pommel" Type="Pommel" scale_factor="100" />
@@ -1178,34 +1178,34 @@
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_noble_sword_1_t5" name="{=Zcaucj4W}Decorated Arming Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_noble_sword_1_t5_blade" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_vlandia_noble_sword_1_t5_blade" Type="Blade" scale_factor="125" />
       <Piece id="crpg_vlandia_noble_sword_1_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_1_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_1_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_noble_sword_2_t5" name="{=ZsaukY0N}Arming Sword with Circle" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_noble_sword_2_t5" name="{=ZsaukY0N}Fine Steel Arming Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_noble_sword_2_t5_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_vlandia_noble_sword_2_t5_blade" Type="Blade" scale_factor="121" />
       <Piece id="crpg_vlandia_noble_sword_2_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_2_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_2_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_noble_sword_3_t5" name="{=P9FUrH8a}Gold Engraved Arming Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_noble_sword_3_t5" name="{=P9FUrH8a}Engraved Pointed Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_noble_sword_3_t5_blade" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_vlandia_noble_sword_3_t5_blade" Type="Blade" scale_factor="125" />
       <Piece id="crpg_vlandia_noble_sword_3_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_3_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_vlandia_noble_sword_3_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_vlandia_noble_sword_4_t5" name="{=4q69NwNy}Crescent Guarded Arming Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_vlandia_noble_sword_4_t5" name="{=4q69NwNy}Crescent Arming Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_vlandia_noble_sword_4_t5_blade" Type="Blade" />
-      <Piece id="crpg_vlandia_noble_sword_4_t5_guard" Type="Guard" />
-      <Piece id="crpg_vlandia_noble_sword_4_t5_handle" Type="Handle" />
-      <Piece id="crpg_vlandia_noble_sword_4_t5_pommel" Type="Pommel" />
+      <Piece id="crpg_vlandia_noble_sword_4_t5_blade" Type="Blade" scale_factor="127" />
+      <Piece id="crpg_vlandia_noble_sword_4_t5_guard" Type="Guard" scale_factor="100" />
+      <Piece id="crpg_vlandia_noble_sword_4_t5_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_vlandia_noble_sword_4_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_empire_noble_sword_1_t5" name="{=GyYsQlVd}Decorated Short Spatha" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -984,7 +984,7 @@
       <Piece id="crpg_broad_ild_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_sword_t3" name="{=cRCkC36E}Short Arming Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_short_sword_t3" name="{=cRCkC36E}Short Arming Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_short_sword_t3_blade" Type="Blade" scale_factor="138" />
       <Piece id="crpg_short_sword_t3_guard" Type="Guard" scale_factor="100" />
@@ -1120,7 +1120,7 @@
       <Piece id="crpg_ridged_sabre_sword_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_broad_arming_sword_t4" name="{=b8AgXwbL}Iron Pointed Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_broad_arming_sword_t4" name="{=b8AgXwbL}Iron Pointed Sword" crafting_template="crpg_OneHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_broad_arming_sword_t4_blade" Type="Blade" scale_factor="93" />
       <Piece id="crpg_broad_arming_sword_t4_guard" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Initial stats pass on all Vlandia 1h swords and 2 additional swords from neutral

extensive renaming as well to reduce wordiness and repetition of "arming sword" somewhat and make the specializations more clear

Decorated Arming Sword
Gold Engraved Arming Sword - renamed to Engraved Pointed Sword
Knightly Arming Sword - renamed to Knightly Cavalry Sword
Arming Sword with Circle - renamed to Fine Steel Arming sword
Wide Fullered Broad Arming Sword - renamed to Fine Steel Cavalry Sword
Ridged Arming Sword - renamed to Narrow Arming Sword
Short Sword - changed culture from Neutral, renamed to Short Arming Sword
Crescent Guarded Arming Sword - renamed to Crescent Arming Sword
Broad Arming Sword - changed culture from Neutral, renamed to Iron Pointed Sword
Ridged Tipped Arming Sword - renamed to Iron Cavalry Sword
Iron Arming Sword
