### PR TITLE
1h sword sturgia

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2537,7 +2537,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.5" /> 
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2875,12 +2875,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_pommel" name="{=LDRnfLRh}Decorated Northern Pommel" tier="4" piece_type="Pommel" mesh="sturgian_noble_pommel_2" culture="Culture.sturgia" length="4.7" weight="0.17">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_pommel" name="{=LDRnfLRh}Decorated Northern Pommel" tier="4" piece_type="Pommel" mesh="sturgian_noble_pommel_2" culture="Culture.sturgia" length="4.7" weight="0.12">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.17">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.2">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -2938,12 +2938,12 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_pommel" name="{=usVYZYYD}Northern Lordly Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_4" culture="Culture.sturgia" length="5.4" weight="0.17">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_pommel" name="{=usVYZYYD}Northern Lordly Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_4" culture="Culture.sturgia" length="5.4" weight="0.2">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.17">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.28">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3148,17 +3148,17 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.17">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.47">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.14">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.25">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.14">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.25">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3179,7 +3179,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.05">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.50">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3492,13 +3492,13 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_handle" name="{=9T2KA9sk}Gold Bound Decorated Steel Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_4" culture="Culture.sturgia" length="15.7" weight="0.270">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_handle" name="{=9T2KA9sk}Gold Bound Decorated Steel Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_4" culture="Culture.sturgia" length="15.7" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_handle" name="{=ueCf3sde}Leather Wrapped Thin One Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_noble_grip_3" culture="Culture.sturgia" length="15" weight="0.270">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_handle" name="{=ueCf3sde}Leather Wrapped Thin One Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_noble_grip_3" culture="Culture.sturgia" length="17" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3607,7 +3607,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.270">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.5">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3619,7 +3619,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_handle" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.270">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_handle" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="23" weight="0.31">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3842,7 +3842,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_handle" name="{=ZKsIpbg6}Half Leather Covered Wire Bound Two Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_grip_36" culture="Culture.sturgia" length="19.8" weight="0.30">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_handle" name="{=ZKsIpbg6}Half Leather Covered Wire Bound Two Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_grip_36" culture="Culture.sturgia" length="19.8" weight="0.4">
     <BuildData piece_offset="0" previous_piece_offset="-0.2" next_piece_offset="0.6" />
     <Materials>
       <Material id="Iron5" count="3" />
@@ -3854,19 +3854,19 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_handle" name="{=8olqutaL}Northern Split Two Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_grip_25" culture="Culture.sturgia" length="25" weight="0.13">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_handle" name="{=8olqutaL}Northern Split Two Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_grip_25" culture="Culture.sturgia" length="27" weight="0.25">
     <BuildData piece_offset="-7.04" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_handle" name="{=LEdJzFrZ}Bevelled Angular One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_7" culture="Culture.sturgia" length="15" weight="0.1">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_handle" name="{=LEdJzFrZ}Bevelled Angular One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_7" culture="Culture.sturgia" length="15" weight="0.45">
     <BuildData piece_offset="0" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_3_t3_handle" name="{=indl9fEW}Roughbound Thick Leather One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_8" culture="Culture.sturgia" length="15" weight="0.1">
+  <CraftingPiece id="crpg_sturgia_sword_3_t3_handle" name="{=indl9fEW}Roughbound Thick Leather One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_8" culture="Culture.sturgia" length="18" weight="0.1">
     <BuildData piece_offset="0" next_piece_offset="0" previous_piece_offset="0.4" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3884,7 +3884,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_handle" name="{=qbYoAvs6}Bound Hide One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_13" length="15.2" weight="0.10">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_handle" name="{=qbYoAvs6}Bound Hide One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_13" length="14" weight="0.20">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -4101,14 +4101,14 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_guard" name="{=4z3U5ubo}Golden Warsword Guard" tier="5" piece_type="Guard" mesh="sturgian_noble_guard_4" culture="Culture.sturgia" length="3.4" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_guard" name="{=4z3U5ubo}Golden Warsword Guard" tier="5" piece_type="Guard" mesh="sturgian_noble_guard_4" culture="Culture.sturgia" length="3.4" weight="0.35">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0" />
-    <StatContributions armor_bonus="5" />
+    <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_guard" name="{=3uUaFQ9Y}Hammer Shaped Guard With Engravings" tier="3" piece_type="Guard" mesh="sturgian_noble_guard_3" culture="Culture.sturgia" length="3.8" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_guard" name="{=3uUaFQ9Y}Hammer Shaped Guard With Engravings" tier="3" piece_type="Guard" mesh="sturgian_noble_guard_3" culture="Culture.sturgia" length="5" weight="0.3">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0.3" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4180,14 +4180,14 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_guard" name="{=L4PDF4MY}Warsword Guard With Golden Engravings" tier="5" piece_type="Guard" mesh="sturgian_noble_guard_1" culture="Culture.sturgia" length="2.36" weight="0.20">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0.3" />
-    <StatContributions armor_bonus="2" />
+    <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_guard" name="{=eapPaDKi}Thick Silvered Warsword Guard " tier="5" piece_type="Guard" mesh="sturgian_noble_guard_2" culture="Culture.sturgia" length="3.5" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_guard" name="{=eapPaDKi}Thick Silvered Warsword Guard " tier="5" piece_type="Guard" mesh="sturgian_noble_guard_2" culture="Culture.sturgia" length="6" weight="0.30">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0.3" />
-    <StatContributions armor_bonus="4" />
+    <StatContributions armor_bonus="3" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -4411,21 +4411,21 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_5_t4_guard" name="{=WxnqOG8s}Broad Concave Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_5" culture="Culture.sturgia" length="2.8" weight="0.15">
     <BuildData next_piece_offset="0.5" />
-    <StatContributions armor_bonus="3" />
+    <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_3_t3_guard" name="{=WxnqOG8s}Broad Concave Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_5" culture="Culture.sturgia" length="2.8" weight="0.15">
     <BuildData next_piece_offset="0.5" />
-    <StatContributions armor_bonus="3" />
+    <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_guard" name="{=RB3oxhaV}Long-Armed Guard" tier="5" piece_type="Guard" mesh="sturgian_guard_4" culture="Culture.sturgia" length="1" weight="0.18">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_guard" name="{=RB3oxhaV}Long-Armed Guard" tier="5" piece_type="Guard" mesh="sturgian_guard_4" culture="Culture.sturgia" length="2" weight="0.2">
     <BuildData next_piece_offset="0.4" />
-    <StatContributions armor_bonus="5" />
+    <StatContributions armor_bonus="2" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -4437,7 +4437,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.35">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4791,10 +4791,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="0.7">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.12">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="0.525" />
-      <Swing damage_type="Cut" damage_factor="0.875" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4803,10 +4803,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_blade" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.4" weight="0.9">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_blade" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="90" weight="1.34">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.575" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4935,10 +4935,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_blade" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="0.9">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_blade" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="102" weight="1.15">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="0.98" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4947,10 +4947,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.9">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="88" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.47" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5357,8 +5357,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_5_t5_blade" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.05" />
-      <Swing damage_type="Cut" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5367,10 +5367,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_3_t3_blade" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="0.76">
+  <CraftingPiece id="crpg_sturgia_sword_3_t3_blade" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="81" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5379,10 +5379,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.74">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="70" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="0.98" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5391,10 +5391,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.7">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="81" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="1.1" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5405,8 +5405,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_4_t4_blade" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.88">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="0.98" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="1.2" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5415,10 +5415,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.76">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="81" weight="0.97">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="0.735" />
-      <Swing damage_type="Cut" damage_factor="1.085" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -26958,9 +26958,9 @@
     "name": "Thamaskene Steel Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 272,
-    "weight": 1.54,
-    "tier": 1.0782969,
+    "price": 5823,
+    "weight": 1.94,
+    "tier": 8.678755,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26972,19 +26972,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 73,
-        "balance": 1.0,
-        "handling": 102,
-        "bodyArmor": 4,
+        "length": 104,
+        "balance": 0.44,
+        "handling": 84,
+        "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 14,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 83
       }
     ]
   },
@@ -26993,9 +26993,9 @@
     "name": "Decorated Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 88,
-    "weight": 1.54,
-    "tier": 0.246702909,
+    "price": 7754,
+    "weight": 2.05,
+    "tier": 10.1867924,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27007,19 +27007,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.95,
-        "handling": 100,
-        "bodyArmor": 2,
+        "length": 111,
+        "balance": 0.4,
+        "handling": 84,
+        "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 9,
+        "thrustSpeed": 86,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 81
       }
     ]
   },
@@ -27028,9 +27028,9 @@
     "name": "Decorated Fullered Sword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 447,
-    "weight": 1.54,
-    "tier": 1.65125048,
+    "price": 8311,
+    "weight": 1.91,
+    "tier": 10.5858135,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27042,19 +27042,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 72,
-        "balance": 1.0,
-        "handling": 103,
+        "length": 102,
+        "balance": 0.41,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 15,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 82
       }
     ]
   },
@@ -27063,9 +27063,9 @@
     "name": "Gold Bound Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 70,
-    "weight": 1.34,
-    "tier": 0.140029,
+    "price": 7567,
+    "weight": 1.97,
+    "tier": 10.0496912,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27078,18 +27078,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 1.0,
-        "handling": 101,
-        "bodyArmor": 5,
+        "balance": 0.71,
+        "handling": 95,
+        "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 5,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 8,
+        "thrustSpeed": 87,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 91
       }
     ]
   },
@@ -27233,149 +27233,9 @@
     "name": "Tapered Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 149,
-    "weight": 1.11,
-    "tier": 0.568580866,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 83,
-        "balance": 1.0,
-        "handling": 105,
-        "bodyArmor": 1,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 7,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 10,
-        "swingDamageType": "Cut",
-        "swingSpeed": 104
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_2_t3",
-    "name": "Backsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 257,
-    "weight": 1.18,
-    "tier": 1.02416778,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 77,
-        "balance": 1.0,
-        "handling": 105,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 12,
-        "swingDamageType": "Cut",
-        "swingSpeed": 105
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_3_t3",
-    "name": "Pointy Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 248,
-    "weight": 1.14,
-    "tier": 0.9893473,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 84,
-        "balance": 1.0,
-        "handling": 103,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 12,
-        "swingDamageType": "Cut",
-        "swingSpeed": 103
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_4_t4",
-    "name": "Long Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 169,
-    "weight": 1.41,
-    "tier": 0.6611655,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 100,
-        "balance": 0.8,
-        "handling": 95,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 13,
-        "swingDamageType": "Cut",
-        "swingSpeed": 93
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_5_t4",
-    "name": "Fullered Narrow Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 226,
-    "weight": 1.23,
-    "tier": 0.903282464,
+    "price": 2654,
+    "weight": 1.87,
+    "tier": 5.502546,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27388,29 +27248,29 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 89,
-        "balance": 1.0,
-        "handling": 98,
-        "bodyArmor": 3,
+        "balance": 0.7,
+        "handling": 89,
+        "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 13,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 13,
+        "thrustSpeed": 87,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 90
       }
     ]
   },
   {
-    "id": "crpg_sturgia_sword_5_t5",
-    "name": "Fullered Long Warsword",
+    "id": "crpg_sturgia_sword_2_t3",
+    "name": "Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 183,
-    "weight": 1.52,
-    "tier": 0.722374141,
+    "price": 4288,
+    "weight": 1.78,
+    "tier": 7.290567,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27422,19 +27282,159 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
-        "balance": 0.8,
-        "handling": 94,
-        "bodyArmor": 5,
+        "length": 90,
+        "balance": 0.62,
+        "handling": 93,
+        "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 14,
+        "thrustSpeed": 89,
+        "swingDamage": 28,
+        "swingDamageType": "Cut",
+        "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_3_t3",
+    "name": "Pointy Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 3231,
+    "weight": 1.48,
+    "tier": 6.18366051,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 92,
+        "balance": 0.75,
+        "handling": 94,
+        "bodyArmor": 1,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 24,
+        "swingDamageType": "Cut",
+        "swingSpeed": 92
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_4_t4",
+    "name": "Long Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 5239,
+    "weight": 1.97,
+    "tier": 8.175372,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 100,
+        "balance": 0.63,
+        "handling": 91,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 28,
+        "swingDamageType": "Cut",
+        "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_5_t4",
+    "name": "Fullered Narrow Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 4622,
+    "weight": 1.69,
+    "tier": 7.6120224,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 86,
+        "balance": 0.78,
+        "handling": 91,
+        "bodyArmor": 1,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 89,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
         "swingSpeed": 93
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_5_t5",
+    "name": "Fullered Long Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 3492,
+    "weight": 1.94,
+    "tier": 6.471994,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 98,
+        "balance": 0.56,
+        "handling": 83,
+        "bodyArmor": 2,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 31,
+        "swingDamageType": "Cut",
+        "swingSpeed": 86
       }
     ]
   },


### PR DESCRIPTION
Didn't quite get them where I wanted, but this seems decent enough.

| Name | Tier | Length | Cut | Stab | Cut spd | Stab spd |
|-|-|-|-|-|-|-|
| Decorated Fullered Sword | 10.5 | 102 | 35 | 12 | 82 | 87 |
| Decorated Long Warsword | 10.1 | 111 | 34 | 17 | 81 | 86 |
| Gold Bound Short Warsword | 10.0 | 84 | 28 | 18 | 91 | 87 |
| Thamaskene Steel Warsword | 8.6 | 104 | 33 | 16 | 83 | 87 |
| Long Warsword | 8.1 | 100 | 28 | 12 | 88 | 87 |
| Fullered Narrow Warsword | 7.6 | 86 | 27 | 16 | 93 | 89 |
| Backsword | 7.2 | 90 | 28 | 11 | 88 | 89 |
| Fullered Long Warsword | 6.4 | 98 | 31 | 15 | 86 | 87 |
| Pointy Warsword | 6.1 | 92 | 24 | 15 | 92 | 91 |
| Tapered Blade | 5.5 | 89 | 27 | 13 | 90 | 87 |

A few things I learned about the tier calculator:
* Values a light blade very strongly. Adding blade weight decreases tiers quickly without much meaningful downside. I only took advantage of this when I was doing the t8 and lower swords.
* Undervalues length. This is probably more true for 1h than other classes. Length isn't free but it seems cheap.
* Overvalues speed. Again, probably a 1h thing.
