### PR TITLE
Removed Auto Reload Bows

### DIFF
--- a/items.json
+++ b/items.json
@@ -276,9 +276,9 @@
     "name": "Adarga",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 2253,
+    "price": 5942,
     "weight": 1.38,
-    "tier": 4.39621,
+    "tier": 7.80487776,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -335,9 +335,9 @@
     "name": "The Ambassador",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 395,
+    "price": 77,
     "weight": 1.69,
-    "tier": 1.49288452,
+    "tier": 0.18010284,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -518,9 +518,9 @@
     "name": "Short Handled Bardiche",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 155,
+    "price": 56,
     "weight": 1.6,
-    "tier": 0.3477309,
+    "tier": 0.023544237,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -556,9 +556,9 @@
     "name": "Executioner Axe",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 113,
+    "price": 52,
     "weight": 1.88,
-    "tier": 0.21908845,
+    "tier": 0.0108834375,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -594,9 +594,9 @@
     "name": "Long Bladed Bardiche",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 12345,
+    "price": 66741,
     "weight": 1.13,
-    "tier": 9.324455,
+    "tier": 23.14361,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -695,9 +695,9 @@
     "name": "Wood Splitter Axe",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 188,
+    "price": 71,
     "weight": 1.15,
-    "tier": 0.745798647,
+    "tier": 0.142472833,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -731,9 +731,9 @@
     "name": "Bamboo Handled Ascia Axe",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 194,
+    "price": 72,
     "weight": 1.02,
-    "tier": 0.768862963,
+    "tier": 0.151421234,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -1301,9 +1301,9 @@
     "name": "Mamluke Lance",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 365,
+    "price": 71,
     "weight": 1.85,
-    "tier": 0.7770322,
+    "tier": 0.06953861,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1398,9 +1398,9 @@
     "name": "Militia Mace",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 109,
+    "price": 55,
     "weight": 1.88,
-    "tier": 0.365254045,
+    "tier": 0.0385528021,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1431,9 +1431,9 @@
     "name": "Fullered Light Mace",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 199,
+    "price": 77,
     "weight": 1.32,
-    "tier": 0.792857349,
+    "tier": 0.1803411,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1464,9 +1464,9 @@
     "name": "Heavy Horsemans Mace",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 194,
+    "price": 75,
     "weight": 1.86,
-    "tier": 0.769345343,
+    "tier": 0.165770859,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1497,9 +1497,9 @@
     "name": "Spiralled Mace",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 400,
+    "price": 164,
     "weight": 1.55,
-    "tier": 1.50941694,
+    "tier": 0.636818,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1530,9 +1530,9 @@
     "name": "Decorated Kaskara",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 22183,
+    "price": 53578,
     "weight": 1.43,
-    "tier": 18.0108166,
+    "tier": 28.6246185,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1565,9 +1565,9 @@
     "name": "Decorated Long Scimitar",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 25453,
+    "price": 76131,
     "weight": 1.46,
-    "tier": 19.3739834,
+    "tier": 34.34215,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1600,9 +1600,9 @@
     "name": "Decorated Scimitar with Wide Grip",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 24648,
+    "price": 67549,
     "weight": 1.55,
-    "tier": 19.0470047,
+    "tier": 32.2817459,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1635,9 +1635,9 @@
     "name": "Engraved Angular Kaskara",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 27190,
+    "price": 83751,
     "weight": 1.52,
-    "tier": 20.0621319,
+    "tier": 36.0759964,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1828,9 +1828,9 @@
     "name": "Iron Flyssa",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 9223,
+    "price": 9238,
     "weight": 1.38,
-    "tier": 11.2115746,
+    "tier": 11.2220745,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1863,9 +1863,9 @@
     "name": "Iron Scimitar",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 19783,
+    "price": 45445,
     "weight": 1.1,
-    "tier": 16.945343,
+    "tier": 26.27184,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -1898,9 +1898,9 @@
     "name": "Slightly Ridged Flyssa",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 16579,
+    "price": 30290,
     "weight": 1.31,
-    "tier": 15.4164333,
+    "tier": 21.2383366,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1931,9 +1931,9 @@
     "name": "Fine Steel Long Kaskara",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 17278,
+    "price": 19136,
     "weight": 1.46,
-    "tier": 15.7619534,
+    "tier": 16.647068,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1964,9 +1964,9 @@
     "name": "Long Fine Steel Scimitar",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 22443,
+    "price": 58831,
     "weight": 1.21,
-    "tier": 18.12288,
+    "tier": 30.0499821,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -1997,9 +1997,9 @@
     "name": "Narrow Fine Steel Kaskara",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 17734,
+    "price": 32494,
     "weight": 1.45,
-    "tier": 15.9832449,
+    "tier": 22.0384731,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -2030,9 +2030,9 @@
     "name": "Thamaskene Steel Kaskara",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 20301,
+    "price": 24539,
     "weight": 1.39,
-    "tier": 17.1805077,
+    "tier": 19.00222,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -2150,9 +2150,9 @@
     "name": "Avalanche",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 278,
+    "price": 87,
     "weight": 1.18,
-    "tier": 0.6720784,
+    "tier": 0.134367868,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -2211,9 +2211,9 @@
     "name": "Bamboo Axe",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 137,
+    "price": 59,
     "weight": 1.21,
-    "tier": 0.508335233,
+    "tier": 0.0647668839,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -2949,9 +2949,9 @@
     "name": "Simple Bastard Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 626,
+    "price": 95,
     "weight": 1.25,
-    "tier": 2.13666058,
+    "tier": 0.288829029,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -2984,9 +2984,9 @@
     "name": "Square Bit Two Handed Axe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 114,
+    "price": 52,
     "weight": 1.4,
-    "tier": 0.2217765,
+    "tier": 0.009021953,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -3022,9 +3022,9 @@
     "name": "Iron Broadsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 413,
+    "price": 72,
     "weight": 1.99,
-    "tier": 0.9730627,
+    "tier": 0.0834826753,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3058,9 +3058,9 @@
     "name": "Highland Broadsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 675,
+    "price": 105,
     "weight": 1.85,
-    "tier": 1.45840466,
+    "tier": 0.1936374,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3134,9 +3134,9 @@
     "name": "Northlander Wide Fullered Greatsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 609,
+    "price": 101,
     "weight": 2.08,
-    "tier": 1.34406853,
+    "tier": 0.179835349,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3170,9 +3170,9 @@
     "name": "Falx",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 1261,
+    "price": 193,
     "weight": 1.91,
-    "tier": 2.30840039,
+    "tier": 0.454044044,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -3247,9 +3247,9 @@
     "name": "Highland Fine Two Handed Sword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 1651,
+    "price": 263,
     "weight": 1.63,
-    "tier": 2.772811,
+    "tier": 0.636401057,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3323,9 +3323,9 @@
     "name": "Battanian Mountain Blade",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 1482,
+    "price": 274,
     "weight": 1.66,
-    "tier": 2.578245,
+    "tier": 0.661710143,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3399,9 +3399,9 @@
     "name": "Norse Hatchet",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 170,
+    "price": 66,
     "weight": 1.09,
-    "tier": 0.667336762,
+    "tier": 0.11335963,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -3435,9 +3435,9 @@
     "name": "One Handed Bearded Axe",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 219,
+    "price": 79,
     "weight": 1.03,
-    "tier": 0.8743233,
+    "tier": 0.193421945,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -3471,9 +3471,9 @@
     "name": "Round Bitted Fine Steel Hatchet",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 208,
+    "price": 75,
     "weight": 1.05,
-    "tier": 0.8277443,
+    "tier": 0.168279946,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -4117,9 +4117,9 @@
     "name": "Bronze Reinforced Highland Large Shield",
     "culture": "Battania",
     "type": "Shield",
-    "price": 3823,
+    "price": 11417,
     "weight": 3.22,
-    "tier": 6.046157,
+    "tier": 11.24312,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -4155,9 +4155,9 @@
     "name": "Iron Reinforced Highland Large Shield",
     "culture": "Battania",
     "type": "Shield",
-    "price": 4180,
+    "price": 12696,
     "weight": 3.57,
-    "tier": 6.37173128,
+    "tier": 11.916708,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -4193,9 +4193,9 @@
     "name": "Highland Large Shield",
     "culture": "Battania",
     "type": "Shield",
-    "price": 3986,
+    "price": 11826,
     "weight": 2.94,
-    "tier": 6.196994,
+    "tier": 11.4624,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -4363,9 +4363,9 @@
     "name": "Knobbed Club",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 156,
+    "price": 65,
     "weight": 1.34,
-    "tier": 0.602756262,
+    "tier": 0.104478121,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4396,9 +4396,9 @@
     "name": "Highland Mace",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 155,
+    "price": 62,
     "weight": 2.13,
-    "tier": 0.595581651,
+    "tier": 0.08864907,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4429,9 +4429,9 @@
     "name": "Highland Spiked Club",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 19507,
+    "price": 100968,
     "weight": 0.91,
-    "tier": 16.8189,
+    "tier": 39.7240944,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4525,9 +4525,9 @@
     "name": "Engraved Backsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7524,
+    "price": 8991,
     "weight": 1.68,
-    "tier": 10.0182543,
+    "tier": 11.0555763,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4560,9 +4560,9 @@
     "name": "Highland Fine Steel Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 21049,
+    "price": 44561,
     "weight": 1.44,
-    "tier": 17.5151081,
+    "tier": 26.0039787,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4595,9 +4595,9 @@
     "name": "Decorated Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7484,
+    "price": 8745,
     "weight": 1.88,
-    "tier": 9.988511,
+    "tier": 10.8877239,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4630,9 +4630,9 @@
     "name": "Rhomphaia",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 27609,
+    "price": 51895,
     "weight": 1.03,
-    "tier": 13.3988733,
+    "tier": 18.7808189,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4743,9 +4743,9 @@
     "name": "Ridged Iron Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 8108,
+    "price": 7115,
     "weight": 1.68,
-    "tier": 10.442338,
+    "tier": 9.71087551,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4778,9 +4778,9 @@
     "name": "Broad Ridged Shortsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5580,
+    "price": 2387,
     "weight": 1.92,
-    "tier": 8.473061,
+    "tier": 5.16186428,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4813,9 +4813,9 @@
     "name": "Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 13975,
+    "price": 21171,
     "weight": 1.51,
-    "tier": 14.0611734,
+    "tier": 17.5689774,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4848,9 +4848,9 @@
     "name": "Fine Steel Cavalry Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5461,
+    "price": 6180,
     "weight": 1.55,
-    "tier": 8.370206,
+    "tier": 8.975168,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4881,9 +4881,9 @@
     "name": "Highland Broad Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 21075,
+    "price": 48679,
     "weight": 1.53,
-    "tier": 17.526638,
+    "tier": 27.2306576,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4916,9 +4916,9 @@
     "name": "Targe",
     "culture": "Battania",
     "type": "Shield",
-    "price": 3891,
+    "price": 11325,
     "weight": 2.52,
-    "tier": 6.109577,
+    "tier": 11.1929131,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -5378,9 +5378,9 @@
     "name": "Simple Horseman Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 2924,
+    "price": 7727,
     "weight": 1.56,
-    "tier": 5.15420341,
+    "tier": 9.053572,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -5416,9 +5416,9 @@
     "name": "Battle Axe",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 240,
+    "price": 85,
     "weight": 1.01,
-    "tier": 0.959834635,
+    "tier": 0.2322078,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5452,9 +5452,9 @@
     "name": "Bearded Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 333,
+    "price": 84,
     "weight": 1.24,
-    "tier": 0.800020933,
+    "tier": 0.124623716,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5570,9 +5570,9 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 34481,
+    "price": 80463,
     "weight": 1.28,
-    "tier": 15.1033554,
+    "tier": 23.66096,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5607,9 +5607,9 @@
     "name": "Black Heart",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 106,
+    "price": 52,
     "weight": 1.64,
-    "tier": 0.19863905,
+    "tier": 0.009418843,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -6019,9 +6019,9 @@
     "name": "Bone Crusher",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 504,
+    "price": 228,
     "weight": 1.49,
-    "tier": 1.814148,
+    "tier": 0.912822247,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6052,9 +6052,9 @@
     "name": "Wooden Adarga",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 2503,
+    "price": 6800,
     "weight": 1.62,
-    "tier": 4.690006,
+    "tier": 8.425197,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -6090,9 +6090,9 @@
     "name": "Desert Round Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 2527,
+    "price": 6886,
     "weight": 1.644,
-    "tier": 4.71837044,
+    "tier": 8.48508549,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -6128,9 +6128,9 @@
     "name": "Cavalry Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 4901,
+    "price": 11894,
     "weight": 3.6192,
-    "tier": 6.988801,
+    "tier": 11.4982529,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -6202,9 +6202,9 @@
     "name": "Bracketed Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5546,
+    "price": 16715,
     "weight": 3.8,
-    "tier": 7.503501,
+    "tier": 13.83801,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -6432,9 +6432,9 @@
     "name": "Broad Arming Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 617,
+    "price": 100,
     "weight": 1.67,
-    "tier": 2.11292553,
+    "tier": 0.31749934,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6465,9 +6465,9 @@
     "name": "Broad Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 250,
+    "price": 62,
     "weight": 2.14,
-    "tier": 0.996573031,
+    "tier": 0.08577618,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6498,9 +6498,9 @@
     "name": "Broad Ild",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 495,
+    "price": 93,
     "weight": 1.39,
-    "tier": 1.78990245,
+    "tier": 0.2769279,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6788,9 +6788,9 @@
     "name": "Highland Dagger",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 23578,
+    "price": 65683,
     "weight": 0.56,
-    "tier": 18.6037884,
+    "tier": 31.8168373,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7029,9 +7029,9 @@
     "name": "Knights Kite Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 7756,
+    "price": 24749,
     "weight": 6.38,
-    "tier": 9.072613,
+    "tier": 17.0819874,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -7067,9 +7067,9 @@
     "name": "Two-Handed Cleaver ",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 459,
+    "price": 76,
     "weight": 2.28,
-    "tier": 1.06550241,
+    "tier": 0.0967352241,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7141,9 +7141,9 @@
     "name": "Cleaver",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 354,
+    "price": 74,
     "weight": 1.8,
-    "tier": 1.36512089,
+    "tier": 0.159797579,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7400,7 +7400,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 12,
@@ -7441,7 +7440,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 13,
@@ -7742,9 +7740,9 @@
     "name": "Curved Round Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 3164,
+    "price": 8945,
     "weight": 2.112,
-    "tier": 5.404415,
+    "tier": 9.824335,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -7824,9 +7822,9 @@
     "name": "Dawnbreaker",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 442,
+    "price": 76,
     "weight": 1.84,
-    "tier": 1.63570416,
+    "tier": 0.176725358,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7980,9 +7978,9 @@
     "name": "Round Steppe Shield",
     "culture": "Khuzait",
     "type": "Shield",
-    "price": 2870,
+    "price": 8084,
     "weight": 1.98,
-    "tier": 5.09756374,
+    "tier": 9.285714,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -8252,9 +8250,9 @@
     "name": "Desert Long Sword",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 356,
+    "price": 74,
     "weight": 1.93,
-    "tier": 1.370589,
+    "tier": 0.160905823,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -8306,9 +8304,9 @@
     "name": "Desert Oval Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 6214,
+    "price": 18678,
     "weight": 4.07,
-    "tier": 8.005563,
+    "tier": 14.6921549,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -8491,9 +8489,9 @@
     "name": "Early Retirement",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1411,
+    "price": 241,
     "weight": 1.32,
-    "tier": 2.4941752,
+    "tier": 0.5800926,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -8565,9 +8563,9 @@
     "name": "Polesword",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 9173,
+    "price": 12686,
     "weight": 1.75,
-    "tier": 7.2681284,
+    "tier": 8.733489,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -8942,9 +8940,9 @@
     "name": "Jagged Spear",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 74107,
+    "price": 564044,
     "weight": 1.43,
-    "tier": 22.6618671,
+    "tier": 64.5228958,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9022,9 +9020,9 @@
     "name": "Narrow Long Headed Spear",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 7864,
+    "price": 6055,
     "weight": 2.17,
-    "tier": 6.65195131,
+    "tier": 5.710596,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9102,9 +9100,9 @@
     "name": "Weighted Steppe Spear",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 2687,
+    "price": 865,
     "weight": 1.73,
-    "tier": 3.474049,
+    "tier": 1.59013617,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9182,9 +9180,9 @@
     "name": "Fine Steel Leaf Spear",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 15366,
+    "price": 23147,
     "weight": 2.01,
-    "tier": 9.719723,
+    "tier": 12.1759834,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9268,9 +9266,9 @@
     "name": "Thin Fine Steel Hewing Spear",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 363,
+    "price": 71,
     "weight": 1.4,
-    "tier": 0.773044646,
+    "tier": 0.06776785,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9325,9 +9323,9 @@
     "name": "Steel Mace",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 245,
+    "price": 92,
     "weight": 1.88,
-    "tier": 0.978069365,
+    "tier": 0.271323681,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9554,9 +9552,9 @@
     "name": "Wicker Square Shield",
     "culture": "Khuzait",
     "type": "Shield",
-    "price": 4340,
+    "price": 12392,
     "weight": 2.61,
-    "tier": 6.51302242,
+    "tier": 11.7595825,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -9634,9 +9632,9 @@
     "name": "Decorated Oval Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 6781,
+    "price": 20889,
     "weight": 4.84,
-    "tier": 8.411777,
+    "tier": 15.6019382,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -9936,9 +9934,9 @@
     "name": "Light Cavalry Lance",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 174,
+    "price": 54,
     "weight": 1.95,
-    "tier": 0.354202628,
+    "tier": 0.0145508721,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10014,9 +10012,9 @@
     "name": "Courser Lance",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 125,
+    "price": 55,
     "weight": 2.22,
-    "tier": 0.225304052,
+    "tier": 0.0163158216,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10073,9 +10071,9 @@
     "name": "Cataphract Lance",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 170,
+    "price": 63,
     "weight": 2.04,
-    "tier": 0.343840957,
+    "tier": 0.04250922,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10193,9 +10191,9 @@
     "name": "Spiked Club",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 12662,
+    "price": 40901,
     "weight": 1.15,
-    "tier": 13.3304148,
+    "tier": 24.8651638,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10226,9 +10224,9 @@
     "name": "Imperial Light Mace",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 375,
+    "price": 149,
     "weight": 1.9,
-    "tier": 1.43152189,
+    "tier": 0.569453835,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10259,9 +10257,9 @@
     "name": "Calradic Mace",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 558,
+    "price": 285,
     "weight": 1.8,
-    "tier": 1.96176088,
+    "tier": 1.12660909,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10292,9 +10290,9 @@
     "name": "Light Royal Mace",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 278,
+    "price": 106,
     "weight": 2.3,
-    "tier": 1.10116279,
+    "tier": 0.347862661,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10325,9 +10323,9 @@
     "name": "Cataphract Mace",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1207,
+    "price": 1016,
     "weight": 1.55,
-    "tier": 3.36395383,
+    "tier": 2.99918962,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10358,9 +10356,9 @@
     "name": "Decorated Short Spatha",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 23826,
+    "price": 45961,
     "weight": 1.46,
-    "tier": 18.70741,
+    "tier": 26.4272366,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10391,9 +10389,9 @@
     "name": "Thamaskene Steel Spatha",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 23604,
+    "price": 58132,
     "weight": 1.38,
-    "tier": 18.6144924,
+    "tier": 29.8639278,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10424,9 +10422,9 @@
     "name": "Spatha Blade with Ring Pommel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 19093,
+    "price": 37771,
     "weight": 1.26,
-    "tier": 16.627409,
+    "tier": 23.8500729,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10495,9 +10493,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 17871,
+    "price": 26151,
     "weight": 1.58,
-    "tier": 10.5666885,
+    "tier": 13.0109177,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10531,9 +10529,9 @@
     "name": "Fine Steel Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 34349,
+    "price": 175165,
     "weight": 1.1,
-    "tier": 15.0723047,
+    "tier": 35.4495621,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10611,9 +10609,9 @@
     "name": "Spatha With Narrow Fuller",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 13202,
+    "price": 18105,
     "weight": 1.33,
-    "tier": 13.635479,
+    "tier": 16.1617413,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -10646,9 +10644,9 @@
     "name": "Spatha",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 10161,
+    "price": 10566,
     "weight": 1.37,
-    "tier": 11.8240356,
+    "tier": 12.0796,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -10681,9 +10679,9 @@
     "name": "Fine Steel Spatha",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 16068,
+    "price": 26212,
     "weight": 1.35,
-    "tier": 15.1597452,
+    "tier": 19.6772442,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -10716,9 +10714,9 @@
     "name": "Fine Steel Paramerion",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 16361,
+    "price": 28493,
     "weight": 1.39,
-    "tier": 15.3072052,
+    "tier": 20.5645161,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10749,9 +10747,9 @@
     "name": "Thamaskene Steel Spathion",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 22174,
+    "price": 52988,
     "weight": 1.32,
-    "tier": 18.0070152,
+    "tier": 28.46015,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10992,9 +10990,9 @@
     "name": "Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 382,
+    "price": 77,
     "weight": 1.69,
-    "tier": 1.45260477,
+    "tier": 0.181587145,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11090,9 +11088,9 @@
     "name": "Fine Pike",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 108,
+    "price": 53,
     "weight": 2.81,
-    "tier": 0.177429572,
+    "tier": 0.009946049,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11214,9 +11212,9 @@
     "name": "Flat Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 6651,
+    "price": 20270,
     "weight": 5.49,
-    "tier": 8.320526,
+    "tier": 15.35248,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -11295,9 +11293,9 @@
     "name": "Wicker Shield",
     "culture": "Khuzait",
     "type": "Shield",
-    "price": 4977,
+    "price": 14566,
     "weight": 3.135,
-    "tier": 7.050653,
+    "tier": 12.8434582,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -11333,9 +11331,9 @@
     "name": "Fortified Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 7628,
+    "price": 24239,
     "weight": 6.16,
-    "tier": 8.988455,
+    "tier": 16.8935032,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -11813,9 +11811,9 @@
     "name": "Xiphos",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 15816,
+    "price": 29150,
     "weight": 0.85,
-    "tier": 15.0310125,
+    "tier": 20.8132668,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11872,7 +11870,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 12,
@@ -12327,9 +12324,9 @@
     "name": "Heater Shield with Cutout",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 3555,
+    "price": 9894,
     "weight": 2.112,
-    "tier": 5.792862,
+    "tier": 10.3895454,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -12365,9 +12362,9 @@
     "name": "Heavy Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 9285,
+    "price": 46299,
     "weight": 10.2,
-    "tier": 10.0305347,
+    "tier": 23.7808628,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -12527,9 +12524,9 @@
     "name": "Heavy Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 6439,
+    "price": 26524,
     "weight": 5.39,
-    "tier": 8.168903,
+    "tier": 17.7238617,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -12748,7 +12745,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 12,
@@ -12765,9 +12761,9 @@
     "name": "Highland Round Shield",
     "culture": "Battania",
     "type": "Shield",
-    "price": 4474,
+    "price": 13480,
     "weight": 2.82,
-    "tier": 6.6287,
+    "tier": 12.3129253,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -12803,9 +12799,9 @@
     "name": "Decorated Round Shield",
     "culture": "Battania",
     "type": "Shield",
-    "price": 3460,
+    "price": 10188,
     "weight": 2.58,
-    "tier": 5.70082569,
+    "tier": 10.55944,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -12841,9 +12837,9 @@
     "name": "Reinforced Highland Spear",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 112,
+    "price": 51,
     "weight": 2.46,
-    "tier": 0.1882276,
+    "tier": 0.00408169162,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -12942,9 +12938,9 @@
     "name": "Steel Tipped Hooked Spear",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 187,
+    "price": 56,
     "weight": 2.03,
-    "tier": 0.385827631,
+    "tier": 0.019649297,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -13022,9 +13018,9 @@
     "name": "Highland War Spear",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 7151,
+    "price": 5386,
     "weight": 1.85,
-    "tier": 6.29487276,
+    "tier": 5.328021,
     "requirement": 0,
     "flags": [
       "NotStackable"
@@ -13193,9 +13189,9 @@
     "name": "Hooked Cavalry Axe",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 146,
+    "price": 54,
     "weight": 1.52,
-    "tier": 0.3217231,
+    "tier": 0.0169958584,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13231,9 +13227,9 @@
     "name": "Falx Knife",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1513,
+    "price": 366,
     "weight": 0.82,
-    "tier": 3.89199543,
+    "tier": 1.40348387,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -13335,9 +13331,9 @@
     "name": "Small Cavalry Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4274,
+    "price": 9550,
     "weight": 3.315,
-    "tier": 6.454725,
+    "tier": 10.1878681,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -13397,7 +13393,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 9,
@@ -13414,9 +13409,9 @@
     "name": "Tzikourion",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 165,
+    "price": 64,
     "weight": 1.08,
-    "tier": 0.6419051,
+    "tier": 0.101851739,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13803,9 +13798,9 @@
     "name": "Short Militia Spear",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 1366,
+    "price": 311,
     "weight": 1.94,
-    "tier": 2.213992,
+    "tier": 0.6659317,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -13996,9 +13991,9 @@
     "name": "Iron Spatha",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 12674,
+    "price": 16722,
     "weight": 1.34,
-    "tier": 13.3370781,
+    "tier": 15.4877443,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -14223,9 +14218,9 @@
     "name": "Iron Rimmed Kite Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5583,
+    "price": 16257,
     "weight": 3.3,
-    "tier": 7.53208256,
+    "tier": 13.6317205,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -14261,9 +14256,9 @@
     "name": "Knights Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4545,
+    "price": 13144,
     "weight": 2.826,
-    "tier": 6.68950272,
+    "tier": 12.1447983,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -14299,9 +14294,9 @@
     "name": "Judgement",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 274,
+    "price": 104,
     "weight": 1.83,
-    "tier": 1.08670914,
+    "tier": 0.337212473,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -14332,9 +14327,9 @@
     "name": "Justicier",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1253,
+    "price": 220,
     "weight": 1.41,
-    "tier": 2.29706454,
+    "tier": 0.527787,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -14368,9 +14363,9 @@
     "name": "Ridged Long Kaskara",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 741,
+    "price": 112,
     "weight": 1.76,
-    "tier": 1.56754076,
+    "tier": 0.217038438,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -14854,9 +14849,9 @@
     "name": "Light Steppe Rider Lance",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 169,
+    "price": 54,
     "weight": 1.91,
-    "tier": 0.341792166,
+    "tier": 0.0134165529,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -14911,9 +14906,9 @@
     "name": "Heavy Cavalry Lance",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 291,
+    "price": 64,
     "weight": 1.94,
-    "tier": 0.624367833,
+    "tier": 0.0467652343,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -14989,9 +14984,9 @@
     "name": "Noble Cavalry Lance",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 423,
+    "price": 80,
     "weight": 1.9,
-    "tier": 0.8879095,
+    "tier": 0.0953967944,
     "requirement": 0,
     "flags": [
       "NotStackable"
@@ -15091,9 +15086,9 @@
     "name": "Steppe Light Mace",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 122,
+    "price": 57,
     "weight": 1.73,
-    "tier": 0.4332706,
+    "tier": 0.0487663932,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15124,9 +15119,9 @@
     "name": "Eastern Heavy Mace",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 1138,
+    "price": 953,
     "weight": 1.41,
-    "tier": 3.23559451,
+    "tier": 2.87241316,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15157,9 +15152,9 @@
     "name": "Fine Steel Mace",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 250,
+    "price": 93,
     "weight": 2.12,
-    "tier": 0.997659743,
+    "tier": 0.277654827,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15190,9 +15185,9 @@
     "name": "Heavy Flanged Mace",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 180,
+    "price": 70,
     "weight": 2.29,
-    "tier": 0.709601164,
+    "tier": 0.138890028,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15280,9 +15275,9 @@
     "name": "Decorated Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 1198,
+    "price": 248,
     "weight": 1.8,
-    "tier": 3.34774756,
+    "tier": 0.9875577,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15313,9 +15308,9 @@
     "name": "Lion Imprinted Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 767,
+    "price": 141,
     "weight": 1.7,
-    "tier": 2.47278357,
+    "tier": 0.530505,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15346,9 +15341,9 @@
     "name": "Tall Gripped Ild Sword",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 935,
+    "price": 180,
     "weight": 1.8,
-    "tier": 2.83566427,
+    "tier": 0.708455443,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15379,9 +15374,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 16297,
+    "price": 18873,
     "weight": 1.28,
-    "tier": 10.0419121,
+    "tier": 10.8886967,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15415,9 +15410,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 22561,
+    "price": 38845,
     "weight": 1.13,
-    "tier": 12.0067549,
+    "tier": 16.0987473,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15472,9 +15467,9 @@
     "name": "Iron Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 671,
+    "price": 122,
     "weight": 1.23,
-    "tier": 2.246969,
+    "tier": 0.432018131,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15507,9 +15502,9 @@
     "name": "Straight Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 643,
+    "price": 118,
     "weight": 1.35,
-    "tier": 2.17907739,
+    "tier": 0.411501348,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15542,9 +15537,9 @@
     "name": "Long Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 578,
+    "price": 106,
     "weight": 1.4,
-    "tier": 2.01291251,
+    "tier": 0.3502849,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15577,9 +15572,9 @@
     "name": "Fine Steel Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 586,
+    "price": 108,
     "weight": 1.55,
-    "tier": 2.03315854,
+    "tier": 0.3572391,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15612,9 +15607,9 @@
     "name": "Heavy Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 548,
+    "price": 101,
     "weight": 1.62,
-    "tier": 1.935133,
+    "tier": 0.323560447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15668,9 +15663,9 @@
     "name": "Knight's Fall",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 185,
+    "price": 73,
     "weight": 1.9,
-    "tier": 0.730101168,
+    "tier": 0.154818937,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15865,9 +15860,9 @@
     "name": "Large Adarga",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 3287,
+    "price": 9564,
     "weight": 2.4,
-    "tier": 5.52889633,
+    "tier": 10.1964283,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -15903,9 +15898,9 @@
     "name": "Large Franziska Axe",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 183,
+    "price": 69,
     "weight": 1.21,
-    "tier": 0.72272867,
+    "tier": 0.132424623,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -16086,9 +16081,9 @@
     "name": "Leather Bound Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 6011,
+    "price": 17100,
     "weight": 3.1232,
-    "tier": 7.85616,
+    "tier": 14.0091209,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -16249,9 +16244,9 @@
     "name": "Large Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 6092,
+    "price": 23228,
     "weight": 4.83,
-    "tier": 7.91640234,
+    "tier": 16.5138035,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -16671,9 +16666,9 @@
     "name": "Light Cavalry Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3444,
+    "price": 9055,
     "weight": 2.0592,
-    "tier": 5.68504333,
+    "tier": 9.891303,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -16709,9 +16704,9 @@
     "name": "Light Mace",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 203,
+    "price": 79,
     "weight": 1.8,
-    "tier": 0.8105634,
+    "tier": 0.193389192,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16974,7 +16969,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 11,
@@ -17054,7 +17048,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 14,
@@ -17286,9 +17279,9 @@
     "name": "Notched Military Fork",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 98,
+    "price": 51,
     "weight": 2.09,
-    "tier": 0.148444518,
+    "tier": 0.00582975056,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -17345,9 +17338,9 @@
     "name": "Military Fork",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 107,
+    "price": 51,
     "weight": 2.17,
-    "tier": 0.173913136,
+    "tier": 0.00361060235,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -17424,9 +17417,9 @@
     "name": "Morningstar",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 33593,
+    "price": 312714,
     "weight": 1.11,
-    "tier": 22.4271774,
+    "tier": 70.7878647,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -17985,7 +17978,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 9,
@@ -18086,9 +18078,9 @@
     "name": "Narrow Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 528,
+    "price": 90,
     "weight": 1.52,
-    "tier": 1.878997,
+    "tier": 0.260448456,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18444,7 +18436,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 14,
@@ -18485,7 +18476,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 18,
@@ -18564,7 +18554,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 15,
@@ -18812,7 +18801,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 10,
@@ -18915,9 +18903,9 @@
     "name": "Fine Steel Two Handed Sword",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 1274,
+    "price": 192,
     "weight": 1.48,
-    "tier": 2.324357,
+    "tier": 0.4532586,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18991,9 +18979,9 @@
     "name": "Northlander Broad Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 484,
+    "price": 133,
     "weight": 1.01,
-    "tier": 1.114852,
+    "tier": 0.281813234,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -19029,9 +19017,9 @@
     "name": "Simple Raider Battle Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 189,
+    "price": 70,
     "weight": 1.15,
-    "tier": 0.7496233,
+    "tier": 0.1403369,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -19188,9 +19176,9 @@
     "name": "Reinforced Cavalry Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 4103,
+    "price": 11946,
     "weight": 2.73,
-    "tier": 6.30276155,
+    "tier": 11.525773,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -19609,9 +19597,9 @@
     "name": "Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 4339,
+    "price": 12205,
     "weight": 3.01,
-    "tier": 6.511757,
+    "tier": 11.6621122,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -19647,9 +19635,9 @@
     "name": "Sturdy Cavalry Kite Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 5007,
+    "price": 14659,
     "weight": 3.744,
-    "tier": 7.075067,
+    "tier": 12.8879309,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -19685,9 +19673,9 @@
     "name": "Short Simple Raider Spear",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 8227,
+    "price": 7213,
     "weight": 1.01,
-    "tier": 6.827436,
+    "tier": 6.327008,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19765,9 +19753,9 @@
     "name": "Broad Leaf Shaped Spear",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 19290,
+    "price": 34614,
     "weight": 1.29,
-    "tier": 11.0204611,
+    "tier": 15.1346788,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19845,9 +19833,9 @@
     "name": "Jagged Fine Steel Spear",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 15950,
+    "price": 34583,
     "weight": 1.87,
-    "tier": 9.922905,
+    "tier": 15.1273069,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19925,9 +19913,9 @@
     "name": "Fine Steel Hewing Spear",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 287,
+    "price": 62,
     "weight": 1.92,
-    "tier": 0.616113245,
+    "tier": 0.0407618359,
     "requirement": 0,
     "flags": [
       "NotStackable"
@@ -20109,9 +20097,9 @@
     "name": "Decorated Eastern Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3909,
+    "price": 11816,
     "weight": 3.06,
-    "tier": 6.12590551,
+    "tier": 11.456955,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20147,9 +20135,9 @@
     "name": "Wooden Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3089,
+    "price": 8305,
     "weight": 1.716,
-    "tier": 5.327469,
+    "tier": 9.426517,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20185,9 +20173,9 @@
     "name": "Makeshift Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 7698,
+    "price": 21563,
     "weight": 3.4,
-    "tier": 9.034618,
+    "tier": 15.86968,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20307,9 +20295,9 @@
     "name": "Ornate Adarga",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 3575,
+    "price": 10600,
     "weight": 2.7,
-    "tier": 5.811493,
+    "tier": 10.7931032,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20345,9 +20333,9 @@
     "name": "Wooden Oval Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 6616,
+    "price": 19271,
     "weight": 3.696,
-    "tier": 8.295672,
+    "tier": 14.9412136,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20691,9 +20679,9 @@
     "name": "Pavise Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 8295,
+    "price": 26603,
     "weight": 6.962,
-    "tier": 9.420386,
+    "tier": 17.75189,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -20828,9 +20816,9 @@
     "name": "Hoe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 80,
+    "price": 50,
     "weight": 1.57,
-    "tier": 0.109976277,
+    "tier": 0.00195346028,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -20931,9 +20919,9 @@
     "name": "Blacksmith Hammer",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 86,
+    "price": 52,
     "weight": 1.4,
-    "tier": 0.234407961,
+    "tier": 0.0168432482,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20966,9 +20954,9 @@
     "name": "Wooden Hammer",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 96,
+    "price": 53,
     "weight": 1.48,
-    "tier": 0.292732775,
+    "tier": 0.025223244,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21002,9 +20990,9 @@
     "name": "Hatchet",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 145,
+    "price": 61,
     "weight": 1.05,
-    "tier": 0.547402,
+    "tier": 0.08000045,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -21039,9 +21027,9 @@
     "name": "Makeshift Sledgehammer",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 170,
+    "price": 69,
     "weight": 1.84,
-    "tier": 0.389943182,
+    "tier": 0.0725347549,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21077,9 +21065,9 @@
     "name": "Sledgehammer",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 149,
+    "price": 62,
     "weight": 1.96,
-    "tier": 0.3315143,
+    "tier": 0.04674714,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21115,9 +21103,9 @@
     "name": "Pickaxe",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 195,
+    "price": 73,
     "weight": 1.05,
-    "tier": 0.775228739,
+    "tier": 0.158321187,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -21152,9 +21140,9 @@
     "name": "Iron Pitchfork",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 114,
+    "price": 51,
     "weight": 1.92,
-    "tier": 0.195513636,
+    "tier": 0.00450603571,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21211,9 +21199,9 @@
     "name": "Pitchfork",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 167,
+    "price": 54,
     "weight": 1.47,
-    "tier": 0.335742146,
+    "tier": 0.0137217864,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21270,9 +21258,9 @@
     "name": "Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 3162,
+    "price": 1059,
     "weight": 2.76,
-    "tier": 3.85031319,
+    "tier": 1.84749794,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21309,9 +21297,9 @@
     "name": "Sickle",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 139,
+    "price": 59,
     "weight": 1.18,
-    "tier": 0.517664969,
+    "tier": 0.0661324039,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21345,9 +21333,9 @@
     "name": "Militia Pernach",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 635,
+    "price": 350,
     "weight": 1.76,
-    "tier": 2.158137,
+    "tier": 1.34930778,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21662,9 +21650,9 @@
     "name": "Pointed Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 490,
+    "price": 95,
     "weight": 1.68,
-    "tier": 1.77395964,
+    "tier": 0.2879235,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21794,9 +21782,9 @@
     "name": "Practice Spear",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 14483,
+    "price": 61691,
     "weight": 1.82,
-    "tier": 9.404741,
+    "tier": 20.5779686,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21853,9 +21841,9 @@
     "name": "Pugio",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 22096,
+    "price": 57273,
     "weight": 0.55,
-    "tier": 17.973196,
+    "tier": 29.6341648,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22109,9 +22097,9 @@
     "name": "Reaper",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1220,
+    "price": 185,
     "weight": 1.94,
-    "tier": 2.25538659,
+    "tier": 0.433428824,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22205,9 +22193,9 @@
     "name": "Reinforced Flat Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 5678,
+    "price": 16616,
     "weight": 3.41,
-    "tier": 7.60446739,
+    "tier": 13.7938366,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -22243,9 +22231,9 @@
     "name": "Reinforced Cavalry Small Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3680,
+    "price": 10408,
     "weight": 2.2932,
-    "tier": 5.91187572,
+    "tier": 10.6844158,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -22361,9 +22349,9 @@
     "name": "Ridged Great Saber",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1340,
+    "price": 214,
     "weight": 1.68,
-    "tier": 2.407456,
+    "tier": 0.5103575,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22454,9 +22442,9 @@
     "name": "Ridged Saber ",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 811,
+    "price": 148,
     "weight": 1.38,
-    "tier": 2.57124925,
+    "tier": 0.5633575,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22911,9 +22899,9 @@
     "name": "Seax",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 2301,
+    "price": 722,
     "weight": 0.44,
-    "tier": 5.048743,
+    "tier": 2.3688817,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -23109,9 +23097,9 @@
     "name": "Sentinel",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1356,
+    "price": 216,
     "weight": 1.44,
-    "tier": 2.42620039,
+    "tier": 0.517805,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23181,9 +23169,9 @@
     "name": "Light Shishpar Mace",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 607,
+    "price": 329,
     "weight": 1.67,
-    "tier": 2.08877349,
+    "tier": 1.28068531,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23236,9 +23224,9 @@
     "name": "Short Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 901,
+    "price": 163,
     "weight": 1.49,
-    "tier": 2.76416636,
+    "tier": 0.635501146,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23271,9 +23259,9 @@
     "name": "Simple Scimitar",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 511,
+    "price": 95,
     "weight": 1.23,
-    "tier": 1.83283424,
+    "tier": 0.2864131,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23306,9 +23294,9 @@
     "name": "Simple Pike",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 86,
+    "price": 50,
     "weight": 1.62,
-    "tier": 0.114986427,
+    "tier": 0.002965569,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23365,9 +23353,9 @@
     "name": "Simple Saber ",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 441,
+    "price": 85,
     "weight": 1.46,
-    "tier": 1.6333791,
+    "tier": 0.229653552,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23400,9 +23388,9 @@
     "name": "Simple Sparth Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 171,
+    "price": 55,
     "weight": 1.13,
-    "tier": 0.394723535,
+    "tier": 0.0195603855,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23525,9 +23513,9 @@
     "name": "Small Bit Axe",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 202,
+    "price": 75,
     "weight": 1.12,
-    "tier": 0.8034475,
+    "tier": 0.167191222,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23561,9 +23549,9 @@
     "name": "Small Flat Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4137,
+    "price": 9997,
     "weight": 3.01,
-    "tier": 6.333547,
+    "tier": 10.4495,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -23599,9 +23587,9 @@
     "name": "Small Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 3119,
+    "price": 8664,
     "weight": 1.96,
-    "tier": 5.3586483,
+    "tier": 9.65138149,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -23637,9 +23625,9 @@
     "name": "Small Spurred Axe",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 180,
+    "price": 69,
     "weight": 1.05,
-    "tier": 0.710614145,
+    "tier": 0.128539249,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23673,9 +23661,9 @@
     "name": "Broad Kaskara",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 1648,
+    "price": 280,
     "weight": 1.39,
-    "tier": 2.76999831,
+    "tier": 0.676078439,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23808,9 +23796,9 @@
     "name": "Reinforced Oval Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 6382,
+    "price": 19331,
     "weight": 4.29,
-    "tier": 8.127827,
+    "tier": 14.9659863,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -23868,9 +23856,9 @@
     "name": "Bamboo Handled Axe",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 199,
+    "price": 74,
     "weight": 0.96,
-    "tier": 0.7923384,
+    "tier": 0.1601339,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23904,9 +23892,9 @@
     "name": "Knob Headed Spear with Frills",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 16371,
+    "price": 26862,
     "weight": 1.19,
-    "tier": 10.0672388,
+    "tier": 13.2012968,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23984,9 +23972,9 @@
     "name": "Long Thamaskene Tipped Spear",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 7346,
+    "price": 5311,
     "weight": 1.96,
-    "tier": 6.39448,
+    "tier": 5.283454,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24064,9 +24052,9 @@
     "name": "Knob Headed Spear",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 4702,
+    "price": 2300,
     "weight": 1.28,
-    "tier": 4.911741,
+    "tier": 3.14303422,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24590,9 +24578,9 @@
     "name": "Star Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 160,
+    "price": 55,
     "weight": 2.3,
-    "tier": 0.6202132,
+    "tier": 0.035194248,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24659,9 +24647,9 @@
     "name": "Steel Shestopyor",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 159,
+    "price": 65,
     "weight": 2.24,
-    "tier": 0.6128076,
+    "tier": 0.103962995,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24692,9 +24680,9 @@
     "name": "Steel Round Shield",
     "culture": "Khuzait",
     "type": "Shield",
-    "price": 4125,
+    "price": 12607,
     "weight": 3.3,
-    "tier": 6.32199049,
+    "tier": 11.8709669,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -24809,7 +24797,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 10,
@@ -24869,9 +24856,9 @@
     "name": "Eastern Cavalry Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3345,
+    "price": 9773,
     "weight": 2.46,
-    "tier": 5.587019,
+    "tier": 10.3191481,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -24973,7 +24960,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 10,
@@ -25116,7 +25102,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 12,
@@ -25370,9 +25355,9 @@
     "name": "Reinforced Oaken Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 7984,
+    "price": 24925,
     "weight": 5.888,
-    "tier": 9.220895,
+    "tier": 17.1467018,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -25408,9 +25393,9 @@
     "name": "Studded Adarga",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 2626,
+    "price": 7229,
     "weight": 1.74,
-    "tier": 4.8300705,
+    "tier": 8.720929,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -25446,9 +25431,9 @@
     "name": "Studded Bound Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 7497,
+    "price": 20865,
     "weight": 5.94,
-    "tier": 8.90119648,
+    "tier": 15.5925455,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -25609,9 +25594,9 @@
     "name": "Iron Round Shield",
     "culture": "Aserai",
     "type": "Shield",
-    "price": 4125,
+    "price": 12607,
     "weight": 3.3,
-    "tier": 6.32199049,
+    "tier": 11.8709669,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -25708,9 +25693,9 @@
     "name": "Drilled Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 164,
+    "price": 58,
     "weight": 1.32,
-    "tier": 0.374214977,
+    "tier": 0.0321687832,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25746,9 +25731,9 @@
     "name": "Northlander Decorated Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 126,
+    "price": 54,
     "weight": 1.68,
-    "tier": 0.260465443,
+    "tier": 0.0166045055,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25784,9 +25769,9 @@
     "name": "Galloglaich Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 180,
+    "price": 69,
     "weight": 1.03,
-    "tier": 0.710614145,
+    "tier": 0.128539249,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25820,9 +25805,9 @@
     "name": "Commoner Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 263,
+    "price": 93,
     "weight": 0.94,
-    "tier": 1.046487,
+    "tier": 0.277642518,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25856,9 +25841,9 @@
     "name": "Veteran Warrior Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 214,
+    "price": 78,
     "weight": 1.19,
-    "tier": 0.853859246,
+    "tier": 0.186750323,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25892,9 +25877,9 @@
     "name": "Rectangular Bitted Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 198,
+    "price": 72,
     "weight": 1.05,
-    "tier": 0.7885971,
+    "tier": 0.152979761,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -26052,9 +26037,9 @@
     "name": "Druzhinnik Lance",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 405,
+    "price": 79,
     "weight": 1.88,
-    "tier": 0.8536472,
+    "tier": 0.0925357342,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -26130,9 +26115,9 @@
     "name": "Heavy Druzhinnik Lance",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 397,
+    "price": 75,
     "weight": 2.16,
-    "tier": 0.8372805,
+    "tier": 0.07939144,
     "requirement": 0,
     "flags": [
       "NotStackable"
@@ -26232,9 +26217,9 @@
     "name": "Thamaskene Steel Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1310,
+    "price": 272,
     "weight": 1.54,
-    "tier": 3.54761577,
+    "tier": 1.0782969,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26267,9 +26252,9 @@
     "name": "Decorated Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 602,
+    "price": 88,
     "weight": 1.54,
-    "tier": 2.07560349,
+    "tier": 0.246702909,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26302,9 +26287,9 @@
     "name": "Decorated Fullered Sword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1839,
+    "price": 447,
     "weight": 1.54,
-    "tier": 4.39951134,
+    "tier": 1.65125048,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26337,9 +26322,9 @@
     "name": "Gold Bound Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 326,
+    "price": 70,
     "weight": 1.34,
-    "tier": 1.26963294,
+    "tier": 0.140029,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26372,9 +26357,9 @@
     "name": "Iron Rimmed Large Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 4862,
+    "price": 14916,
     "weight": 3.57,
-    "tier": 6.9564,
+    "tier": 13.0101824,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -26410,9 +26395,9 @@
     "name": "Simple Large Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 3267,
+    "price": 9294,
     "weight": 1.96,
-    "tier": 5.509427,
+    "tier": 10.035964,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -26448,9 +26433,9 @@
     "name": "Warrazor",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 23405,
+    "price": 40883,
     "weight": 0.94,
-    "tier": 12.2495289,
+    "tier": 16.54436,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -26507,9 +26492,9 @@
     "name": "Tapered Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 815,
+    "price": 149,
     "weight": 1.11,
-    "tier": 2.57900929,
+    "tier": 0.568580866,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26542,9 +26527,9 @@
     "name": "Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1276,
+    "price": 257,
     "weight": 1.18,
-    "tier": 3.48854446,
+    "tier": 1.02416778,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26577,9 +26562,9 @@
     "name": "Pointy Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1240,
+    "price": 248,
     "weight": 1.14,
-    "tier": 3.42325139,
+    "tier": 0.9893473,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26612,9 +26597,9 @@
     "name": "Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 915,
+    "price": 169,
     "weight": 1.41,
-    "tier": 2.795269,
+    "tier": 0.6611655,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26647,9 +26632,9 @@
     "name": "Fullered Narrow Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1156,
+    "price": 226,
     "weight": 1.23,
-    "tier": 3.26934576,
+    "tier": 0.903282464,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -26682,9 +26667,9 @@
     "name": "Fullered Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 978,
+    "price": 183,
     "weight": 1.52,
-    "tier": 2.92389846,
+    "tier": 0.722374141,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27035,9 +27020,9 @@
     "name": "Tall Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 9235,
+    "price": 44935,
     "weight": 9.764999,
-    "tier": 10.0,
+    "tier": 23.4110374,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -27136,9 +27121,9 @@
     "name": "Thamaskene Pike",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 108,
+    "price": 53,
     "weight": 2.78,
-    "tier": 0.1788748,
+    "tier": 0.0111574009,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27195,9 +27180,9 @@
     "name": "Scalpel",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 411,
+    "price": 81,
     "weight": 1.47,
-    "tier": 1.5435586,
+    "tier": 0.203358337,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27531,9 +27516,9 @@
     "name": "Triangular Headed Spear",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 3130,
+    "price": 988,
     "weight": 1.83,
-    "tier": 3.82590914,
+    "tier": 1.75494766,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27635,7 +27620,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 13,
@@ -27652,9 +27636,9 @@
     "name": "Tribal Steppe Shield",
     "culture": "Khuzait",
     "type": "Shield",
-    "price": 3687,
+    "price": 11009,
     "weight": 2.82,
-    "tier": 5.919149,
+    "tier": 11.0204086,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -28037,9 +28021,9 @@
     "name": "Tyrhung",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 432,
+    "price": 76,
     "weight": 1.95,
-    "tier": 1.6080693,
+    "tier": 0.177952379,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -28072,9 +28056,9 @@
     "name": "Broad Tzikourion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 158,
+    "price": 63,
     "weight": 1.23,
-    "tier": 0.612401962,
+    "tier": 0.09382899,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28249,9 +28233,9 @@
     "name": "Norse Round Shield",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 5470,
+    "price": 19236,
     "weight": 4.27,
-    "tier": 7.444012,
+    "tier": 14.9265118,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -28367,9 +28351,9 @@
     "name": "Short Bill",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 91,
+    "price": 51,
     "weight": 1.72,
-    "tier": 0.14790833,
+    "tier": 0.006095216,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28406,9 +28390,9 @@
     "name": "Wide Fullered Broad Two Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 1968,
+    "price": 413,
     "weight": 1.79,
-    "tier": 3.11410427,
+    "tier": 0.972903252,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28440,9 +28424,9 @@
     "name": "Thamaskene Steel Two Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 2196,
+    "price": 487,
     "weight": 1.69,
-    "tier": 3.34314036,
+    "tier": 1.12042511,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28474,9 +28458,9 @@
     "name": "Infantry Axe",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 182,
+    "price": 69,
     "weight": 0.92,
-    "tier": 0.7169692,
+    "tier": 0.129564181,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28510,9 +28494,9 @@
     "name": "Spiked Battle Axe",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 1165,
+    "price": 822,
     "weight": 0.74,
-    "tier": 3.28577232,
+    "tier": 2.59537554,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28690,9 +28674,9 @@
     "name": "Light Lance",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 165,
+    "price": 53,
     "weight": 2.12,
-    "tier": 0.331804276,
+    "tier": 0.012774976,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28791,9 +28775,9 @@
     "name": "Knight Lance",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 326,
+    "price": 66,
     "weight": 1.99,
-    "tier": 0.697286546,
+    "tier": 0.0518620536,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28869,9 +28853,9 @@
     "name": "Heavy Knight Lance",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 364,
+    "price": 70,
     "weight": 2.21,
-    "tier": 0.774970233,
+    "tier": 0.06587923,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28966,9 +28950,9 @@
     "name": "Spiked Mace",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 13215,
+    "price": 48783,
     "weight": 1.3,
-    "tier": 13.642312,
+    "tier": 27.2611485,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28999,9 +28983,9 @@
     "name": "Fullered Cavalry Mace",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 365,
+    "price": 148,
     "weight": 2.1,
-    "tier": 1.40088618,
+    "tier": 0.561679661,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29032,9 +29016,9 @@
     "name": "Pernach",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 328,
+    "price": 126,
     "weight": 1.92,
-    "tier": 1.27718508,
+    "tier": 0.4541541,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29065,9 +29049,9 @@
     "name": "Decorated Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 1862,
+    "price": 461,
     "weight": 1.59,
-    "tier": 4.434094,
+    "tier": 1.69108069,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29100,9 +29084,9 @@
     "name": "Arming Sword with Circle",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 950,
+    "price": 175,
     "weight": 1.67,
-    "tier": 2.86719155,
+    "tier": 0.6870705,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29135,9 +29119,9 @@
     "name": "Gold Engraved Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 1156,
+    "price": 207,
     "weight": 1.55,
-    "tier": 3.269768,
+    "tier": 0.8245614,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29170,9 +29154,9 @@
     "name": "Crescent Guarded Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 1526,
+    "price": 330,
     "weight": 1.37,
-    "tier": 3.91317225,
+    "tier": 1.28373814,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29205,9 +29189,9 @@
     "name": "Pike",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 98,
+    "price": 53,
     "weight": 3.19,
-    "tier": 0.1502421,
+    "tier": 0.0102240527,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29264,9 +29248,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 15695,
+    "price": 17163,
     "weight": 1.27,
-    "tier": 9.834564,
+    "tier": 10.3336353,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -29303,9 +29287,9 @@
     "name": "Iron Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 454,
+    "price": 85,
     "weight": 1.34,
-    "tier": 1.67115521,
+    "tier": 0.227970988,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29338,9 +29322,9 @@
     "name": "Ridged Tipped Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 708,
+    "price": 120,
     "weight": 1.45,
-    "tier": 2.33426046,
+    "tier": 0.4248608,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29373,9 +29357,9 @@
     "name": "Knightly Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 986,
+    "price": 186,
     "weight": 1.41,
-    "tier": 2.940577,
+    "tier": 0.736903548,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29408,9 +29392,9 @@
     "name": "Ridged Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 664,
+    "price": 113,
     "weight": 1.54,
-    "tier": 2.22928858,
+    "tier": 0.386712581,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29441,9 +29425,9 @@
     "name": "Wide Fullered Broad Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 1276,
+    "price": 199,
     "weight": 1.5,
-    "tier": 3.487886,
+    "tier": 0.7930983,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29633,9 +29617,9 @@
     "name": "War Razor",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1036,
+    "price": 158,
     "weight": 1.54,
-    "tier": 2.00879455,
+    "tier": 0.3554008,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -29707,9 +29691,9 @@
     "name": "Tapered Two-Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 780,
+    "price": 118,
     "weight": 1.67,
-    "tier": 1.62976027,
+    "tier": 0.23674278,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29783,9 +29767,9 @@
     "name": "Broad Two Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 982,
+    "price": 163,
     "weight": 1.84,
-    "tier": 1.93298972,
+    "tier": 0.371415466,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30029,9 +30013,9 @@
     "name": "Kite Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5862,
+    "price": 17321,
     "weight": 3.63,
-    "tier": 7.744274,
+    "tier": 14.1069584,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -30086,9 +30070,9 @@
     "name": "Horseman Kite Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4167,
+    "price": 11937,
     "weight": 2.584,
-    "tier": 6.360078,
+    "tier": 11.5211439,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -30145,9 +30129,9 @@
     "name": "Simple Commoner Spear",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 16906,
+    "price": 31488,
     "weight": 1.17,
-    "tier": 10.2477341,
+    "tier": 14.3838177,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30225,9 +30209,9 @@
     "name": "Simple Short Spear",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 3250,
+    "price": 1253,
     "weight": 1.08,
-    "tier": 3.91700864,
+    "tier": 2.08390832,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30305,9 +30289,9 @@
     "name": "Tall Tipped Long Spear",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 2124,
+    "price": 516,
     "weight": 2.07,
-    "tier": 2.98371148,
+    "tier": 1.05397928,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30385,9 +30369,9 @@
     "name": "Tall Tipped Spear",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 1190,
+    "price": 228,
     "weight": 2.1,
-    "tier": 2.00939441,
+    "tier": 0.483380973,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30465,9 +30449,9 @@
     "name": "Long Fine Steel Spear",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 180,
+    "price": 54,
     "weight": 2.06,
-    "tier": 0.368982732,
+    "tier": 0.0149093475,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30522,9 +30506,9 @@
     "name": "Fine Steel Spear",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 180,
+    "price": 54,
     "weight": 2.06,
-    "tier": 0.368982732,
+    "tier": 0.0149093475,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30661,9 +30645,9 @@
     "name": "Wide Heater Shield",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5813,
+    "price": 17920,
     "weight": 4.32,
-    "tier": 7.707899,
+    "tier": 14.367732,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -30699,9 +30683,9 @@
     "name": "Wide Leaf Spear",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 191,
+    "price": 55,
     "weight": 2.02,
-    "tier": 0.395247817,
+    "tier": 0.01677753,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30779,9 +30763,9 @@
     "name": "Winds Fury",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 800,
+    "price": 146,
     "weight": 1.39,
-    "tier": 2.5454092,
+    "tier": 0.5536339,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30892,9 +30876,9 @@
     "name": "Wooden Twohander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 602,
+    "price": 158,
     "weight": 0.55,
-    "tier": 1.33279145,
+    "tier": 0.356791854,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30969,9 +30953,9 @@
     "name": "Wooden Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 356,
+    "price": 111,
     "weight": 0.58,
-    "tier": 1.3708694,
+    "tier": 0.3774702,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31003,9 +30987,9 @@
     "name": "Woodland Axe",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 196,
+    "price": 73,
     "weight": 1.27,
-    "tier": 0.780707836,
+    "tier": 0.156122625,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -31063,7 +31047,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 16,
@@ -31104,7 +31087,6 @@
           "HasString",
           "StringHeldByHand",
           "UnloadWhenSheathed",
-          "AutoReload",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 16,
@@ -31121,9 +31103,9 @@
     "name": "Makeshift Horseman Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 3122,
+    "price": 8420,
     "weight": 1.7472,
-    "tier": 5.361285,
+    "tier": 9.499303,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -31159,9 +31141,9 @@
     "name": "Worn Kite Shield",
     "culture": "Neutral",
     "type": "Shield",
-    "price": 6292,
+    "price": 15900,
     "weight": 3.456,
-    "tier": 8.062683,
+    "tier": 13.4686966,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -1679,7 +1679,7 @@
   <Item id="crpg_hunting_bow" name="{=wltdyF2j}Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="95" missile_speed="75" weapon_length="110" accuracy="135" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1687,7 +1687,7 @@
   <Item id="crpg_mountain_hunting_bow" name="{=YGQ6UXCo}Mountain Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="125" missile_speed="79" weapon_length="108" accuracy="98" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1695,7 +1695,7 @@
   <Item id="crpg_steppe_bow" name="{=steppebowitem}Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="93" missile_speed="76" weapon_length="110" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1703,7 +1703,7 @@
   <Item id="crpg_glen_ranger_bow" name="{=KTegaNPW}Longbow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="97" missile_speed="93" weapon_length="111" accuracy="110" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1711,7 +1711,7 @@
   <Item id="crpg_highland_ranger_bow" name="{=mTWvG1xz}Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.6" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="90" missile_speed="108" weapon_length="113" accuracy="117" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1719,7 +1719,7 @@
   <Item id="crpg_composite_bow" name="{=h1jKICdp}Simple Short Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="92" missile_speed="78" weapon_length="110" accuracy="117" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1727,7 +1727,7 @@
   <Item id="crpg_composite_steppe_bow" name="{=w6EU77OH}Steppe Recurve Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="110" speed_rating="95" missile_speed="80" weapon_length="108" accuracy="110" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1735,7 +1735,7 @@
   <Item id="crpg_steppe_heavy_bow" name="{=E7miRMw1}Heavy Recurve Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="120" missile_speed="81" weapon_length="106" accuracy="95" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1743,7 +1743,7 @@
   <Item id="crpg_nordic_shortbow" name="{=tEimkEsU}Nordic Shortbow" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.35" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="81" speed_rating="94" missile_speed="89" weapon_length="108" accuracy="120" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1751,7 +1751,7 @@
   <Item id="crpg_lowland_longbow" name="{=A6llHL9s}Yonsun Yumi" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="82" missile_speed="86" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1759,7 +1759,7 @@
   <Item id="crpg_tribal_bow" name="{=ZQv5Bcl2}Rokusun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="81" missile_speed="85" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1767,7 +1767,7 @@
   <Item id="crpg_steppe_war_bow" name="{=wfhHGTbl}Steppe War Bow" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="105" missile_speed="83" weapon_length="107" accuracy="98" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1775,7 +1775,7 @@
   <Item id="crpg_woodland_yew_bow" name="{=RcCtV0aS}Woodland Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.65" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="99" speed_rating="95" missile_speed="95" weapon_length="115" accuracy="100" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1783,7 +1783,7 @@
   <Item id="crpg_woodland_longbow" name="{=ZFwKlHIJ}Woodland Longbow" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="89" missile_speed="98" weapon_length="118" accuracy="99" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1791,7 +1791,7 @@
   <Item id="crpg_nomad_bow" name="{=ifzgMcrK}Hassun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="80" missile_speed="86" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1799,7 +1799,7 @@
   <Item id="crpg_lowland_yew_bow" name="{=9YbFEaZ1}Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.55" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="96" missile_speed="94" weapon_length="117" accuracy="109" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1807,7 +1807,7 @@
   <Item id="crpg_noble_bow" name="{=EO7pCu1b}Noble Bow" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="98" missile_speed="85" weapon_length="116" accuracy="95" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
@@ -1815,7 +1815,7 @@
   <Item id="crpg_noble_long_bow" name="{=WRqYWspc}Noble Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="86" speed_rating="88" missile_speed="100" weapon_length="118" accuracy="97" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
-        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />


### PR DESCRIPTION
I removed auto reload from all bows to allow the archer the choice whether or not to pull arrow, or run. Currently crossbowmen can skirmish more affectively then archers, because they can shoot and then move full speed, dodging incoming projectiles; an archer however, has to shoot, then be slowed without choice while those who are shooting at them know that this slowdown is about to occur. So they shoot where the slowed down version will go, or try to go.