### PR TITLE
Adjusted swing poles according to V12

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1432,7 +1432,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.43	">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.38	">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.8" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -859,13 +859,13 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="0.9">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1.1">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1.35">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_handle" name="{=NQb8boHt}Hardened Ash Shaft" tier="4" piece_type="Handle" mesh="spear_handle_15" length="170" weight="1.4">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -937,7 +937,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.9" CraftingCost="110">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="1.05" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -949,13 +949,13 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="0.9" CraftingCost="110">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="1.15" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="1" CraftingCost="110">
+  <CraftingPiece id="crpg_battania_polearm_1_t5_handle" name="{=aQa3tp6Q}Decorated Long Pine Shaft" tier="5" piece_type="Handle" mesh="spear_handle_8" length="230" weight="1.15" CraftingCost="110">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -979,7 +979,7 @@
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_polearm_t2_handle" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.2" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
+  <CraftingPiece id="crpg_billhook_polearm_t2_handle" name="{=LSOXMCAW}Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_4" length="190" weight="1.6" excluded_item_usage_features="long" item_holster_pos_shift="0,0,0.10" CraftingCost="100">
     <BuildData piece_offset="19.4" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1243,8 +1243,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bo_staff_t1_blade" name="{=V9Kbq6vj}Blunt Practice Tip" tier="1" piece_type="Blade" mesh="spear_blade_34" length="18.3" weight="0.1">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Blunt" damage_factor="1.8" />
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Thrust damage_type="Blunt" damage_factor="1.0" />
+      <Swing damage_type="Blunt" damage_factor="1.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1487,17 +1487,17 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.34">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.2" />
+      <Thrust damage_type="Cut" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.7">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.55">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="4" />
+      <Thrust damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1512,11 +1512,11 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.49">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.43">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1833,7 +1833,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.51" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
@@ -6021,7 +6021,7 @@
 <CraftingPiece id="crpg_war_scythe_blade" name="{=}War Scythe Blade" tier="2" piece_type="Blade" mesh="warscythe_head" length="120" weight="0.6" excluded_item_usage_features="shield:thrust">
 <BuildData piece_offset="-20"/>
 <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-<Swing damage_type="Cut" damage_factor="4.0"/>
+<Swing damage_type="Cut" damage_factor="4.3"/>
 </BladeData>
 <Materials>
 <Material id="Iron3" count="4"/>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2040,7 +2040,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_bardiche_handle" name="{=}Long Bardiche Handle" tier="4" piece_type="Handle" mesh="axe_craft_10_handle" length="132" weight="0.65" excluded_item_usage_features="widegrip">
+  <CraftingPiece id="crpg_long_bardiche_handle" name="{=}Long Bardiche Handle" tier="4" piece_type="Handle" mesh="axe_craft_10_handle" length="132" weight="0.7" excluded_item_usage_features="widegrip">
     <BuildData piece_offset="28.87" next_piece_offset="2.5" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -2337,8 +2337,8 @@
   <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.6">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="5" />
+      <Thrust damage_type="Cut" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6130,7 +6130,7 @@
 </CraftingPiece>
 <CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.2" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Blunt" damage_factor="1.5" />
+      <Thrust damage_type="Blunt" damage_factor="1.6" />
       <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
@@ -6141,7 +6141,7 @@
       <Material id="Iron3" count="5" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_hafted_spiked_mace_handle" name="{=}Long Hafted Spiked Mace Handle" tier="5" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.3" CraftingCost="75">
+  <CraftingPiece id="crpg_long_hafted_spiked_mace_handle" name="{=}Long Hafted Spiked Mace Handle" tier="5" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.35" CraftingCost="75">
     <BuildData piece_offset="15" />
     <Materials>
       <Material id="Wood" count="2" />

--- a/items.json
+++ b/items.json
@@ -17511,9 +17511,9 @@
     "name": "Long Bardiche",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 23449,
-    "weight": 1.58,
-    "tier": 12.2621946,
+    "price": 15938,
+    "weight": 1.65,
+    "tier": 9.918792,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -17526,7 +17526,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 161,
-        "balance": 0.23,
+        "balance": 0.21,
         "handling": 67,
         "bodyArmor": 0,
         "flags": [
@@ -17536,12 +17536,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 23,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 50,
+        "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 76
       }
     ]
   },
@@ -17632,9 +17632,9 @@
     "name": "Long Hafted Spiked Mace",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 17921,
-    "weight": 1.69,
-    "tier": 10.5830441,
+    "price": 13775,
+    "weight": 1.83,
+    "tier": 9.145699,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -17647,8 +17647,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 154,
-        "balance": 0.23,
-        "handling": 68,
+        "balance": 0.2,
+        "handling": 67,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -17657,12 +17657,12 @@
           "TwoHandIdleOnMount",
           "MultiplePenetration"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Blunt",
-        "thrustSpeed": 94,
+        "thrustSpeed": 93,
         "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 76
+        "swingSpeed": 75
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -10914,9 +10914,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 14088,
-    "weight": 1.7,
-    "tier": 9.261129,
+    "price": 15781,
+    "weight": 1.72,
+    "tier": 9.864457,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10926,8 +10926,8 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 164,
-        "balance": 0.46,
+        "length": 169,
+        "balance": 0.44,
         "handling": 72,
         "bodyArmor": 0,
         "flags": [

--- a/items.json
+++ b/items.json
@@ -4679,9 +4679,9 @@
     "name": "Rhomphaia",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 20438,
-    "weight": 1.25,
-    "tier": 11.3753214,
+    "price": 12946,
+    "weight": 1.35,
+    "tier": 8.833304,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4692,8 +4692,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 184,
-        "balance": 0.33,
-        "handling": 69,
+        "balance": 0.28,
+        "handling": 67,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -4704,10 +4704,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 98,
+        "thrustSpeed": 96,
         "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 78
       }
     ]
   },
@@ -5661,9 +5661,9 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 23734,
-    "weight": 1.67,
-    "tier": 12.3430233,
+    "price": 15222,
+    "weight": 1.91,
+    "tier": 9.668979,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5674,8 +5674,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 141,
-        "balance": 0.46,
-        "handling": 71,
+        "balance": 0.42,
+        "handling": 69,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5686,10 +5686,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 94,
+        "thrustSpeed": 93,
         "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 82
       }
     ]
   },
@@ -5772,9 +5772,9 @@
     "name": "Bo Staff",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 8352,
+    "price": 1107,
     "weight": 2.39,
-    "tier": 6.886944,
+    "tier": 1.90749764,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5795,10 +5795,10 @@
           "TwoHandIdleOnMount",
           "NoBlood"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 10,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 91,
-        "swingDamage": 18,
+        "swingDamage": 14,
         "swingDamageType": "Blunt",
         "swingSpeed": 94
       }
@@ -10914,9 +10914,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 18269,
-    "weight": 1.66,
-    "tier": 10.6957655,
+    "price": 14088,
+    "weight": 1.7,
+    "tier": 9.261129,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -10927,8 +10927,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 164,
-        "balance": 0.47,
-        "handling": 73,
+        "balance": 0.46,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -10938,10 +10938,10 @@
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
+        "thrustSpeed": 94,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 83
       }
     ]
   },
@@ -16090,9 +16090,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 5797,
-    "weight": 1.58,
-    "tier": 5.565307,
+    "price": 14671,
+    "weight": 1.63,
+    "tier": 9.472459,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16103,8 +16103,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 147,
-        "balance": 0.41,
-        "handling": 70,
+        "balance": 0.48,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16112,12 +16112,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
+        "thrustDamage": 25,
+        "thrustDamageType": "Cut",
         "thrustSpeed": 95,
-        "swingDamage": 40,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -16126,9 +16126,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 23594,
-    "weight": 1.2,
-    "tier": 12.303441,
+    "price": 14929,
+    "weight": 1.35,
+    "tier": 9.564983,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16139,8 +16139,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.28,
-        "handling": 67,
+        "balance": 0.22,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16148,12 +16148,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 98,
+        "thrustSpeed": 96,
         "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 76
       }
     ]
   },
@@ -30640,9 +30640,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 23348,
-    "weight": 1.29,
-    "tier": 12.2334385,
+    "price": 15805,
+    "weight": 1.45,
+    "tier": 9.872618,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -30655,8 +30655,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.44,
-        "handling": 67,
+        "balance": 0.4,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30665,12 +30665,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 48,
+        "thrustSpeed": 96,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 82
       }
     ]
   },
@@ -31044,9 +31044,9 @@
     "name": "War Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 7334,
+    "price": 12977,
     "weight": 1.68,
-    "tier": 6.38806343,
+    "tier": 8.845194,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31069,7 +31069,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 40,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -685,7 +685,7 @@
     <Pieces>
       <Piece id="crpg_empire_polearm_1_t4_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_empire_polearm_1_t4_guard" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_empire_polearm_1_t4_handle" Type="Handle" scale_factor="91" />
+      <Piece id="crpg_empire_polearm_1_t4_handle" Type="Handle" scale_factor="96" />
       <Piece id="crpg_empire_polearm_1_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>


### PR DESCRIPTION
Following weapons affected:

Glaive (89 speed -> 84 speed, thrust is now cut)
Long Glaive
Menavlion
Voulge
Billhook
War Scythe
Rhomphaia
Bo Staff (18b swing -> 14b, 18b thrust -> 10b)
Long Bardiche
Long Hafted Spiked Mace