### PR TITLE
Mount Rework v1.1

### DIFF
--- a/items.json
+++ b/items.json
@@ -20284,9 +20284,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13752,
+    "price": 12916,
     "weight": 420.0,
-    "tier": 8.60612,
+    "tier": 8.307658,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20295,7 +20295,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 74,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 195
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -6972,12 +6972,12 @@
   },
   {
     "id": "crpg_camel_10",
-    "name": "Tunisian Light War Camel",
+    "name": "Seleucid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 15111,
+    "price": 14276,
     "weight": 520.0,
-    "tier": 9.072852,
+    "tier": 8.788731,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6987,18 +6987,18 @@
       "chargeDamage": 4,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 235
+      "hitPoints": 229
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_11",
-    "name": "Tunisian Heavy War Camel",
+    "name": "Seleucid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 16338,
+    "price": 15506,
     "weight": 520.0,
-    "tier": 9.47656,
+    "tier": 9.204619,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7008,18 +7008,18 @@
       "chargeDamage": 5,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 255
+      "hitPoints": 249
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_12",
-    "name": "Parthian Light War Camel",
+    "name": "Parthian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 16902,
+    "price": 15961,
     "weight": 520.0,
-    "tier": 9.656998,
+    "tier": 9.354147,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7029,18 +7029,18 @@
       "chargeDamage": 4,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 235
+      "hitPoints": 229
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_13",
-    "name": "Parthian Heavy War Camel",
+    "name": "Parthian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 18318,
+    "price": 17379,
     "weight": 520.0,
-    "tier": 10.0976152,
+    "tier": 9.807319,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7050,18 +7050,18 @@
       "chargeDamage": 5,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 255
+      "hitPoints": 249
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_14",
-    "name": "Achaemenian Light War Camel",
+    "name": "Achaemenian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 20944,
+    "price": 19817,
     "weight": 520.0,
-    "tier": 10.8717165,
+    "tier": 10.5457993,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7071,18 +7071,18 @@
       "chargeDamage": 5,
       "maneuver": 84,
       "speed": 38,
-      "hitPoints": 245
+      "hitPoints": 239
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_15",
-    "name": "Achaemenian Heavy War Camel",
+    "name": "Achaemenian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 22634,
+    "price": 21510,
     "weight": 520.0,
-    "tier": 11.3449173,
+    "tier": 11.0323381,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7092,7 +7092,7 @@
       "chargeDamage": 6,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 265
+      "hitPoints": 259
     },
     "weapons": []
   },
@@ -7101,9 +7101,9 @@
     "name": "Padisha",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 27526,
+    "price": 26155,
     "weight": 520.0,
-    "tier": 12.6228046,
+    "tier": 12.2769156,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7113,7 +7113,7 @@
       "chargeDamage": 7,
       "maneuver": 86,
       "speed": 38,
-      "hitPoints": 265
+      "hitPoints": 259
     },
     "weapons": []
   },
@@ -7161,7 +7161,7 @@
   },
   {
     "id": "crpg_camel_4",
-    "name": "Qedarite War Camel",
+    "name": "Qedarite Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 7912,
@@ -7182,7 +7182,7 @@
   },
   {
     "id": "crpg_camel_5",
-    "name": "Palmyrene War Camel",
+    "name": "Palmyrene Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 9486,
@@ -7203,12 +7203,12 @@
   },
   {
     "id": "crpg_camel_6",
-    "name": "Syrian Light War Camel",
+    "name": "Sargonid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 10939,
+    "price": 10323,
     "weight": 520.0,
-    "tier": 7.561577,
+    "tier": 7.315475,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7218,18 +7218,18 @@
       "chargeDamage": 4,
       "maneuver": 80,
       "speed": 34,
-      "hitPoints": 225
+      "hitPoints": 219
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_7",
-    "name": "Syrian Heavy War Camel",
+    "name": "Sargonid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 11859,
+    "price": 11246,
     "weight": 520.0,
-    "tier": 7.916426,
+    "tier": 7.68140936,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7239,18 +7239,18 @@
       "chargeDamage": 5,
       "maneuver": 79,
       "speed": 33,
-      "hitPoints": 245
+      "hitPoints": 239
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_8",
-    "name": "Nabatean Light War Camel",
+    "name": "Nabatean Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 12268,
+    "price": 11571,
     "weight": 520.0,
-    "tier": 8.06994152,
+    "tier": 7.806819,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7260,18 +7260,18 @@
       "chargeDamage": 4,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 225
+      "hitPoints": 219
     },
     "weapons": []
   },
   {
     "id": "crpg_camel_9",
-    "name": "Nabatean Heavy War Camel",
+    "name": "Nabatean Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 13334,
+    "price": 12638,
     "weight": 520.0,
-    "tier": 8.458322,
+    "tier": 8.206637,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7281,7 +7281,7 @@
       "chargeDamage": 5,
       "maneuver": 80,
       "speed": 34,
-      "hitPoints": 245
+      "hitPoints": 239
     },
     "weapons": []
   },
@@ -18961,9 +18961,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17827,
+    "price": 16757,
     "weight": 430.0,
-    "tier": 9.946721,
+    "tier": 9.611014,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18973,7 +18973,7 @@
       "chargeDamage": 5,
       "maneuver": 81,
       "speed": 41,
-      "hitPoints": 217
+      "hitPoints": 211
     },
     "weapons": []
   },
@@ -18982,9 +18982,9 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20663,
+    "price": 19438,
     "weight": 430.0,
-    "tier": 10.7913475,
+    "tier": 10.4340172,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18994,7 +18994,7 @@
       "chargeDamage": 6,
       "maneuver": 82,
       "speed": 42,
-      "hitPoints": 220
+      "hitPoints": 214
     },
     "weapons": []
   },
@@ -19003,9 +19003,9 @@
     "name": "Lusitano Pureblood Destrier",
     "culture": "Battania",
     "type": "Mount",
-    "price": 22756,
+    "price": 21416,
     "weight": 430.0,
-    "tier": 11.3782444,
+    "tier": 11.0058794,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19015,7 +19015,7 @@
       "chargeDamage": 6,
       "maneuver": 82,
       "speed": 43,
-      "hitPoints": 223
+      "hitPoints": 217
     },
     "weapons": []
   },
@@ -19024,9 +19024,9 @@
     "name": "Bohemond",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 26352,
+    "price": 24821,
     "weight": 430.0,
-    "tier": 12.3272352,
+    "tier": 11.9317226,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19036,7 +19036,7 @@
       "chargeDamage": 7,
       "maneuver": 83,
       "speed": 44,
-      "hitPoints": 226
+      "hitPoints": 220
     },
     "weapons": []
   },
@@ -19045,9 +19045,9 @@
     "name": "Llamrei",
     "culture": "Battania",
     "type": "Mount",
-    "price": 28927,
+    "price": 27259,
     "weight": 430.0,
-    "tier": 12.96768,
+    "tier": 12.5562592,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19057,7 +19057,7 @@
       "chargeDamage": 7,
       "maneuver": 83,
       "speed": 45,
-      "hitPoints": 229
+      "hitPoints": 223
     },
     "weapons": []
   },
@@ -19066,9 +19066,9 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8342,
+    "price": 7826,
     "weight": 450.0,
-    "tier": 6.47115564,
+    "tier": 6.235701,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19078,7 +19078,7 @@
       "chargeDamage": 3,
       "maneuver": 73,
       "speed": 37,
-      "hitPoints": 202
+      "hitPoints": 196
     },
     "weapons": []
   },
@@ -19087,9 +19087,9 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9982,
+    "price": 9365,
     "weight": 430.0,
-    "tier": 7.1762886,
+    "tier": 6.91836262,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19099,7 +19099,7 @@
       "chargeDamage": 3,
       "maneuver": 75,
       "speed": 38,
-      "hitPoints": 205
+      "hitPoints": 199
     },
     "weapons": []
   },
@@ -19108,9 +19108,9 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12071,
+    "price": 11331,
     "weight": 430.0,
-    "tier": 7.996349,
+    "tier": 7.71446657,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19120,7 +19120,7 @@
       "chargeDamage": 4,
       "maneuver": 77,
       "speed": 39,
-      "hitPoints": 208
+      "hitPoints": 202
     },
     "weapons": []
   },
@@ -19129,9 +19129,9 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14374,
+    "price": 13494,
     "weight": 430.0,
-    "tier": 8.822511,
+    "tier": 8.515131,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19141,7 +19141,7 @@
       "chargeDamage": 4,
       "maneuver": 79,
       "speed": 40,
-      "hitPoints": 211
+      "hitPoints": 205
     },
     "weapons": []
   },
@@ -19150,9 +19150,9 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16678,
+    "price": 15668,
     "weight": 430.0,
-    "tier": 9.585763,
+    "tier": 9.258071,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19162,7 +19162,7 @@
       "chargeDamage": 5,
       "maneuver": 80,
       "speed": 41,
-      "hitPoints": 214
+      "hitPoints": 208
     },
     "weapons": []
   },
@@ -19171,9 +19171,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 18156,
+    "price": 17148,
     "weight": 450.0,
-    "tier": 10.0481415,
+    "tier": 9.734966,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19183,7 +19183,7 @@
       "chargeDamage": 8,
       "maneuver": 72,
       "speed": 44,
-      "hitPoints": 227
+      "hitPoints": 221
     },
     "weapons": []
   },
@@ -19192,9 +19192,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 21391,
+    "price": 20227,
     "weight": 450.0,
-    "tier": 10.9987364,
+    "tier": 10.6654711,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19204,7 +19204,7 @@
       "chargeDamage": 9,
       "maneuver": 73,
       "speed": 45,
-      "hitPoints": 230
+      "hitPoints": 224
     },
     "weapons": []
   },
@@ -19213,9 +19213,9 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 23337,
+    "price": 22074,
     "weight": 450.0,
-    "tier": 11.5363531,
+    "tier": 11.1899786,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19225,7 +19225,7 @@
       "chargeDamage": 9,
       "maneuver": 73,
       "speed": 46,
-      "hitPoints": 233
+      "hitPoints": 227
     },
     "weapons": []
   },
@@ -19234,9 +19234,9 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 27638,
+    "price": 26178,
     "weight": 450.0,
-    "tier": 12.6506109,
+    "tier": 12.2827349,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19246,7 +19246,7 @@
       "chargeDamage": 10,
       "maneuver": 74,
       "speed": 47,
-      "hitPoints": 236
+      "hitPoints": 230
     },
     "weapons": []
   },
@@ -19255,9 +19255,9 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 30044,
+    "price": 28465,
     "weight": 450.0,
-    "tier": 13.2365427,
+    "tier": 12.8547964,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19267,7 +19267,7 @@
       "chargeDamage": 10,
       "maneuver": 74,
       "speed": 48,
-      "hitPoints": 239
+      "hitPoints": 233
     },
     "weapons": []
   },
@@ -19276,9 +19276,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8034,
+    "price": 7566,
     "weight": 450.0,
-    "tier": 6.33151865,
+    "tier": 6.114084,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19288,7 +19288,7 @@
       "chargeDamage": 4,
       "maneuver": 64,
       "speed": 40,
-      "hitPoints": 212
+      "hitPoints": 206
     },
     "weapons": []
   },
@@ -19297,9 +19297,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9782,
+    "price": 9216,
     "weight": 450.0,
-    "tier": 7.0936265,
+    "tier": 6.854764,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19309,7 +19309,7 @@
       "chargeDamage": 5,
       "maneuver": 66,
       "speed": 41,
-      "hitPoints": 215
+      "hitPoints": 209
     },
     "weapons": []
   },
@@ -19318,9 +19318,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11896,
+    "price": 11213,
     "weight": 450.0,
-    "tier": 7.93043041,
+    "tier": 7.668689,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19330,7 +19330,7 @@
       "chargeDamage": 6,
       "maneuver": 68,
       "speed": 42,
-      "hitPoints": 218
+      "hitPoints": 212
     },
     "weapons": []
   },
@@ -19339,9 +19339,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14473,
+    "price": 13650,
     "weight": 450.0,
-    "tier": 8.856582,
+    "tier": 8.570456,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19351,7 +19351,7 @@
       "chargeDamage": 7,
       "maneuver": 70,
       "speed": 43,
-      "hitPoints": 221
+      "hitPoints": 215
     },
     "weapons": []
   },
@@ -19360,9 +19360,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16973,
+    "price": 16024,
     "weight": 450.0,
-    "tier": 9.679592,
+    "tier": 9.374633,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19372,7 +19372,7 @@
       "chargeDamage": 8,
       "maneuver": 71,
       "speed": 44,
-      "hitPoints": 224
+      "hitPoints": 218
     },
     "weapons": []
   },
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18538,
+    "price": 17353,
     "weight": 420.0,
-    "tier": 10.16444,
+    "tier": 9.799385,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19393,7 +19393,7 @@
       "chargeDamage": 5,
       "maneuver": 71,
       "speed": 50,
-      "hitPoints": 204
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21095,
+    "price": 19756,
     "weight": 420.0,
-    "tier": 10.9149818,
+    "tier": 10.52789,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19414,7 +19414,7 @@
       "chargeDamage": 5,
       "maneuver": 72,
       "speed": 51,
-      "hitPoints": 207
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23024,
+    "price": 21575,
     "weight": 420.0,
-    "tier": 11.4515133,
+    "tier": 11.0506887,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19435,7 +19435,7 @@
       "chargeDamage": 5,
       "maneuver": 72,
       "speed": 52,
-      "hitPoints": 210
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 26462,
+    "price": 24818,
     "weight": 420.0,
-    "tier": 12.3550625,
+    "tier": 11.9307365,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19456,7 +19456,7 @@
       "chargeDamage": 6,
       "maneuver": 73,
       "speed": 53,
-      "hitPoints": 213
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 28810,
+    "price": 27037,
     "weight": 420.0,
-    "tier": 12.9391708,
+    "tier": 12.5003471,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19477,7 +19477,7 @@
       "chargeDamage": 6,
       "maneuver": 73,
       "speed": 54,
-      "hitPoints": 216
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8649,
+    "price": 8077,
     "weight": 420.0,
-    "tier": 6.6081295,
+    "tier": 6.351092,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19498,7 +19498,7 @@
       "chargeDamage": 3,
       "maneuver": 63,
       "speed": 46,
-      "hitPoints": 189
+      "hitPoints": 183
     },
     "weapons": []
   },
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10354,
+    "price": 9670,
     "weight": 420.0,
-    "tier": 7.328395,
+    "tier": 7.047114,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19519,7 +19519,7 @@
       "chargeDamage": 3,
       "maneuver": 65,
       "speed": 47,
-      "hitPoints": 192
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12524,
+    "price": 11703,
     "weight": 420.0,
-    "tier": 8.16449,
+    "tier": 7.857399,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19540,7 +19540,7 @@
       "chargeDamage": 4,
       "maneuver": 67,
       "speed": 48,
-      "hitPoints": 195
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14917,
+    "price": 13943,
     "weight": 420.0,
-    "tier": 9.00760651,
+    "tier": 8.673087,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19561,7 +19561,7 @@
       "chargeDamage": 4,
       "maneuver": 69,
       "speed": 49,
-      "hitPoints": 198
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17218,
+    "price": 16107,
     "weight": 420.0,
-    "tier": 9.757032,
+    "tier": 9.401814,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19582,7 +19582,7 @@
       "chargeDamage": 5,
       "maneuver": 70,
       "speed": 50,
-      "hitPoints": 201
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19591,9 +19591,9 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16720,
+    "price": 15788,
     "weight": 450.0,
-    "tier": 9.599004,
+    "tier": 9.29752,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19603,7 +19603,7 @@
       "chargeDamage": 6,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 231
+      "hitPoints": 225
     },
     "weapons": []
   },
@@ -19612,9 +19612,9 @@
     "name": "Brabant Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19534,
+    "price": 18459,
     "weight": 450.0,
-    "tier": 10.4626055,
+    "tier": 10.1406078,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19624,7 +19624,7 @@
       "chargeDamage": 7,
       "maneuver": 84,
       "speed": 38,
-      "hitPoints": 234
+      "hitPoints": 228
     },
     "weapons": []
   },
@@ -19633,9 +19633,9 @@
     "name": "Comtois Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 21593,
+    "price": 20411,
     "weight": 450.0,
-    "tier": 11.0556536,
+    "tier": 10.7188635,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19645,7 +19645,7 @@
       "chargeDamage": 7,
       "maneuver": 84,
       "speed": 39,
-      "hitPoints": 237
+      "hitPoints": 231
     },
     "weapons": []
   },
@@ -19654,9 +19654,9 @@
     "name": "English Black Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23523,
+    "price": 22261,
     "weight": 450.0,
-    "tier": 11.586628,
+    "tier": 11.2420568,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19666,7 +19666,7 @@
       "chargeDamage": 8,
       "maneuver": 85,
       "speed": 39,
-      "hitPoints": 240
+      "hitPoints": 234
     },
     "weapons": []
   },
@@ -19675,9 +19675,9 @@
     "name": "Perechon Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 25935,
+    "price": 24551,
     "weight": 450.0,
-    "tier": 12.2206106,
+    "tier": 11.86062,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19687,7 +19687,7 @@
       "chargeDamage": 8,
       "maneuver": 85,
       "speed": 40,
-      "hitPoints": 243
+      "hitPoints": 237
     },
     "weapons": []
   },
@@ -19696,9 +19696,9 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7234,
+    "price": 6817,
     "weight": 450.0,
-    "tier": 5.955337,
+    "tier": 5.751242,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19708,7 +19708,7 @@
       "chargeDamage": 2,
       "maneuver": 74,
       "speed": 33,
-      "hitPoints": 216
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19717,9 +19717,9 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8948,
+    "price": 8438,
     "weight": 450.0,
-    "tier": 6.73897362,
+    "tier": 6.51444769,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19729,7 +19729,7 @@
       "chargeDamage": 4,
       "maneuver": 76,
       "speed": 34,
-      "hitPoints": 219
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19738,9 +19738,9 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10874,
+    "price": 10259,
     "weight": 450.0,
-    "tier": 7.53589,
+    "tier": 7.289525,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19750,7 +19750,7 @@
       "chargeDamage": 5,
       "maneuver": 78,
       "speed": 35,
-      "hitPoints": 222
+      "hitPoints": 216
     },
     "weapons": []
   },
@@ -19759,9 +19759,9 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12976,
+    "price": 12242,
     "weight": 450.0,
-    "tier": 8.329686,
+    "tier": 8.060016,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19771,7 +19771,7 @@
       "chargeDamage": 5,
       "maneuver": 80,
       "speed": 36,
-      "hitPoints": 225
+      "hitPoints": 219
     },
     "weapons": []
   },
@@ -19780,9 +19780,9 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15160,
+    "price": 14311,
     "weight": 450.0,
-    "tier": 9.089338,
+    "tier": 8.800743,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19792,7 +19792,7 @@
       "chargeDamage": 6,
       "maneuver": 81,
       "speed": 37,
-      "hitPoints": 228
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -19801,9 +19801,9 @@
     "name": "Berber Jennet",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17487,
+    "price": 16309,
     "weight": 300.0,
-    "tier": 9.841122,
+    "tier": 9.467125,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19813,7 +19813,7 @@
       "chargeDamage": 3,
       "maneuver": 84,
       "speed": 43,
-      "hitPoints": 195
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19822,9 +19822,9 @@
     "name": "Tchenarani Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20199,
+    "price": 18855,
     "weight": 300.0,
-    "tier": 10.6572971,
+    "tier": 10.2600384,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19834,7 +19834,7 @@
       "chargeDamage": 4,
       "maneuver": 85,
       "speed": 44,
-      "hitPoints": 198
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19843,9 +19843,9 @@
     "name": "Asil Purebred Arabian Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 22279,
+    "price": 20810,
     "weight": 300.0,
-    "tier": 11.2468557,
+    "tier": 10.833416,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19855,7 +19855,7 @@
       "chargeDamage": 4,
       "maneuver": 85,
       "speed": 45,
-      "hitPoints": 201
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19864,9 +19864,9 @@
     "name": "Marengo",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 25406,
+    "price": 23743,
     "weight": 300.0,
-    "tier": 12.084136,
+    "tier": 11.6458416,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19876,7 +19876,7 @@
       "chargeDamage": 4,
       "maneuver": 86,
       "speed": 46,
-      "hitPoints": 204
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -19885,9 +19885,9 @@
     "name": "Baucent",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 28210,
+    "price": 26390,
     "weight": 300.0,
-    "tier": 12.79213,
+    "tier": 12.3367434,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19897,7 +19897,7 @@
       "chargeDamage": 5,
       "maneuver": 86,
       "speed": 47,
-      "hitPoints": 207
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19906,9 +19906,9 @@
     "name": "Irish Hobby",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8301,
+    "price": 7722,
     "weight": 300.0,
-    "tier": 6.45270348,
+    "tier": 6.18717146,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19918,7 +19918,7 @@
       "chargeDamage": 2,
       "maneuver": 76,
       "speed": 39,
-      "hitPoints": 180
+      "hitPoints": 174
     },
     "weapons": []
   },
@@ -19927,9 +19927,9 @@
     "name": "Caspian Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9918,
+    "price": 9229,
     "weight": 300.0,
-    "tier": 7.150033,
+    "tier": 6.860152,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19939,7 +19939,7 @@
       "chargeDamage": 2,
       "maneuver": 78,
       "speed": 40,
-      "hitPoints": 183
+      "hitPoints": 177
     },
     "weapons": []
   },
@@ -19948,9 +19948,9 @@
     "name": "Marwari Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11829,
+    "price": 11009,
     "weight": 300.0,
-    "tier": 7.90500355,
+    "tier": 7.58922052,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19960,7 +19960,7 @@
       "chargeDamage": 2,
       "maneuver": 80,
       "speed": 41,
-      "hitPoints": 186
+      "hitPoints": 180
     },
     "weapons": []
   },
@@ -19969,9 +19969,9 @@
     "name": "Moroccan Barb",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14080,
+    "price": 13109,
     "weight": 300.0,
-    "tier": 8.72091,
+    "tier": 8.377619,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19981,7 +19981,7 @@
       "chargeDamage": 2,
       "maneuver": 82,
       "speed": 42,
-      "hitPoints": 189
+      "hitPoints": 183
     },
     "weapons": []
   },
@@ -19990,9 +19990,9 @@
     "name": "Morvandiau Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16311,
+    "price": 15200,
     "weight": 300.0,
-    "tier": 9.467891,
+    "tier": 9.102712,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20002,7 +20002,7 @@
       "chargeDamage": 3,
       "maneuver": 83,
       "speed": 43,
-      "hitPoints": 192
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -20011,9 +20011,9 @@
     "name": "Black Forest Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16621,
+    "price": 15553,
     "weight": 420.0,
-    "tier": 9.567626,
+    "tier": 9.220161,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20023,7 +20023,7 @@
       "chargeDamage": 3,
       "maneuver": 78,
       "speed": 44,
-      "hitPoints": 204
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -20032,9 +20032,9 @@
     "name": "Bidet Breton Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 19720,
+    "price": 18458,
     "weight": 420.0,
-    "tier": 10.5172977,
+    "tier": 10.1402969,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20044,7 +20044,7 @@
       "chargeDamage": 3,
       "maneuver": 80,
       "speed": 45,
-      "hitPoints": 207
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -20053,9 +20053,9 @@
     "name": "Dzhabe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21132,
+    "price": 19794,
     "weight": 420.0,
-    "tier": 10.9253778,
+    "tier": 10.5391073,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20065,7 +20065,7 @@
       "chargeDamage": 3,
       "maneuver": 81,
       "speed": 45,
-      "hitPoints": 210
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -20074,9 +20074,9 @@
     "name": "Karachay Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 24112,
+    "price": 22596,
     "weight": 420.0,
-    "tier": 11.7442932,
+    "tier": 11.3344841,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20086,7 +20086,7 @@
       "chargeDamage": 3,
       "maneuver": 82,
       "speed": 46,
-      "hitPoints": 213
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -20095,9 +20095,9 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 26494,
+    "price": 24844,
     "weight": 420.0,
-    "tier": 12.3632574,
+    "tier": 11.9375353,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20107,7 +20107,7 @@
       "chargeDamage": 3,
       "maneuver": 82,
       "speed": 47,
-      "hitPoints": 216
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -20158,9 +20158,9 @@
     "name": "Fell Pony",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 6350,
+    "price": 5931,
     "weight": 420.0,
-    "tier": 5.51556063,
+    "tier": 5.29648638,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20170,7 +20170,7 @@
       "chargeDamage": 2,
       "maneuver": 69,
       "speed": 38,
-      "hitPoints": 186
+      "hitPoints": 180
     },
     "weapons": []
   },
@@ -20179,9 +20179,9 @@
     "name": "Welsh Cob",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7840,
+    "price": 7322,
     "weight": 420.0,
-    "tier": 6.24222231,
+    "tier": 5.997667,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20191,7 +20191,7 @@
       "chargeDamage": 2,
       "maneuver": 70,
       "speed": 40,
-      "hitPoints": 189
+      "hitPoints": 183
     },
     "weapons": []
   },
@@ -20200,9 +20200,9 @@
     "name": "Sanhe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9511,
+    "price": 8887,
     "weight": 420.0,
-    "tier": 6.980195,
+    "tier": 6.71256733,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20212,7 +20212,7 @@
       "chargeDamage": 3,
       "maneuver": 72,
       "speed": 41,
-      "hitPoints": 192
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -20221,9 +20221,9 @@
     "name": "Megrelakaya Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11353,
+    "price": 10609,
     "weight": 420.0,
-    "tier": 7.722898,
+    "tier": 7.43069363,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20233,7 +20233,7 @@
       "chargeDamage": 3,
       "maneuver": 74,
       "speed": 42,
-      "hitPoints": 195
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -20242,9 +20242,9 @@
     "name": "East Anglis Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13525,
+    "price": 12642,
     "weight": 420.0,
-    "tier": 8.526216,
+    "tier": 8.20787048,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20254,7 +20254,7 @@
       "chargeDamage": 3,
       "maneuver": 76,
       "speed": 43,
-      "hitPoints": 198
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -20263,9 +20263,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15489,
+    "price": 14484,
     "weight": 420.0,
-    "tier": 9.198949,
+    "tier": 8.860133,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20275,7 +20275,7 @@
       "chargeDamage": 3,
       "maneuver": 77,
       "speed": 44,
-      "hitPoints": 201
+      "hitPoints": 195
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -6972,7 +6972,7 @@
   },
   {
     "id": "crpg_camel_10",
-    "name": "Seleucid Light Camel",
+    "name": "Tunisian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 15111,
@@ -6993,7 +6993,7 @@
   },
   {
     "id": "crpg_camel_11",
-    "name": "Seleucid Heavy Camel",
+    "name": "Tunisian Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 16338,
@@ -7014,7 +7014,7 @@
   },
   {
     "id": "crpg_camel_12",
-    "name": "Parthian Light Camel",
+    "name": "Parthian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 16902,
@@ -7035,7 +7035,7 @@
   },
   {
     "id": "crpg_camel_13",
-    "name": "Parthian Heavy Camel",
+    "name": "Parthian Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 18318,
@@ -7056,7 +7056,7 @@
   },
   {
     "id": "crpg_camel_14",
-    "name": "Achaemenian Light Camel",
+    "name": "Achaemenian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 20944,
@@ -7077,7 +7077,7 @@
   },
   {
     "id": "crpg_camel_15",
-    "name": "Achaemenian Heavy Camel",
+    "name": "Achaemenian Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 22634,
@@ -7161,7 +7161,7 @@
   },
   {
     "id": "crpg_camel_4",
-    "name": "Qedarite Camel",
+    "name": "Qedarite War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 7912,
@@ -7182,7 +7182,7 @@
   },
   {
     "id": "crpg_camel_5",
-    "name": "Palmyrene Camel",
+    "name": "Palmyrene War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 9486,
@@ -7203,7 +7203,7 @@
   },
   {
     "id": "crpg_camel_6",
-    "name": "Sargonid Light Camel",
+    "name": "Syrian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 10939,
@@ -7224,7 +7224,7 @@
   },
   {
     "id": "crpg_camel_7",
-    "name": "Sargonid Heavy Camel",
+    "name": "Syrian Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 11859,
@@ -7245,7 +7245,7 @@
   },
   {
     "id": "crpg_camel_8",
-    "name": "Nabatean Light Camel",
+    "name": "Nabatean Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 12268,
@@ -7266,7 +7266,7 @@
   },
   {
     "id": "crpg_camel_9",
-    "name": "Nabatean Heavy Camel",
+    "name": "Nabatean Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 13334,
@@ -19171,16 +19171,16 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17671,
+    "price": 18156,
     "weight": 450.0,
-    "tier": 9.898619,
+    "tier": 10.0481415,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 72,
       "speed": 44,
       "hitPoints": 227
@@ -19192,16 +19192,16 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20643,
+    "price": 21391,
     "weight": 450.0,
-    "tier": 10.7856979,
+    "tier": 10.9987364,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
+      "chargeDamage": 9,
       "maneuver": 73,
       "speed": 45,
       "hitPoints": 230
@@ -19213,16 +19213,16 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 22556,
+    "price": 23337,
     "weight": 450.0,
-    "tier": 11.3233137,
+    "tier": 11.5363531,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
+      "chargeDamage": 9,
       "maneuver": 73,
       "speed": 46,
       "hitPoints": 233
@@ -19234,16 +19234,16 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 26431,
+    "price": 27638,
     "weight": 450.0,
-    "tier": 12.3472843,
+    "tier": 12.6506109,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 9,
+      "chargeDamage": 10,
       "maneuver": 74,
       "speed": 47,
       "hitPoints": 236
@@ -19255,16 +19255,16 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 28786,
+    "price": 30044,
     "weight": 450.0,
-    "tier": 12.933217,
+    "tier": 13.2365427,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 9,
+      "chargeDamage": 10,
       "maneuver": 74,
       "speed": 48,
       "hitPoints": 239
@@ -19276,16 +19276,16 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7912,
+    "price": 8034,
     "weight": 450.0,
-    "tier": 6.275423,
+    "tier": 6.33151865,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 64,
       "speed": 40,
       "hitPoints": 212
@@ -19297,16 +19297,16 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9628,
+    "price": 9782,
     "weight": 450.0,
-    "tier": 7.029407,
+    "tier": 7.0936265,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 66,
       "speed": 41,
       "hitPoints": 215
@@ -19318,16 +19318,16 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11685,
+    "price": 11896,
     "weight": 450.0,
-    "tier": 7.850517,
+    "tier": 7.93043041,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 68,
       "speed": 42,
       "hitPoints": 218
@@ -19339,16 +19339,16 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14163,
+    "price": 14473,
     "weight": 450.0,
-    "tier": 8.749711,
+    "tier": 8.856582,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 6,
+      "chargeDamage": 7,
       "maneuver": 70,
       "speed": 43,
       "hitPoints": 221
@@ -19360,16 +19360,16 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16504,
+    "price": 16973,
     "weight": 450.0,
-    "tier": 9.530069,
+    "tier": 9.679592,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 71,
       "speed": 44,
       "hitPoints": 224

--- a/items.json
+++ b/items.json
@@ -6972,7 +6972,7 @@
   },
   {
     "id": "crpg_camel_10",
-    "name": "Seleucid Light War Camel",
+    "name": "Seleucid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 15111,
@@ -6993,7 +6993,7 @@
   },
   {
     "id": "crpg_camel_11",
-    "name": "Seleucid Heavy War Camel",
+    "name": "Seleucid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 16338,
@@ -7014,7 +7014,7 @@
   },
   {
     "id": "crpg_camel_12",
-    "name": "Parthian Light War Camel",
+    "name": "Parthian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 16902,
@@ -7035,7 +7035,7 @@
   },
   {
     "id": "crpg_camel_13",
-    "name": "Parthian Heavy War Camel",
+    "name": "Parthian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 18318,
@@ -7056,7 +7056,7 @@
   },
   {
     "id": "crpg_camel_14",
-    "name": "Achaemenian Light War Camel",
+    "name": "Achaemenian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 20944,
@@ -7077,7 +7077,7 @@
   },
   {
     "id": "crpg_camel_15",
-    "name": "Achaemenian Heavy War Camel",
+    "name": "Achaemenian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 22634,
@@ -7161,7 +7161,7 @@
   },
   {
     "id": "crpg_camel_4",
-    "name": "Qedarite War Camel",
+    "name": "Qedarite Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 7912,
@@ -7182,7 +7182,7 @@
   },
   {
     "id": "crpg_camel_5",
-    "name": "Palmyrene War Camel",
+    "name": "Palmyrene Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 9486,
@@ -7203,7 +7203,7 @@
   },
   {
     "id": "crpg_camel_6",
-    "name": "Sargonid Light War Camel",
+    "name": "Sargonid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 10939,
@@ -7224,7 +7224,7 @@
   },
   {
     "id": "crpg_camel_7",
-    "name": "Sargonid Heavy War Camel",
+    "name": "Sargonid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 11859,
@@ -7245,7 +7245,7 @@
   },
   {
     "id": "crpg_camel_8",
-    "name": "Nabatean Light War Camel",
+    "name": "Nabatean Light Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 12268,
@@ -7266,7 +7266,7 @@
   },
   {
     "id": "crpg_camel_9",
-    "name": "Nabatean Heavy War Camel",
+    "name": "Nabatean Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 13334,

--- a/items.json
+++ b/items.json
@@ -6975,9 +6975,9 @@
     "name": "Seleucid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 14276,
+    "price": 14413,
     "weight": 520.0,
-    "tier": 8.788731,
+    "tier": 8.835952,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6987,7 +6987,7 @@
       "chargeDamage": 4,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 229
+      "hitPoints": 230
     },
     "weapons": []
   },
@@ -6996,9 +6996,9 @@
     "name": "Seleucid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 15506,
+    "price": 15370,
     "weight": 520.0,
-    "tier": 9.204619,
+    "tier": 9.15946,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7008,7 +7008,7 @@
       "chargeDamage": 5,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 249
+      "hitPoints": 248
     },
     "weapons": []
   },
@@ -7017,9 +7017,9 @@
     "name": "Parthian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 15961,
+    "price": 16115,
     "weight": 520.0,
-    "tier": 9.354147,
+    "tier": 9.404481,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7029,7 +7029,7 @@
       "chargeDamage": 4,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 229
+      "hitPoints": 230
     },
     "weapons": []
   },
@@ -7038,9 +7038,9 @@
     "name": "Parthian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 17379,
+    "price": 17225,
     "weight": 520.0,
-    "tier": 9.807319,
+    "tier": 9.759111,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7050,7 +7050,7 @@
       "chargeDamage": 5,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 249
+      "hitPoints": 248
     },
     "weapons": []
   },
@@ -7080,9 +7080,9 @@
     "name": "Achaemenian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 21510,
+    "price": 21143,
     "weight": 520.0,
-    "tier": 11.0323381,
+    "tier": 10.9285612,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7092,7 +7092,7 @@
       "chargeDamage": 6,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 259
+      "hitPoints": 257
     },
     "weapons": []
   },
@@ -7101,9 +7101,9 @@
     "name": "Padisha",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 26155,
+    "price": 26380,
     "weight": 520.0,
-    "tier": 12.2769156,
+    "tier": 12.33442,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7113,7 +7113,7 @@
       "chargeDamage": 7,
       "maneuver": 86,
       "speed": 38,
-      "hitPoints": 259
+      "hitPoints": 260
     },
     "weapons": []
   },
@@ -7122,9 +7122,9 @@
     "name": "Pack Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 4514,
+    "price": 4601,
     "weight": 520.0,
-    "tier": 4.493249,
+    "tier": 4.546,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7134,7 +7134,7 @@
       "chargeDamage": 2,
       "maneuver": 72,
       "speed": 29,
-      "hitPoints": 210
+      "hitPoints": 212
     },
     "weapons": []
   },
@@ -7143,9 +7143,9 @@
     "name": "Pratihara Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 6576,
+    "price": 6515,
     "weight": 520.0,
-    "tier": 5.6307497,
+    "tier": 5.59981155,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7155,7 +7155,7 @@
       "chargeDamage": 2,
       "maneuver": 76,
       "speed": 30,
-      "hitPoints": 225
+      "hitPoints": 224
     },
     "weapons": []
   },
@@ -7185,9 +7185,9 @@
     "name": "Palmyrene Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 9486,
+    "price": 9572,
     "weight": 520.0,
-    "tier": 6.96950531,
+    "tier": 7.00575924,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7197,7 +7197,7 @@
       "chargeDamage": 4,
       "maneuver": 78,
       "speed": 32,
-      "hitPoints": 235
+      "hitPoints": 236
     },
     "weapons": []
   },
@@ -7206,9 +7206,9 @@
     "name": "Sargonid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 10323,
+    "price": 10526,
     "weight": 520.0,
-    "tier": 7.315475,
+    "tier": 7.39731646,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7218,7 +7218,7 @@
       "chargeDamage": 4,
       "maneuver": 80,
       "speed": 34,
-      "hitPoints": 219
+      "hitPoints": 221
     },
     "weapons": []
   },
@@ -7248,9 +7248,9 @@
     "name": "Nabatean Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 11571,
+    "price": 11801,
     "weight": 520.0,
-    "tier": 7.806819,
+    "tier": 7.894321,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7260,7 +7260,7 @@
       "chargeDamage": 4,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 219
+      "hitPoints": 221
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -7203,7 +7203,7 @@
   },
   {
     "id": "crpg_camel_6",
-    "name": "Syrian Light War Camel",
+    "name": "Sargonid Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 10939,
@@ -7224,7 +7224,7 @@
   },
   {
     "id": "crpg_camel_7",
-    "name": "Syrian Heavy War Camel",
+    "name": "Sargonid Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 11859,

--- a/items.json
+++ b/items.json
@@ -18961,9 +18961,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16833,
+    "price": 15722,
     "weight": 430.0,
-    "tier": 9.635215,
+    "tier": 9.275743,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18972,7 +18972,7 @@
       "bodyLength": 100,
       "chargeDamage": 6,
       "maneuver": 81,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 210
     },
     "weapons": []
@@ -18982,9 +18982,9 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19599,
+    "price": 18335,
     "weight": 430.0,
-    "tier": 10.4815845,
+    "tier": 10.1026392,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18993,7 +18993,7 @@
       "bodyLength": 100,
       "chargeDamage": 7,
       "maneuver": 82,
-      "speed": 42,
+      "speed": 41,
       "hitPoints": 213
     },
     "weapons": []
@@ -19003,9 +19003,9 @@
     "name": "Lusitano Pureblood Destrier",
     "culture": "Battania",
     "type": "Mount",
-    "price": 21576,
+    "price": 20207,
     "weight": 430.0,
-    "tier": 11.0509443,
+    "tier": 10.6597128,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19014,7 +19014,7 @@
       "bodyLength": 100,
       "chargeDamage": 7,
       "maneuver": 82,
-      "speed": 43,
+      "speed": 42,
       "hitPoints": 216
     },
     "weapons": []
@@ -19024,9 +19024,9 @@
     "name": "Bohemond",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 25142,
+    "price": 23587,
     "weight": 430.0,
-    "tier": 12.0155954,
+    "tier": 11.6037531,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19035,7 +19035,7 @@
       "bodyLength": 100,
       "chargeDamage": 8,
       "maneuver": 83,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 219
     },
     "weapons": []
@@ -19045,9 +19045,9 @@
     "name": "Llamrei",
     "culture": "Battania",
     "type": "Mount",
-    "price": 27585,
+    "price": 25905,
     "weight": 430.0,
-    "tier": 12.6374884,
+    "tier": 12.2127743,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19056,7 +19056,7 @@
       "bodyLength": 100,
       "chargeDamage": 8,
       "maneuver": 83,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 222
     },
     "weapons": []
@@ -19066,9 +19066,9 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7863,
+    "price": 7313,
     "weight": 450.0,
-    "tier": 6.25273466,
+    "tier": 5.99361658,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19077,7 +19077,7 @@
       "bodyLength": 105,
       "chargeDamage": 4,
       "maneuver": 73,
-      "speed": 37,
+      "speed": 36,
       "hitPoints": 195
     },
     "weapons": []
@@ -19087,9 +19087,9 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9396,
+    "price": 8746,
     "weight": 430.0,
-    "tier": 6.931665,
+    "tier": 6.65095043,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19098,7 +19098,7 @@
       "bodyLength": 105,
       "chargeDamage": 4,
       "maneuver": 75,
-      "speed": 38,
+      "speed": 37,
       "hitPoints": 198
     },
     "weapons": []
@@ -19108,9 +19108,9 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11376,
+    "price": 10603,
     "weight": 430.0,
-    "tier": 7.731916,
+    "tier": 7.42838,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19119,7 +19119,7 @@
       "bodyLength": 105,
       "chargeDamage": 5,
       "maneuver": 77,
-      "speed": 39,
+      "speed": 38,
       "hitPoints": 201
     },
     "weapons": []
@@ -19129,9 +19129,9 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13531,
+    "price": 12622,
     "weight": 430.0,
-    "tier": 8.528346,
+    "tier": 8.200723,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19140,7 +19140,7 @@
       "bodyLength": 100,
       "chargeDamage": 5,
       "maneuver": 79,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 204
     },
     "weapons": []
@@ -19150,9 +19150,9 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15746,
+    "price": 14711,
     "weight": 430.0,
-    "tier": 9.283607,
+    "tier": 8.937754,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19161,7 +19161,7 @@
       "bodyLength": 100,
       "chargeDamage": 6,
       "maneuver": 80,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 207
     },
     "weapons": []
@@ -19171,9 +19171,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16820,
+    "price": 15812,
     "weight": 450.0,
-    "tier": 9.631062,
+    "tier": 9.305339,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19182,7 +19182,7 @@
       "bodyLength": 105,
       "chargeDamage": 8,
       "maneuver": 72,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 219
     },
     "weapons": []
@@ -19192,9 +19192,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19848,
+    "price": 18693,
     "weight": 450.0,
-    "tier": 10.5548964,
+    "tier": 10.211257,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19203,7 +19203,7 @@
       "bodyLength": 105,
       "chargeDamage": 9,
       "maneuver": 73,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 222
     },
     "weapons": []
@@ -19213,9 +19213,9 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 21662,
+    "price": 20418,
     "weight": 450.0,
-    "tier": 11.0750465,
+    "tier": 10.7208557,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19224,7 +19224,7 @@
       "bodyLength": 105,
       "chargeDamage": 9,
       "maneuver": 73,
-      "speed": 46,
+      "speed": 45,
       "hitPoints": 225
     },
     "weapons": []
@@ -19234,9 +19234,9 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 25702,
+    "price": 24275,
     "weight": 450.0,
-    "tier": 12.1606607,
+    "tier": 11.7874956,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19245,7 +19245,7 @@
       "bodyLength": 105,
       "chargeDamage": 10,
       "maneuver": 74,
-      "speed": 47,
+      "speed": 46,
       "hitPoints": 228
     },
     "weapons": []
@@ -19255,9 +19255,9 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 27950,
+    "price": 26418,
     "weight": 450.0,
-    "tier": 12.7281122,
+    "tier": 12.3438768,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19266,7 +19266,7 @@
       "bodyLength": 105,
       "chargeDamage": 10,
       "maneuver": 74,
-      "speed": 48,
+      "speed": 47,
       "hitPoints": 231
     },
     "weapons": []
@@ -19276,9 +19276,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7414,
+    "price": 6936,
     "weight": 450.0,
-    "tier": 6.04196835,
+    "tier": 5.81050348,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19287,7 +19287,7 @@
       "bodyLength": 105,
       "chargeDamage": 4,
       "maneuver": 64,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 204
     },
     "weapons": []
@@ -19297,9 +19297,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9032,
+    "price": 8459,
     "weight": 450.0,
-    "tier": 6.775536,
+    "tier": 6.52374554,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19308,7 +19308,7 @@
       "bodyLength": 105,
       "chargeDamage": 5,
       "maneuver": 66,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 207
     },
     "weapons": []
@@ -19318,9 +19318,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10991,
+    "price": 10305,
     "weight": 450.0,
-    "tier": 7.581867,
+    "tier": 7.30855227,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19329,7 +19329,7 @@
       "bodyLength": 105,
       "chargeDamage": 6,
       "maneuver": 68,
-      "speed": 42,
+      "speed": 41,
       "hitPoints": 210
     },
     "weapons": []
@@ -19339,9 +19339,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13383,
+    "price": 12564,
     "weight": 450.0,
-    "tier": 8.475537,
+    "tier": 8.179463,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19350,7 +19350,7 @@
       "bodyLength": 105,
       "chargeDamage": 7,
       "maneuver": 70,
-      "speed": 43,
+      "speed": 42,
       "hitPoints": 213
     },
     "weapons": []
@@ -19360,9 +19360,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15715,
+    "price": 14778,
     "weight": 450.0,
-    "tier": 9.27346,
+    "tier": 8.96065,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19371,7 +19371,7 @@
       "bodyLength": 105,
       "chargeDamage": 8,
       "maneuver": 71,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 216
     },
     "weapons": []
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17353,
+    "price": 16119,
     "weight": 420.0,
-    "tier": 9.799385,
+    "tier": 9.405501,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19391,8 +19391,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 71,
-      "speed": 50,
+      "maneuver": 72,
+      "speed": 48,
       "hitPoints": 198
     },
     "weapons": []
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 19756,
+    "price": 18371,
     "weight": 420.0,
-    "tier": 10.52789,
+    "tier": 10.113595,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19412,8 +19412,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 72,
-      "speed": 51,
+      "maneuver": 73,
+      "speed": 49,
       "hitPoints": 201
     },
     "weapons": []
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21575,
+    "price": 20099,
     "weight": 420.0,
-    "tier": 11.0506887,
+    "tier": 10.6282539,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19433,8 +19433,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 72,
-      "speed": 52,
+      "maneuver": 73,
+      "speed": 50,
       "hitPoints": 204
     },
     "weapons": []
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 24818,
+    "price": 23154,
     "weight": 420.0,
-    "tier": 11.9307365,
+    "tier": 11.4869175,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19454,8 +19454,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 73,
-      "speed": 53,
+      "maneuver": 74,
+      "speed": 51,
       "hitPoints": 207
     },
     "weapons": []
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 27037,
+    "price": 25268,
     "weight": 420.0,
-    "tier": 12.5003471,
+    "tier": 12.0482607,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19475,8 +19475,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 73,
-      "speed": 54,
+      "maneuver": 74,
+      "speed": 52,
       "hitPoints": 210
     },
     "weapons": []
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8077,
+    "price": 7489,
     "weight": 420.0,
-    "tier": 6.351092,
+    "tier": 6.077647,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19496,8 +19496,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 63,
-      "speed": 46,
+      "maneuver": 64,
+      "speed": 44,
       "hitPoints": 183
     },
     "weapons": []
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9670,
+    "price": 8968,
     "weight": 420.0,
-    "tier": 7.047114,
+    "tier": 6.74791336,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19517,8 +19517,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 65,
-      "speed": 47,
+      "maneuver": 66,
+      "speed": 45,
       "hitPoints": 186
     },
     "weapons": []
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11703,
+    "price": 10861,
     "weight": 420.0,
-    "tier": 7.857399,
+    "tier": 7.530829,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19538,8 +19538,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 67,
-      "speed": 48,
+      "maneuver": 68,
+      "speed": 46,
       "hitPoints": 189
     },
     "weapons": []
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13943,
+    "price": 12943,
     "weight": 420.0,
-    "tier": 8.673087,
+    "tier": 8.317475,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19559,8 +19559,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 69,
-      "speed": 49,
+      "maneuver": 70,
+      "speed": 47,
       "hitPoints": 192
     },
     "weapons": []
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16107,
+    "price": 14975,
     "weight": 420.0,
-    "tier": 9.401814,
+    "tier": 9.027238,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19580,8 +19580,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 70,
-      "speed": 50,
+      "maneuver": 71,
+      "speed": 48,
       "hitPoints": 195
     },
     "weapons": []
@@ -19591,9 +19591,9 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17238,
+    "price": 16024,
     "weight": 450.0,
-    "tier": 9.763345,
+    "tier": 9.374831,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19602,7 +19602,7 @@
       "bodyLength": 105,
       "chargeDamage": 7,
       "maneuver": 82,
-      "speed": 38,
+      "speed": 37,
       "hitPoints": 228
     },
     "weapons": []
@@ -19612,9 +19612,9 @@
     "name": "Brabant Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20235,
+    "price": 18849,
     "weight": 450.0,
-    "tier": 10.6676989,
+    "tier": 10.2583418,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19623,7 +19623,7 @@
       "bodyLength": 105,
       "chargeDamage": 8,
       "maneuver": 83,
-      "speed": 39,
+      "speed": 38,
       "hitPoints": 231
     },
     "weapons": []
@@ -19633,9 +19633,9 @@
     "name": "Comtois Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 22308,
+    "price": 20806,
     "weight": 450.0,
-    "tier": 11.255044,
+    "tier": 10.8325243,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19644,7 +19644,7 @@
       "bodyLength": 105,
       "chargeDamage": 8,
       "maneuver": 83,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 234
     },
     "weapons": []
@@ -19654,9 +19654,9 @@
     "name": "English Black Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 24534,
+    "price": 22902,
     "weight": 450.0,
-    "tier": 11.8561363,
+    "tier": 11.4182129,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19665,7 +19665,7 @@
       "bodyLength": 105,
       "chargeDamage": 9,
       "maneuver": 84,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 237
     },
     "weapons": []
@@ -19675,9 +19675,9 @@
     "name": "Perechon Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 26972,
+    "price": 25207,
     "weight": 450.0,
-    "tier": 12.48401,
+    "tier": 12.0323639,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19686,7 +19686,7 @@
       "bodyLength": 105,
       "chargeDamage": 9,
       "maneuver": 84,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 240
     },
     "weapons": []
@@ -19696,9 +19696,9 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7842,
+    "price": 7247,
     "weight": 450.0,
-    "tier": 6.24311447,
+    "tier": 5.961785,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19707,7 +19707,7 @@
       "bodyLength": 105,
       "chargeDamage": 4,
       "maneuver": 74,
-      "speed": 34,
+      "speed": 33,
       "hitPoints": 213
     },
     "weapons": []
@@ -19717,9 +19717,9 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9547,
+    "price": 8837,
     "weight": 450.0,
-    "tier": 6.99526548,
+    "tier": 6.690727,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19728,7 +19728,7 @@
       "bodyLength": 105,
       "chargeDamage": 5,
       "maneuver": 76,
-      "speed": 35,
+      "speed": 34,
       "hitPoints": 216
     },
     "weapons": []
@@ -19738,9 +19738,9 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11609,
+    "price": 10764,
     "weight": 450.0,
-    "tier": 7.821442,
+    "tier": 7.492402,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19749,7 +19749,7 @@
       "bodyLength": 105,
       "chargeDamage": 6,
       "maneuver": 78,
-      "speed": 36,
+      "speed": 35,
       "hitPoints": 219
     },
     "weapons": []
@@ -19759,9 +19759,9 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13818,
+    "price": 12824,
     "weight": 450.0,
-    "tier": 8.629402,
+    "tier": 8.274528,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19770,7 +19770,7 @@
       "bodyLength": 105,
       "chargeDamage": 6,
       "maneuver": 80,
-      "speed": 37,
+      "speed": 36,
       "hitPoints": 222
     },
     "weapons": []
@@ -19780,9 +19780,9 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16182,
+    "price": 15048,
     "weight": 450.0,
-    "tier": 9.426086,
+    "tier": 9.051661,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19791,7 +19791,7 @@
       "bodyLength": 105,
       "chargeDamage": 7,
       "maneuver": 81,
-      "speed": 38,
+      "speed": 37,
       "hitPoints": 225
     },
     "weapons": []
@@ -19801,9 +19801,9 @@
     "name": "Berber Jennet",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16309,
+    "price": 15261,
     "weight": 300.0,
-    "tier": 9.467125,
+    "tier": 9.123065,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19812,7 +19812,7 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 84,
-      "speed": 43,
+      "speed": 42,
       "hitPoints": 189
     },
     "weapons": []
@@ -19822,9 +19822,9 @@
     "name": "Tchenarani Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18855,
+    "price": 17667,
     "weight": 300.0,
-    "tier": 10.2600384,
+    "tier": 9.897135,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19833,7 +19833,7 @@
       "bodyLength": 95,
       "chargeDamage": 4,
       "maneuver": 85,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 192
     },
     "weapons": []
@@ -19843,9 +19843,9 @@
     "name": "Asil Purebred Arabian Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20810,
+    "price": 19520,
     "weight": 300.0,
-    "tier": 10.833416,
+    "tier": 10.458271,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19854,7 +19854,7 @@
       "bodyLength": 95,
       "chargeDamage": 4,
       "maneuver": 85,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 195
     },
     "weapons": []
@@ -19864,9 +19864,9 @@
     "name": "Marengo",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23743,
+    "price": 22293,
     "weight": 300.0,
-    "tier": 11.6458416,
+    "tier": 11.2507267,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19875,7 +19875,7 @@
       "bodyLength": 95,
       "chargeDamage": 4,
       "maneuver": 86,
-      "speed": 46,
+      "speed": 45,
       "hitPoints": 198
     },
     "weapons": []
@@ -19885,9 +19885,9 @@
     "name": "Baucent",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 26390,
+    "price": 24810,
     "weight": 300.0,
-    "tier": 12.3367434,
+    "tier": 11.9287815,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19896,7 +19896,7 @@
       "bodyLength": 95,
       "chargeDamage": 5,
       "maneuver": 86,
-      "speed": 47,
+      "speed": 46,
       "hitPoints": 201
     },
     "weapons": []
@@ -19906,9 +19906,9 @@
     "name": "Irish Hobby",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7722,
+    "price": 7201,
     "weight": 300.0,
-    "tier": 6.18717146,
+    "tier": 5.93948174,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19917,7 +19917,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 76,
-      "speed": 39,
+      "speed": 38,
       "hitPoints": 174
     },
     "weapons": []
@@ -19927,9 +19927,9 @@
     "name": "Caspian Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9229,
+    "price": 8612,
     "weight": 300.0,
-    "tier": 6.860152,
+    "tier": 6.59189034,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19938,7 +19938,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 78,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 177
     },
     "weapons": []
@@ -19948,9 +19948,9 @@
     "name": "Marwari Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11009,
+    "price": 10282,
     "weight": 300.0,
-    "tier": 7.58922052,
+    "tier": 7.299211,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19959,7 +19959,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 80,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 180
     },
     "weapons": []
@@ -19969,9 +19969,9 @@
     "name": "Moroccan Barb",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13109,
+    "price": 12254,
     "weight": 300.0,
-    "tier": 8.377619,
+    "tier": 8.064646,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19980,7 +19980,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 82,
-      "speed": 42,
+      "speed": 41,
       "hitPoints": 183
     },
     "weapons": []
@@ -19990,9 +19990,9 @@
     "name": "Morvandiau Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15200,
+    "price": 14228,
     "weight": 300.0,
-    "tier": 9.102712,
+    "tier": 8.772116,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20001,7 +20001,7 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 83,
-      "speed": 43,
+      "speed": 42,
       "hitPoints": 186
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -19171,9 +19171,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15812,
+    "price": 16428,
     "weight": 450.0,
-    "tier": 9.305339,
+    "tier": 9.505461,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19181,7 +19181,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 72,
+      "maneuver": 73,
       "speed": 43,
       "hitPoints": 219
     },
@@ -19192,9 +19192,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18693,
+    "price": 19405,
     "weight": 450.0,
-    "tier": 10.211257,
+    "tier": 10.4243555,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19202,7 +19202,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 73,
+      "maneuver": 74,
       "speed": 44,
       "hitPoints": 222
     },
@@ -19213,9 +19213,9 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 20418,
+    "price": 21203,
     "weight": 450.0,
-    "tier": 10.7208557,
+    "tier": 10.9455223,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19223,7 +19223,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 73,
+      "maneuver": 74,
       "speed": 45,
       "hitPoints": 225
     },
@@ -19234,9 +19234,9 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 24275,
+    "price": 25183,
     "weight": 450.0,
-    "tier": 11.7874956,
+    "tier": 12.0262079,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19244,7 +19244,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 10,
-      "maneuver": 74,
+      "maneuver": 75,
       "speed": 46,
       "hitPoints": 228
     },
@@ -19255,9 +19255,9 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 26418,
+    "price": 27415,
     "weight": 450.0,
-    "tier": 12.3438768,
+    "tier": 12.5950489,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19265,7 +19265,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 10,
-      "maneuver": 74,
+      "maneuver": 75,
       "speed": 47,
       "hitPoints": 231
     },
@@ -19276,9 +19276,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 6936,
+    "price": 7234,
     "weight": 450.0,
-    "tier": 5.81050348,
+    "tier": 5.95558548,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19286,7 +19286,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 64,
+      "maneuver": 65,
       "speed": 39,
       "hitPoints": 204
     },
@@ -19297,9 +19297,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8459,
+    "price": 8814,
     "weight": 450.0,
-    "tier": 6.52374554,
+    "tier": 6.68071556,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19307,7 +19307,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 66,
+      "maneuver": 67,
       "speed": 40,
       "hitPoints": 207
     },
@@ -19318,9 +19318,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10305,
+    "price": 10728,
     "weight": 450.0,
-    "tier": 7.30855227,
+    "tier": 7.47807,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19328,7 +19328,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 68,
+      "maneuver": 69,
       "speed": 41,
       "hitPoints": 210
     },
@@ -19339,9 +19339,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12564,
+    "price": 13066,
     "weight": 450.0,
-    "tier": 8.179463,
+    "tier": 8.362206,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19349,7 +19349,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 70,
+      "maneuver": 71,
       "speed": 42,
       "hitPoints": 213
     },
@@ -19360,9 +19360,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14778,
+    "price": 15359,
     "weight": 450.0,
-    "tier": 8.96065,
+    "tier": 9.155558,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19370,7 +19370,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 71,
+      "maneuver": 72,
       "speed": 43,
       "hitPoints": 216
     },
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16119,
+    "price": 16660,
     "weight": 420.0,
-    "tier": 9.405501,
+    "tier": 9.580141,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19393,7 +19393,7 @@
       "chargeDamage": 5,
       "maneuver": 72,
       "speed": 48,
-      "hitPoints": 198
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18371,
+    "price": 18984,
     "weight": 420.0,
-    "tier": 10.113595,
+    "tier": 10.2989645,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19414,7 +19414,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 49,
-      "hitPoints": 201
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 20099,
+    "price": 20764,
     "weight": 420.0,
-    "tier": 10.6282539,
+    "tier": 10.820447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19435,7 +19435,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 50,
-      "hitPoints": 204
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23154,
+    "price": 23910,
     "weight": 420.0,
-    "tier": 11.4869175,
+    "tier": 11.690567,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19456,7 +19456,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 51,
-      "hitPoints": 207
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 25268,
+    "price": 26085,
     "weight": 420.0,
-    "tier": 12.0482607,
+    "tier": 12.2591181,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19477,7 +19477,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 52,
-      "hitPoints": 210
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7489,
+    "price": 7750,
     "weight": 420.0,
-    "tier": 6.077647,
+    "tier": 6.200236,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19498,7 +19498,7 @@
       "chargeDamage": 3,
       "maneuver": 64,
       "speed": 44,
-      "hitPoints": 183
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8968,
+    "price": 9280,
     "weight": 420.0,
-    "tier": 6.74791336,
+    "tier": 6.88217068,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19519,7 +19519,7 @@
       "chargeDamage": 3,
       "maneuver": 66,
       "speed": 45,
-      "hitPoints": 186
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10861,
+    "price": 11236,
     "weight": 420.0,
-    "tier": 7.530829,
+    "tier": 7.67751741,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19540,7 +19540,7 @@
       "chargeDamage": 4,
       "maneuver": 68,
       "speed": 46,
-      "hitPoints": 189
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12943,
+    "price": 13388,
     "weight": 420.0,
-    "tier": 8.317475,
+    "tier": 8.477386,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19561,7 +19561,7 @@
       "chargeDamage": 4,
       "maneuver": 70,
       "speed": 47,
-      "hitPoints": 192
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14975,
+    "price": 15484,
     "weight": 420.0,
-    "tier": 9.027238,
+    "tier": 9.197222,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19582,7 +19582,7 @@
       "chargeDamage": 5,
       "maneuver": 71,
       "speed": 48,
-      "hitPoints": 195
+      "hitPoints": 198
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -6971,13 +6971,160 @@
     "weapons": []
   },
   {
-    "id": "crpg_camel_5",
-    "name": "Pratihara Camel",
+    "id": "crpg_camel_10",
+    "name": "Tunisian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 5317,
+    "price": 15111,
     "weight": 520.0,
-    "tier": 4.961558,
+    "tier": 9.072852,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 4,
+      "maneuver": 82,
+      "speed": 36,
+      "hitPoints": 235
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_11",
+    "name": "Tunisian Heavy War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 16338,
+    "weight": 520.0,
+    "tier": 9.47656,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 5,
+      "maneuver": 81,
+      "speed": 35,
+      "hitPoints": 255
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_12",
+    "name": "Parthian Light War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 16902,
+    "weight": 520.0,
+    "tier": 9.656998,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 4,
+      "maneuver": 83,
+      "speed": 37,
+      "hitPoints": 235
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_13",
+    "name": "Parthian Heavy War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 18318,
+    "weight": 520.0,
+    "tier": 10.0976152,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 5,
+      "maneuver": 82,
+      "speed": 36,
+      "hitPoints": 255
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_14",
+    "name": "Achaemenian Light War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 20944,
+    "weight": 520.0,
+    "tier": 10.8717165,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 5,
+      "maneuver": 84,
+      "speed": 38,
+      "hitPoints": 245
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_15",
+    "name": "Achaemenian Heavy War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 22634,
+    "weight": 520.0,
+    "tier": 11.3449173,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 6,
+      "maneuver": 83,
+      "speed": 37,
+      "hitPoints": 265
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_16",
+    "name": "Padisha",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 27526,
+    "weight": 520.0,
+    "tier": 12.6228046,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 7,
+      "maneuver": 86,
+      "speed": 38,
+      "hitPoints": 265
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_2",
+    "name": "Pack Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 4514,
+    "weight": 520.0,
+    "tier": 4.493249,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6986,19 +7133,19 @@
       "bodyLength": 110,
       "chargeDamage": 2,
       "maneuver": 72,
-      "speed": 30,
-      "hitPoints": 218
+      "speed": 29,
+      "hitPoints": 210
     },
     "weapons": []
   },
   {
-    "id": "crpg_camel_6",
-    "name": "Qedarite War Camel",
+    "id": "crpg_camel_3",
+    "name": "Pratihara Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 7249,
+    "price": 6576,
     "weight": 520.0,
-    "tier": 5.962626,
+    "tier": 5.6307497,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7006,14 +7153,35 @@
     "mount": {
       "bodyLength": 110,
       "chargeDamage": 2,
-      "maneuver": 75,
+      "maneuver": 76,
+      "speed": 30,
+      "hitPoints": 225
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_4",
+    "name": "Qedarite War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 7912,
+    "weight": 520.0,
+    "tier": 6.275274,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 3,
+      "maneuver": 77,
       "speed": 31,
       "hitPoints": 230
     },
     "weapons": []
   },
   {
-    "id": "crpg_camel_7",
+    "id": "crpg_camel_5",
     "name": "Palmyrene War Camel",
     "culture": "Aserai",
     "type": "Mount",
@@ -7034,13 +7202,76 @@
     "weapons": []
   },
   {
-    "id": "crpg_camel_8",
-    "name": "Nabatean War Camel",
+    "id": "crpg_camel_6",
+    "name": "Syrian Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 11965,
+    "price": 10939,
     "weight": 520.0,
-    "tier": 7.9565,
+    "tier": 7.561577,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 4,
+      "maneuver": 80,
+      "speed": 34,
+      "hitPoints": 225
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_7",
+    "name": "Syrian Heavy War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 11859,
+    "weight": 520.0,
+    "tier": 7.916426,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 5,
+      "maneuver": 79,
+      "speed": 33,
+      "hitPoints": 245
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_8",
+    "name": "Nabatean Light War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 12268,
+    "weight": 520.0,
+    "tier": 8.06994152,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 4,
+      "maneuver": 81,
+      "speed": 35,
+      "hitPoints": 225
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_9",
+    "name": "Nabatean Heavy War Camel",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 13334,
+    "weight": 520.0,
+    "tier": 8.458322,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7049,29 +7280,8 @@
       "bodyLength": 110,
       "chargeDamage": 5,
       "maneuver": 80,
-      "speed": 33,
-      "hitPoints": 242
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_camel_9",
-    "name": "Parthian War Camel",
-    "culture": "Aserai",
-    "type": "Mount",
-    "price": 14819,
-    "weight": 520.0,
-    "tier": 8.974289,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 110,
-      "chargeDamage": 5,
-      "maneuver": 82,
       "speed": 34,
-      "hitPoints": 249
+      "hitPoints": 245
     },
     "weapons": []
   },
@@ -7114,48 +7324,6 @@
       "armArmor": 0,
       "legArmor": 0,
       "materialType": "Leather"
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_camel2_10",
-    "name": "Achaemenian War Camel",
-    "culture": "Aserai",
-    "type": "Mount",
-    "price": 17991,
-    "weight": 520.0,
-    "tier": 9.997325,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 110,
-      "chargeDamage": 5,
-      "maneuver": 84,
-      "speed": 35,
-      "hitPoints": 254
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_camel2_11",
-    "name": "Padisha",
-    "culture": "Aserai",
-    "type": "Mount",
-    "price": 21710,
-    "weight": 520.0,
-    "tier": 11.0886145,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 110,
-      "chargeDamage": 6,
-      "maneuver": 86,
-      "speed": 38,
-      "hitPoints": 240
     },
     "weapons": []
   },
@@ -18789,13 +18957,55 @@
     ]
   },
   {
+    "id": "crpg_mount_balanced_10",
+    "name": "Yunnan Destrier",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 17827,
+    "weight": 430.0,
+    "tier": 9.946721,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 5,
+      "maneuver": 81,
+      "speed": 41,
+      "hitPoints": 217
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_mount_balanced_11",
-    "name": "Bohemond",
+    "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 21416,
+    "price": 20663,
     "weight": 430.0,
-    "tier": 11.0058794,
+    "tier": 10.7913475,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 6,
+      "maneuver": 82,
+      "speed": 42,
+      "hitPoints": 220
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_balanced_12",
+    "name": "Lusitano Pureblood Destrier",
+    "culture": "Battania",
+    "type": "Mount",
+    "price": 22756,
+    "weight": 430.0,
+    "tier": 11.3782444,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18805,18 +19015,18 @@
       "chargeDamage": 6,
       "maneuver": 82,
       "speed": 43,
-      "hitPoints": 217
+      "hitPoints": 223
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount_balanced_12",
-    "name": "Llamrei",
-    "culture": "Battania",
+    "id": "crpg_mount_balanced_13",
+    "name": "Bohemond",
+    "culture": "Vlandia",
     "type": "Mount",
-    "price": 24821,
+    "price": 26352,
     "weight": 430.0,
-    "tier": 11.9317226,
+    "tier": 12.3272352,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18826,70 +19036,91 @@
       "chargeDamage": 7,
       "maneuver": 83,
       "speed": 44,
-      "hitPoints": 220
+      "hitPoints": 226
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_balanced_14",
+    "name": "Llamrei",
+    "culture": "Battania",
+    "type": "Mount",
+    "price": 28927,
+    "weight": 430.0,
+    "tier": 12.96768,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 7,
+      "maneuver": 83,
+      "speed": 45,
+      "hitPoints": 229
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_balanced_5",
-    "name": "Murgese Rouncey",
+    "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 5384,
+    "price": 8342,
     "weight": 450.0,
-    "tier": 4.998832,
+    "tier": 6.47115564,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 1,
-      "maneuver": 66,
-      "speed": 40,
-      "hitPoints": 172
+      "chargeDamage": 3,
+      "maneuver": 73,
+      "speed": 37,
+      "hitPoints": 202
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_balanced_6",
-    "name": "Holsteiner Rouncey",
+    "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7184,
+    "price": 9982,
     "weight": 430.0,
-    "tier": 5.931493,
+    "tier": 7.1762886,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 1,
-      "maneuver": 70,
-      "speed": 41,
-      "hitPoints": 177
+      "chargeDamage": 3,
+      "maneuver": 75,
+      "speed": 38,
+      "hitPoints": 205
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_balanced_7",
-    "name": "Perechon Destrier",
+    "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9904,
+    "price": 12071,
     "weight": 430.0,
-    "tier": 7.144061,
+    "tier": 7.996349,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
-      "maneuver": 71,
-      "speed": 43,
-      "hitPoints": 181
+      "chargeDamage": 4,
+      "maneuver": 77,
+      "speed": 39,
+      "hitPoints": 208
     },
     "weapons": []
   },
@@ -18898,19 +19129,19 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12061,
+    "price": 14374,
     "weight": 430.0,
-    "tier": 7.992573,
+    "tier": 8.822511,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 2,
-      "maneuver": 74,
-      "speed": 44,
-      "hitPoints": 190
+      "chargeDamage": 4,
+      "maneuver": 79,
+      "speed": 40,
+      "hitPoints": 211
     },
     "weapons": []
   },
@@ -18919,30 +19150,30 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14854,
+    "price": 16678,
     "weight": 430.0,
-    "tier": 8.986279,
+    "tier": 9.585763,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 3,
-      "maneuver": 76,
-      "speed": 45,
-      "hitPoints": 195
+      "chargeDamage": 5,
+      "maneuver": 80,
+      "speed": 41,
+      "hitPoints": 214
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount_charger_11",
-    "name": "Lionheart",
-    "culture": "Vlandia",
+    "id": "crpg_mount_charger_10",
+    "name": "Desert Norman Charger",
+    "culture": "Khuzait",
     "type": "Mount",
-    "price": 22051,
+    "price": 17671,
     "weight": 450.0,
-    "tier": 11.1837521,
+    "tier": 9.898619,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18950,20 +19181,20 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 75,
-      "speed": 47,
-      "hitPoints": 219
+      "maneuver": 72,
+      "speed": 44,
+      "hitPoints": 227
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount_charger_12",
-    "name": "Bucephalus",
-    "culture": "Empire",
+    "id": "crpg_mount_charger_11",
+    "name": "Andravida Charger",
+    "culture": "Vlandia",
     "type": "Mount",
-    "price": 24671,
+    "price": 20643,
     "weight": 450.0,
-    "tier": 11.8923073,
+    "tier": 10.7856979,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18971,9 +19202,72 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 75,
+      "maneuver": 73,
+      "speed": 45,
+      "hitPoints": 230
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_charger_12",
+    "name": "Neapolitan Charger",
+    "culture": "Empire",
+    "type": "Mount",
+    "price": 22556,
+    "weight": 450.0,
+    "tier": 11.3233137,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 8,
+      "maneuver": 73,
+      "speed": 46,
+      "hitPoints": 233
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_charger_13",
+    "name": "Lionheart",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 26431,
+    "weight": 450.0,
+    "tier": 12.3472843,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 9,
+      "maneuver": 74,
+      "speed": 47,
+      "hitPoints": 236
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_charger_14",
+    "name": "Bucephalus",
+    "culture": "Empire",
+    "type": "Mount",
+    "price": 28786,
+    "weight": 450.0,
+    "tier": 12.933217,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 9,
+      "maneuver": 74,
       "speed": 48,
-      "hitPoints": 222
+      "hitPoints": 239
     },
     "weapons": []
   },
@@ -18982,19 +19276,19 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 5277,
+    "price": 7912,
     "weight": 450.0,
-    "tier": 4.93924952,
+    "tier": 6.275423,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
-      "maneuver": 61,
-      "speed": 38,
-      "hitPoints": 188
+      "chargeDamage": 3,
+      "maneuver": 64,
+      "speed": 40,
+      "hitPoints": 212
     },
     "weapons": []
   },
@@ -19003,9 +19297,51 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7266,
+    "price": 9628,
     "weight": 450.0,
-    "tier": 5.97086143,
+    "tier": 7.029407,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 4,
+      "maneuver": 66,
+      "speed": 41,
+      "hitPoints": 215
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_charger_7",
+    "name": "Shire Charger",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 11685,
+    "weight": 450.0,
+    "tier": 7.850517,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 5,
+      "maneuver": 68,
+      "speed": 42,
+      "hitPoints": 218
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_charger_8",
+    "name": "Ardennes Charger",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 14163,
+    "weight": 450.0,
+    "tier": 8.749711,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19013,51 +19349,9 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 64,
-      "speed": 40,
-      "hitPoints": 198
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount_charger_7",
-    "name": "Ardennais Charger",
-    "culture": "Khuzait",
-    "type": "Mount",
-    "price": 9469,
-    "weight": 450.0,
-    "tier": 6.962321,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 105,
-      "chargeDamage": 7,
-      "maneuver": 66,
-      "speed": 41,
-      "hitPoints": 207
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount_charger_8",
-    "name": "Shire Charger",
-    "culture": "Khuzait",
-    "type": "Mount",
-    "price": 12113,
-    "weight": 450.0,
-    "tier": 8.012118,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 105,
-      "chargeDamage": 8,
-      "maneuver": 68,
-      "speed": 42,
-      "hitPoints": 214
+      "maneuver": 70,
+      "speed": 43,
+      "hitPoints": 221
     },
     "weapons": []
   },
@@ -19066,30 +19360,72 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14771,
+    "price": 16504,
     "weight": 450.0,
-    "tier": 8.958275,
+    "tier": 9.530069,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
-      "maneuver": 70,
-      "speed": 43,
-      "hitPoints": 220
+      "chargeDamage": 7,
+      "maneuver": 71,
+      "speed": 44,
+      "hitPoints": 224
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_fast_10",
+    "name": "Ahalteke Courser",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 18160,
+    "weight": 420.0,
+    "tier": 10.0493755,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 4,
+      "maneuver": 73,
+      "speed": 49,
+      "hitPoints": 201
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_fast_11",
-    "name": "Hengeron",
+    "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21894,
+    "price": 20690,
     "weight": 420.0,
-    "tier": 11.1399012,
+    "tier": 10.7990713,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 4,
+      "maneuver": 74,
+      "speed": 50,
+      "hitPoints": 204
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_fast_12",
+    "name": "Darashouri Courser",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 22627,
+    "weight": 420.0,
+    "tier": 11.3427849,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19099,18 +19435,18 @@
       "chargeDamage": 4,
       "maneuver": 74,
       "speed": 51,
-      "hitPoints": 204
+      "hitPoints": 207
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount_fast_12",
-    "name": "Shadowfax",
+    "id": "crpg_mount_fast_13",
+    "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 25142,
+    "price": 25972,
     "weight": 420.0,
-    "tier": 12.0154247,
+    "tier": 12.2302046,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19120,7 +19456,28 @@
       "chargeDamage": 5,
       "maneuver": 75,
       "speed": 52,
-      "hitPoints": 207
+      "hitPoints": 210
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_fast_14",
+    "name": "Shadowfax",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 28333,
+    "weight": 420.0,
+    "tier": 12.822403,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 5,
+      "maneuver": 75,
+      "speed": 53,
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19129,19 +19486,19 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 5551,
+    "price": 8476,
     "weight": 420.0,
-    "tier": 5.091233,
+    "tier": 6.531326,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 1,
-      "maneuver": 58,
-      "speed": 48,
-      "hitPoints": 164
+      "chargeDamage": 2,
+      "maneuver": 65,
+      "speed": 45,
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -19150,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7351,
+    "price": 10150,
     "weight": 420.0,
-    "tier": 6.01183653,
+    "tier": 7.245394,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19160,9 +19517,9 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 60,
-      "speed": 50,
-      "hitPoints": 169
+      "maneuver": 67,
+      "speed": 46,
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19171,19 +19528,19 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9780,
+    "price": 12272,
     "weight": 420.0,
-    "tier": 7.092777,
+    "tier": 8.071199,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 2,
-      "maneuver": 62,
-      "speed": 52,
-      "hitPoints": 176
+      "chargeDamage": 3,
+      "maneuver": 69,
+      "speed": 47,
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19192,30 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12000,
+    "price": 14620,
     "weight": 420.0,
-    "tier": 7.969482,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 100,
-      "chargeDamage": 2,
-      "maneuver": 64,
-      "speed": 53,
-      "hitPoints": 181
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount_fast_9",
-    "name": "Ahalteke Courser",
-    "culture": "Neutral",
-    "type": "Mount",
-    "price": 14838,
-    "weight": 420.0,
-    "tier": 8.98094749,
+    "tier": 8.906923,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19223,20 +19559,272 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 66,
-      "speed": 54,
-      "hitPoints": 186
+      "maneuver": 71,
+      "speed": 48,
+      "hitPoints": 195
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_fast_9",
+    "name": "Einsiedler Courser",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 16872,
+    "weight": 420.0,
+    "tier": 9.647507,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 4,
+      "maneuver": 72,
+      "speed": 49,
+      "hitPoints": 198
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_10",
+    "name": "Barthais Great Horse",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 16720,
+    "weight": 450.0,
+    "tier": 9.599004,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 6,
+      "maneuver": 83,
+      "speed": 37,
+      "hitPoints": 231
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_11",
+    "name": "Brabant Great Horse",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 19534,
+    "weight": 450.0,
+    "tier": 10.4626055,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 7,
+      "maneuver": 84,
+      "speed": 38,
+      "hitPoints": 234
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_12",
+    "name": "Comtois Great Horse",
+    "culture": "Empire",
+    "type": "Mount",
+    "price": 21593,
+    "weight": 450.0,
+    "tier": 11.0556536,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 7,
+      "maneuver": 84,
+      "speed": 39,
+      "hitPoints": 237
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_13",
+    "name": "English Black Great Horse",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 23523,
+    "weight": 450.0,
+    "tier": 11.586628,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 8,
+      "maneuver": 85,
+      "speed": 39,
+      "hitPoints": 240
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_14",
+    "name": "Perechon Great Horse",
+    "culture": "Empire",
+    "type": "Mount",
+    "price": 25935,
+    "weight": 450.0,
+    "tier": 12.2206106,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 8,
+      "maneuver": 85,
+      "speed": 40,
+      "hitPoints": 243
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_5",
+    "name": "Suffolk Punch Draught",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 7234,
+    "weight": 450.0,
+    "tier": 5.955337,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 2,
+      "maneuver": 74,
+      "speed": 33,
+      "hitPoints": 216
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_6",
+    "name": "Boulonnais Great Horse",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 8948,
+    "weight": 450.0,
+    "tier": 6.73897362,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 4,
+      "maneuver": 76,
+      "speed": 34,
+      "hitPoints": 219
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_7",
+    "name": "Galloway Great Horse",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 10874,
+    "weight": 450.0,
+    "tier": 7.53589,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 5,
+      "maneuver": 78,
+      "speed": 35,
+      "hitPoints": 222
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_8",
+    "name": "Poitevin Great Horse",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 12976,
+    "weight": 450.0,
+    "tier": 8.329686,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 5,
+      "maneuver": 80,
+      "speed": 36,
+      "hitPoints": 225
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_greathorse_9",
+    "name": "Oberlander Great Horse",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 15160,
+    "weight": 450.0,
+    "tier": 9.089338,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 6,
+      "maneuver": 81,
+      "speed": 37,
+      "hitPoints": 228
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_maneuverable_10",
+    "name": "Berber Jennet",
+    "culture": "Khuzait",
+    "type": "Mount",
+    "price": 16359,
+    "weight": 300.0,
+    "tier": 9.483243,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 95,
+      "chargeDamage": 3,
+      "maneuver": 84,
+      "speed": 42,
+      "hitPoints": 195
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_maneuverable_11",
-    "name": "Marengo",
+    "name": "Tchenarani Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 22159,
+    "price": 18921,
     "weight": 300.0,
-    "tier": 11.2135954,
+    "tier": 10.2800465,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19245,19 +19833,61 @@
       "bodyLength": 95,
       "chargeDamage": 4,
       "maneuver": 85,
-      "speed": 46,
-      "hitPoints": 195
+      "speed": 43,
+      "hitPoints": 198
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_maneuverable_12",
+    "name": "Asil Purebred Arabian Palfrey",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 20892,
+    "weight": 300.0,
+    "tier": 10.8571081,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 95,
+      "chargeDamage": 4,
+      "maneuver": 85,
+      "speed": 44,
+      "hitPoints": 201
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_maneuverable_13",
+    "name": "Marengo",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 23848,
+    "weight": 300.0,
+    "tier": 11.6738739,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 95,
+      "chargeDamage": 4,
+      "maneuver": 86,
+      "speed": 45,
+      "hitPoints": 204
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_maneuverable_14",
     "name": "Baucent",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23983,
+    "price": 26516,
     "weight": 300.0,
-    "tier": 11.7100611,
+    "tier": 12.3687677,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19267,7 +19897,7 @@
       "chargeDamage": 5,
       "maneuver": 86,
       "speed": 46,
-      "hitPoints": 198
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19276,9 +19906,9 @@
     "name": "Irish Hobby",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 5618,
+    "price": 7737,
     "weight": 300.0,
-    "tier": 5.128017,
+    "tier": 6.194204,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19286,9 +19916,9 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 74,
+      "maneuver": 76,
       "speed": 38,
-      "hitPoints": 160
+      "hitPoints": 180
     },
     "weapons": []
   },
@@ -19297,9 +19927,9 @@
     "name": "Caspian Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7247,
+    "price": 9252,
     "weight": 300.0,
-    "tier": 5.96184874,
+    "tier": 6.870263,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19307,20 +19937,20 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 77,
+      "maneuver": 78,
       "speed": 39,
-      "hitPoints": 166
+      "hitPoints": 183
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_maneuverable_7",
-    "name": "Mongolian Palfrey",
+    "name": "Marwari Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9867,
+    "price": 11044,
     "weight": 300.0,
-    "tier": 7.1288147,
+    "tier": 7.60276127,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19328,41 +19958,41 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 79,
-      "speed": 41,
-      "hitPoints": 174
+      "maneuver": 80,
+      "speed": 40,
+      "hitPoints": 186
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_maneuverable_8",
-    "name": "Marwari Palfrey",
+    "name": "Moroccan Barb",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12192,
+    "price": 13157,
     "weight": 300.0,
-    "tier": 8.04167,
+    "tier": 8.394953,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 95,
-      "chargeDamage": 3,
-      "maneuver": 81,
-      "speed": 42,
-      "hitPoints": 179
+      "chargeDamage": 2,
+      "maneuver": 82,
+      "speed": 41,
+      "hitPoints": 189
     },
     "weapons": []
   },
   {
     "id": "crpg_mount_maneuverable_9",
-    "name": "Berber Jennet",
+    "name": "Morvandiau Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14840,
+    "price": 15263,
     "weight": 300.0,
-    "tier": 8.981658,
+    "tier": 9.123802,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19371,19 +20001,19 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 83,
-      "speed": 43,
-      "hitPoints": 184
+      "speed": 42,
+      "hitPoints": 192
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount2_balanced_10",
-    "name": "Parthian Destrier",
-    "culture": "Khuzait",
+    "id": "crpg_mount_rouncey_10",
+    "name": "Black Forest Rouncey",
+    "culture": "Neutral",
     "type": "Mount",
-    "price": 17838,
-    "weight": 430.0,
-    "tier": 9.950334,
+    "price": 16621,
+    "weight": 420.0,
+    "tier": 9.567626,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19392,40 +20022,19 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 78,
-      "speed": 46,
-      "hitPoints": 199
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount2_charger_10",
-    "name": "Neapolitan Charger",
-    "culture": "Khuzait",
-    "type": "Mount",
-    "price": 17816,
-    "weight": 450.0,
-    "tier": 9.943507,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 105,
-      "chargeDamage": 8,
-      "maneuver": 72,
       "speed": 44,
-      "hitPoints": 225
+      "hitPoints": 204
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount2_fast_10",
-    "name": "Lusitano Pureblood Courser",
+    "id": "crpg_mount_rouncey_11",
+    "name": "Bidet Breton Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17877,
+    "price": 19720,
     "weight": 420.0,
-    "tier": 9.962206,
+    "tier": 10.5172977,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19433,30 +20042,240 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 68,
-      "speed": 55,
-      "hitPoints": 190
+      "maneuver": 80,
+      "speed": 45,
+      "hitPoints": 207
     },
     "weapons": []
   },
   {
-    "id": "crpg_mount2_maneuverable_10",
-    "name": "Arabian Palfrey",
-    "culture": "Khuzait",
+    "id": "crpg_mount_rouncey_12",
+    "name": "Dzhabe Rouncey",
+    "culture": "Neutral",
     "type": "Mount",
-    "price": 17990,
-    "weight": 300.0,
-    "tier": 9.996982,
+    "price": 21132,
+    "weight": 420.0,
+    "tier": 10.9253778,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
-      "bodyLength": 95,
-      "chargeDamage": 4,
-      "maneuver": 85,
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 81,
+      "speed": 45,
+      "hitPoints": 210
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_13",
+    "name": "Karachay Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 24112,
+    "weight": 420.0,
+    "tier": 11.7442932,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 82,
+      "speed": 46,
+      "hitPoints": 213
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_14",
+    "name": "Unmol Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 26494,
+    "weight": 420.0,
+    "tier": 12.3632574,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 82,
+      "speed": 47,
+      "hitPoints": 216
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_2",
+    "name": "Sumpter Horse",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 2682,
+    "weight": 420.0,
+    "tier": 3.24377155,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 1,
+      "maneuver": 56,
+      "speed": 32,
+      "hitPoints": 200
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_3",
+    "name": "Raymond Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 3330,
+    "weight": 420.0,
+    "tier": 3.721898,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 1,
+      "maneuver": 60,
+      "speed": 34,
+      "hitPoints": 189
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_4",
+    "name": "Fell Pony",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 6350,
+    "weight": 420.0,
+    "tier": 5.51556063,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 2,
+      "maneuver": 69,
+      "speed": 38,
+      "hitPoints": 186
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_5",
+    "name": "Welsh Cob",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 7840,
+    "weight": 420.0,
+    "tier": 6.24222231,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 2,
+      "maneuver": 70,
+      "speed": 40,
+      "hitPoints": 189
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_6",
+    "name": "Sanhe Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 9511,
+    "weight": 420.0,
+    "tier": 6.980195,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 72,
+      "speed": 41,
+      "hitPoints": 192
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_7",
+    "name": "Megrelakaya Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 11353,
+    "weight": 420.0,
+    "tier": 7.722898,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 74,
+      "speed": 42,
+      "hitPoints": 195
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_8",
+    "name": "East Anglis Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 13525,
+    "weight": 420.0,
+    "tier": 8.526216,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 76,
+      "speed": 43,
+      "hitPoints": 198
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_9",
+    "name": "Anadolu Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 15489,
+    "weight": 420.0,
+    "tier": 9.198949,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 3,
+      "maneuver": 77,
       "speed": 44,
-      "hitPoints": 188
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19500,6 +20319,48 @@
         "swingSpeed": 125
       }
     ]
+  },
+  {
+    "id": "crpg_mule",
+    "name": "Mule",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 2440,
+    "weight": 300.0,
+    "tier": 3.05089855,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 92,
+      "chargeDamage": 0,
+      "maneuver": 58,
+      "speed": 30,
+      "hitPoints": 200
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mule_2",
+    "name": "Chadz",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 6643,
+    "weight": 300.0,
+    "tier": 5.664498,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 92,
+      "chargeDamage": 1,
+      "maneuver": 60,
+      "speed": 33,
+      "hitPoints": 275
+    },
+    "weapons": []
   },
   {
     "id": "crpg_mule_load_a",
@@ -19561,48 +20422,6 @@
       "armArmor": 0,
       "legArmor": 0,
       "materialType": "Cloth"
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mule2_1",
-    "name": "Mule",
-    "culture": "Neutral",
-    "type": "Mount",
-    "price": 2440,
-    "weight": 300.0,
-    "tier": 3.05089855,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 92,
-      "chargeDamage": 0,
-      "maneuver": 58,
-      "speed": 30,
-      "hitPoints": 200
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mule2_2",
-    "name": "Chadz",
-    "culture": "Neutral",
-    "type": "Mount",
-    "price": 6643,
-    "weight": 300.0,
-    "tier": 5.664498,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 92,
-      "chargeDamage": 1,
-      "maneuver": 60,
-      "speed": 33,
-      "hitPoints": 275
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -20284,9 +20284,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12916,
+    "price": 13752,
     "weight": 420.0,
-    "tier": 8.307658,
+    "tier": 8.60612,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20295,7 +20295,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 74,
-      "speed": 44,
+      "speed": 45,
       "hitPoints": 195
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -7098,6 +7098,27 @@
   },
   {
     "id": "crpg_camel_16",
+    "name": "Safinat al-Barr",
+    "culture": "Aserai",
+    "type": "Mount",
+    "price": 23251,
+    "weight": 520.0,
+    "tier": 11.5130272,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 110,
+      "chargeDamage": 7,
+      "maneuver": 85,
+      "speed": 37,
+      "hitPoints": 258
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_camel_17",
     "name": "Padisha",
     "culture": "Aserai",
     "type": "Mount",

--- a/items.json
+++ b/items.json
@@ -20011,9 +20011,9 @@
     "name": "Black Forest Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15553,
+    "price": 14579,
     "weight": 420.0,
-    "tier": 9.220161,
+    "tier": 8.892787,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20022,7 +20022,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 78,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 198
     },
     "weapons": []
@@ -20032,9 +20032,9 @@
     "name": "Bidet Breton Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18458,
+    "price": 17316,
     "weight": 420.0,
-    "tier": 10.1402969,
+    "tier": 9.78765,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20043,7 +20043,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 80,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 201
     },
     "weapons": []
@@ -20053,9 +20053,9 @@
     "name": "Dzhabe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 19794,
+    "price": 18564,
     "weight": 420.0,
-    "tier": 10.5391073,
+    "tier": 10.1723757,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20064,7 +20064,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 81,
-      "speed": 45,
+      "speed": 44,
       "hitPoints": 204
     },
     "weapons": []
@@ -20074,9 +20074,9 @@
     "name": "Karachay Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 22596,
+    "price": 21212,
     "weight": 420.0,
-    "tier": 11.3344841,
+    "tier": 10.94819,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20085,7 +20085,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 82,
-      "speed": 46,
+      "speed": 45,
       "hitPoints": 207
     },
     "weapons": []
@@ -20095,9 +20095,9 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 24844,
+    "price": 23347,
     "weight": 420.0,
-    "tier": 11.9375353,
+    "tier": 11.5390072,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20106,7 +20106,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 82,
-      "speed": 47,
+      "speed": 46,
       "hitPoints": 210
     },
     "weapons": []
@@ -20179,9 +20179,9 @@
     "name": "Welsh Cob",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7322,
+    "price": 6842,
     "weight": 420.0,
-    "tier": 5.997667,
+    "tier": 5.7636447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20190,7 +20190,7 @@
       "bodyLength": 100,
       "chargeDamage": 2,
       "maneuver": 70,
-      "speed": 40,
+      "speed": 39,
       "hitPoints": 183
     },
     "weapons": []
@@ -20200,9 +20200,9 @@
     "name": "Sanhe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8887,
+    "price": 8314,
     "weight": 420.0,
-    "tier": 6.71256733,
+    "tier": 6.458555,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20211,7 +20211,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 72,
-      "speed": 41,
+      "speed": 40,
       "hitPoints": 186
     },
     "weapons": []
@@ -20221,9 +20221,9 @@
     "name": "Megrelakaya Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10609,
+    "price": 9931,
     "weight": 420.0,
-    "tier": 7.43069363,
+    "tier": 7.155524,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20232,7 +20232,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 74,
-      "speed": 42,
+      "speed": 41,
       "hitPoints": 189
     },
     "weapons": []
@@ -20242,9 +20242,9 @@
     "name": "East Anglis Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12642,
+    "price": 11843,
     "weight": 420.0,
-    "tier": 8.20787048,
+    "tier": 7.9103384,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20253,7 +20253,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 76,
-      "speed": 43,
+      "speed": 42,
       "hitPoints": 192
     },
     "weapons": []
@@ -20263,9 +20263,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14484,
+    "price": 13580,
     "weight": 420.0,
-    "tier": 8.860133,
+    "tier": 8.54576,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20274,7 +20274,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 77,
-      "speed": 44,
+      "speed": 43,
       "hitPoints": 195
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -6972,7 +6972,7 @@
   },
   {
     "id": "crpg_camel_10",
-    "name": "Tunisian Light War Camel",
+    "name": "Seleucid Light War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 15111,
@@ -6993,7 +6993,7 @@
   },
   {
     "id": "crpg_camel_11",
-    "name": "Tunisian Heavy War Camel",
+    "name": "Seleucid Heavy War Camel",
     "culture": "Aserai",
     "type": "Mount",
     "price": 16338,

--- a/items.json
+++ b/items.json
@@ -19696,9 +19696,9 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7556,
+    "price": 7842,
     "weight": 450.0,
-    "tier": 6.109216,
+    "tier": 6.24311447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19706,7 +19706,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 73,
+      "maneuver": 74,
       "speed": 34,
       "hitPoints": 213
     },
@@ -19717,9 +19717,9 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9205,
+    "price": 9547,
     "weight": 450.0,
-    "tier": 6.850005,
+    "tier": 6.99526548,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19727,7 +19727,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 75,
+      "maneuver": 76,
       "speed": 35,
       "hitPoints": 216
     },
@@ -19738,9 +19738,9 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11201,
+    "price": 11609,
     "weight": 450.0,
-    "tier": 7.66417027,
+    "tier": 7.821442,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19748,7 +19748,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 77,
+      "maneuver": 78,
       "speed": 36,
       "hitPoints": 219
     },
@@ -19759,9 +19759,9 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13337,
+    "price": 13818,
     "weight": 450.0,
-    "tier": 8.45945,
+    "tier": 8.629402,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19769,7 +19769,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 79,
+      "maneuver": 80,
       "speed": 37,
       "hitPoints": 222
     },
@@ -19780,9 +19780,9 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15626,
+    "price": 16182,
     "weight": 450.0,
-    "tier": 9.244228,
+    "tier": 9.426086,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19790,7 +19790,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 80,
+      "maneuver": 81,
       "speed": 38,
       "hitPoints": 225
     },

--- a/items.json
+++ b/items.json
@@ -19591,9 +19591,9 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16582,
+    "price": 17238,
     "weight": 450.0,
-    "tier": 9.554875,
+    "tier": 9.763345,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19601,8 +19601,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 83,
-      "speed": 37,
+      "maneuver": 82,
+      "speed": 38,
       "hitPoints": 228
     },
     "weapons": []
@@ -19612,9 +19612,9 @@
     "name": "Brabant Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19495,
+    "price": 20235,
     "weight": 450.0,
-    "tier": 10.4508572,
+    "tier": 10.6676989,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19622,8 +19622,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 84,
-      "speed": 38,
+      "maneuver": 83,
+      "speed": 39,
       "hitPoints": 231
     },
     "weapons": []
@@ -19633,9 +19633,9 @@
     "name": "Comtois Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 21525,
+    "price": 22308,
     "weight": 450.0,
-    "tier": 11.0365,
+    "tier": 11.255044,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19643,8 +19643,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 84,
-      "speed": 39,
+      "maneuver": 83,
+      "speed": 40,
       "hitPoints": 234
     },
     "weapons": []
@@ -19654,9 +19654,9 @@
     "name": "English Black Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23674,
+    "price": 24534,
     "weight": 450.0,
-    "tier": 11.6270962,
+    "tier": 11.8561363,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19664,8 +19664,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 85,
-      "speed": 39,
+      "maneuver": 84,
+      "speed": 40,
       "hitPoints": 237
     },
     "weapons": []
@@ -19675,9 +19675,9 @@
     "name": "Perechon Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 26063,
+    "price": 26972,
     "weight": 450.0,
-    "tier": 12.2533617,
+    "tier": 12.48401,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19685,8 +19685,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 85,
-      "speed": 40,
+      "maneuver": 84,
+      "speed": 41,
       "hitPoints": 240
     },
     "weapons": []
@@ -19696,9 +19696,9 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7247,
+    "price": 7556,
     "weight": 450.0,
-    "tier": 5.961785,
+    "tier": 6.109216,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19706,8 +19706,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 74,
-      "speed": 33,
+      "maneuver": 73,
+      "speed": 34,
       "hitPoints": 213
     },
     "weapons": []
@@ -19717,9 +19717,9 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8837,
+    "price": 9205,
     "weight": 450.0,
-    "tier": 6.690727,
+    "tier": 6.850005,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19727,8 +19727,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 76,
-      "speed": 34,
+      "maneuver": 75,
+      "speed": 35,
       "hitPoints": 216
     },
     "weapons": []
@@ -19738,9 +19738,9 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10764,
+    "price": 11201,
     "weight": 450.0,
-    "tier": 7.492402,
+    "tier": 7.66417027,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19748,8 +19748,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 78,
-      "speed": 35,
+      "maneuver": 77,
+      "speed": 36,
       "hitPoints": 219
     },
     "weapons": []
@@ -19759,9 +19759,9 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12824,
+    "price": 13337,
     "weight": 450.0,
-    "tier": 8.274528,
+    "tier": 8.45945,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19769,8 +19769,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 80,
-      "speed": 36,
+      "maneuver": 79,
+      "speed": 37,
       "hitPoints": 222
     },
     "weapons": []
@@ -19780,9 +19780,9 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15048,
+    "price": 15626,
     "weight": 450.0,
-    "tier": 9.051661,
+    "tier": 9.244228,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19790,8 +19790,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 81,
-      "speed": 37,
+      "maneuver": 80,
+      "speed": 38,
       "hitPoints": 225
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -18961,16 +18961,16 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16757,
+    "price": 17009,
     "weight": 430.0,
-    "tier": 9.611014,
+    "tier": 9.69092751,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 81,
       "speed": 41,
       "hitPoints": 211
@@ -18982,16 +18982,16 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19438,
+    "price": 19800,
     "weight": 430.0,
-    "tier": 10.4340172,
+    "tier": 10.5408888,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 6,
+      "chargeDamage": 7,
       "maneuver": 82,
       "speed": 42,
       "hitPoints": 214
@@ -19003,16 +19003,16 @@
     "name": "Lusitano Pureblood Destrier",
     "culture": "Battania",
     "type": "Mount",
-    "price": 21416,
+    "price": 21797,
     "weight": 430.0,
-    "tier": 11.0058794,
+    "tier": 11.11275,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 6,
+      "chargeDamage": 7,
       "maneuver": 82,
       "speed": 43,
       "hitPoints": 217
@@ -19024,16 +19024,16 @@
     "name": "Bohemond",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 24821,
+    "price": 25395,
     "weight": 430.0,
-    "tier": 11.9317226,
+    "tier": 12.0812435,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 83,
       "speed": 44,
       "hitPoints": 220
@@ -19045,16 +19045,16 @@
     "name": "Llamrei",
     "culture": "Battania",
     "type": "Mount",
-    "price": 27259,
+    "price": 27860,
     "weight": 430.0,
-    "tier": 12.5562592,
+    "tier": 12.7057819,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 83,
       "speed": 45,
       "hitPoints": 223
@@ -19066,16 +19066,16 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7826,
+    "price": 7948,
     "weight": 450.0,
-    "tier": 6.235701,
+    "tier": 6.29179668,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 73,
       "speed": 37,
       "hitPoints": 196
@@ -19087,16 +19087,16 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9365,
+    "price": 9498,
     "weight": 430.0,
-    "tier": 6.91836262,
+    "tier": 6.97445774,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 75,
       "speed": 38,
       "hitPoints": 199
@@ -19108,16 +19108,16 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11331,
+    "price": 11497,
     "weight": 430.0,
-    "tier": 7.71446657,
+    "tier": 7.778686,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 77,
       "speed": 39,
       "hitPoints": 202
@@ -19129,16 +19129,16 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13494,
+    "price": 13676,
     "weight": 430.0,
-    "tier": 8.515131,
+    "tier": 8.57935,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 79,
       "speed": 40,
       "hitPoints": 205
@@ -19150,16 +19150,16 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15668,
+    "price": 15911,
     "weight": 430.0,
-    "tier": 9.258071,
+    "tier": 9.337985,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 80,
       "speed": 41,
       "hitPoints": 208
@@ -19591,19 +19591,19 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15788,
+    "price": 16582,
     "weight": 450.0,
-    "tier": 9.29752,
+    "tier": 9.554875,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 6,
+      "chargeDamage": 7,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 225
+      "hitPoints": 228
     },
     "weapons": []
   },
@@ -19612,19 +19612,19 @@
     "name": "Brabant Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18459,
+    "price": 19495,
     "weight": 450.0,
-    "tier": 10.1406078,
+    "tier": 10.4508572,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 84,
       "speed": 38,
-      "hitPoints": 228
+      "hitPoints": 231
     },
     "weapons": []
   },
@@ -19633,19 +19633,19 @@
     "name": "Comtois Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 20411,
+    "price": 21525,
     "weight": 450.0,
-    "tier": 10.7188635,
+    "tier": 11.0365,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
+      "chargeDamage": 8,
       "maneuver": 84,
       "speed": 39,
-      "hitPoints": 231
+      "hitPoints": 234
     },
     "weapons": []
   },
@@ -19654,19 +19654,19 @@
     "name": "English Black Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 22261,
+    "price": 23674,
     "weight": 450.0,
-    "tier": 11.2420568,
+    "tier": 11.6270962,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
+      "chargeDamage": 9,
       "maneuver": 85,
       "speed": 39,
-      "hitPoints": 234
+      "hitPoints": 237
     },
     "weapons": []
   },
@@ -19675,19 +19675,19 @@
     "name": "Perechon Great Horse",
     "culture": "Empire",
     "type": "Mount",
-    "price": 24551,
+    "price": 26063,
     "weight": 450.0,
-    "tier": 11.86062,
+    "tier": 12.2533617,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
+      "chargeDamage": 9,
       "maneuver": 85,
       "speed": 40,
-      "hitPoints": 237
+      "hitPoints": 240
     },
     "weapons": []
   },
@@ -19696,19 +19696,19 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 6817,
+    "price": 7247,
     "weight": 450.0,
-    "tier": 5.751242,
+    "tier": 5.961785,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 2,
+      "chargeDamage": 4,
       "maneuver": 74,
       "speed": 33,
-      "hitPoints": 210
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19717,19 +19717,19 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8438,
+    "price": 8837,
     "weight": 450.0,
-    "tier": 6.51444769,
+    "tier": 6.690727,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 76,
       "speed": 34,
-      "hitPoints": 213
+      "hitPoints": 216
     },
     "weapons": []
   },
@@ -19738,19 +19738,19 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10259,
+    "price": 10764,
     "weight": 450.0,
-    "tier": 7.289525,
+    "tier": 7.492402,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 78,
       "speed": 35,
-      "hitPoints": 216
+      "hitPoints": 219
     },
     "weapons": []
   },
@@ -19759,19 +19759,19 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12242,
+    "price": 12824,
     "weight": 450.0,
-    "tier": 8.060016,
+    "tier": 8.274528,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 80,
       "speed": 36,
-      "hitPoints": 219
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -19780,19 +19780,19 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14311,
+    "price": 15048,
     "weight": 450.0,
-    "tier": 8.800743,
+    "tier": 9.051661,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 6,
+      "chargeDamage": 7,
       "maneuver": 81,
       "speed": 37,
-      "hitPoints": 222
+      "hitPoints": 225
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -18982,9 +18982,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16246,
+    "price": 17369,
     "weight": 430.0,
-    "tier": 9.446945,
+    "tier": 9.804319,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18993,7 +18993,7 @@
       "bodyLength": 100,
       "chargeDamage": 6,
       "maneuver": 80,
-      "speed": 41,
+      "speed": 42,
       "hitPoints": 210
     },
     "weapons": []
@@ -19192,9 +19192,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16591,
+    "price": 17672,
     "weight": 450.0,
-    "tier": 9.557849,
+    "tier": 9.898636,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19203,7 +19203,7 @@
       "bodyLength": 105,
       "chargeDamage": 7,
       "maneuver": 74,
-      "speed": 43,
+      "speed": 44,
       "hitPoints": 219
     },
     "weapons": []
@@ -19402,9 +19402,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16660,
+    "price": 17651,
     "weight": 420.0,
-    "tier": 9.580141,
+    "tier": 9.892221,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19413,7 +19413,7 @@
       "bodyLength": 100,
       "chargeDamage": 5,
       "maneuver": 72,
-      "speed": 48,
+      "speed": 49,
       "hitPoints": 201
     },
     "weapons": []
@@ -19612,9 +19612,9 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16024,
+    "price": 17238,
     "weight": 450.0,
-    "tier": 9.374831,
+    "tier": 9.763345,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19623,7 +19623,7 @@
       "bodyLength": 105,
       "chargeDamage": 7,
       "maneuver": 82,
-      "speed": 37,
+      "speed": 38,
       "hitPoints": 228
     },
     "weapons": []
@@ -19822,9 +19822,9 @@
     "name": "Berber Jennet",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15261,
+    "price": 16309,
     "weight": 300.0,
-    "tier": 9.123065,
+    "tier": 9.467125,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19833,7 +19833,7 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 84,
-      "speed": 42,
+      "speed": 43,
       "hitPoints": 189
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -19126,7 +19126,7 @@
   },
   {
     "id": "crpg_mount_balanced_8",
-    "name": "Fresian Destrier",
+    "name": "Friesian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
     "price": 13051,
@@ -19672,7 +19672,7 @@
   },
   {
     "id": "crpg_mount_greathorse_14",
-    "name": "Perechon Great Horse",
+    "name": "Percheron Great Horse",
     "culture": "Empire",
     "type": "Mount",
     "price": 25207,
@@ -20011,9 +20011,9 @@
     "name": "Black Forest Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15365,
+    "price": 14222,
     "weight": 420.0,
-    "tier": 9.157804,
+    "tier": 8.770262,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20021,7 +20021,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 76,
+      "maneuver": 74,
       "speed": 45,
       "hitPoints": 198
     },
@@ -20032,9 +20032,9 @@
     "name": "Bidet Breton Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18243,
+    "price": 16906,
     "weight": 420.0,
-    "tier": 10.0745325,
+    "tier": 9.658382,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20042,7 +20042,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 78,
+      "maneuver": 76,
       "speed": 46,
       "hitPoints": 201
     },
@@ -20053,9 +20053,9 @@
     "name": "Dzhabe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 19580,
+    "price": 18158,
     "weight": 420.0,
-    "tier": 10.4761057,
+    "tier": 10.0485439,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20063,7 +20063,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 79,
+      "maneuver": 77,
       "speed": 46,
       "hitPoints": 204
     },
@@ -20074,9 +20074,9 @@
     "name": "Karachay Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 22340,
+    "price": 20726,
     "weight": 420.0,
-    "tier": 11.2639112,
+    "tier": 10.80942,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20084,7 +20084,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 80,
+      "maneuver": 78,
       "speed": 47,
       "hitPoints": 207
     },
@@ -20095,9 +20095,9 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 24529,
+    "price": 22748,
     "weight": 420.0,
-    "tier": 11.8546782,
+    "tier": 11.3760147,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20105,7 +20105,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 80,
+      "maneuver": 78,
       "speed": 48,
       "hitPoints": 210
     },
@@ -20137,9 +20137,9 @@
     "name": "Raymond Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 4567,
+    "price": 4828,
     "weight": 420.0,
-    "tier": 4.525363,
+    "tier": 4.680662,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20147,8 +20147,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 1,
-      "maneuver": 64,
-      "speed": 36,
+      "maneuver": 62,
+      "speed": 38,
       "hitPoints": 189
     },
     "weapons": []
@@ -20158,9 +20158,9 @@
     "name": "Fell Pony",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 6017,
+    "price": 5535,
     "weight": 420.0,
-    "tier": 5.34199333,
+    "tier": 5.08262157,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20168,7 +20168,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 66,
+      "maneuver": 64,
       "speed": 40,
       "hitPoints": 180
     },
@@ -20179,9 +20179,9 @@
     "name": "Welsh Cob",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7220,
+    "price": 6650,
     "weight": 420.0,
-    "tier": 5.94881725,
+    "tier": 5.667833,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20189,7 +20189,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 68,
+      "maneuver": 66,
       "speed": 41,
       "hitPoints": 183
     },
@@ -20200,9 +20200,9 @@
     "name": "Sanhe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8769,
+    "price": 8090,
     "weight": 420.0,
-    "tier": 6.660801,
+    "tier": 6.356974,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20210,7 +20210,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 70,
+      "maneuver": 68,
       "speed": 42,
       "hitPoints": 186
     },
@@ -20221,9 +20221,9 @@
     "name": "Megrelakaya Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10472,
+    "price": 9672,
     "weight": 420.0,
-    "tier": 7.37590265,
+    "tier": 7.04795742,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20231,7 +20231,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 72,
+      "maneuver": 70,
       "speed": 43,
       "hitPoints": 189
     },
@@ -20242,9 +20242,9 @@
     "name": "East Anglis Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12484,
+    "price": 11544,
     "weight": 420.0,
-    "tier": 8.149946,
+    "tier": 7.79657173,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20252,7 +20252,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 74,
+      "maneuver": 72,
       "speed": 44,
       "hitPoints": 192
     },
@@ -20263,9 +20263,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14295,
+    "price": 13223,
     "weight": 420.0,
-    "tier": 8.795376,
+    "tier": 8.418521,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20273,7 +20273,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 75,
+      "maneuver": 73,
       "speed": 45,
       "hitPoints": 195
     },

--- a/items.json
+++ b/items.json
@@ -20032,9 +20032,9 @@
     "name": "Black Forest Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14222,
+    "price": 14786,
     "weight": 420.0,
-    "tier": 8.770262,
+    "tier": 8.963193,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20042,7 +20042,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 74,
+      "maneuver": 75,
       "speed": 45,
       "hitPoints": 198
     },
@@ -20074,9 +20074,9 @@
     "name": "Dzhabe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18158,
+    "price": 19306,
     "weight": 420.0,
-    "tier": 10.0485439,
+    "tier": 10.3948927,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20085,7 +20085,7 @@
       "bodyLength": 100,
       "chargeDamage": 3,
       "maneuver": 77,
-      "speed": 46,
+      "speed": 47,
       "hitPoints": 204
     },
     "weapons": []
@@ -20284,9 +20284,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13223,
+    "price": 13752,
     "weight": 420.0,
-    "tier": 8.418521,
+    "tier": 8.60612,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20294,7 +20294,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 73,
+      "maneuver": 74,
       "speed": 45,
       "hitPoints": 195
     },

--- a/items.json
+++ b/items.json
@@ -19381,19 +19381,19 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18754,
+    "price": 18538,
     "weight": 420.0,
-    "tier": 10.229785,
+    "tier": 10.16444,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 71,
-      "speed": 51,
-      "hitPoints": 201
+      "speed": 50,
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19402,19 +19402,19 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21348,
+    "price": 21095,
     "weight": 420.0,
-    "tier": 10.9864693,
+    "tier": 10.9149818,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 72,
-      "speed": 52,
-      "hitPoints": 204
+      "speed": 51,
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19423,19 +19423,19 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23299,
+    "price": 23024,
     "weight": 420.0,
-    "tier": 11.5261393,
+    "tier": 11.4515133,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 72,
-      "speed": 53,
-      "hitPoints": 207
+      "speed": 52,
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19444,19 +19444,19 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 26720,
+    "price": 26462,
     "weight": 420.0,
-    "tier": 12.420433,
+    "tier": 12.3550625,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 73,
-      "speed": 54,
-      "hitPoints": 210
+      "speed": 53,
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19465,19 +19465,19 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 29093,
+    "price": 28810,
     "weight": 420.0,
-    "tier": 13.0078049,
+    "tier": 12.9391708,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 5,
+      "chargeDamage": 6,
       "maneuver": 73,
-      "speed": 55,
-      "hitPoints": 213
+      "speed": 54,
+      "hitPoints": 216
     },
     "weapons": []
   },
@@ -19486,19 +19486,19 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8740,
+    "price": 8649,
     "weight": 420.0,
-    "tier": 6.64814949,
+    "tier": 6.6081295,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 2,
+      "chargeDamage": 3,
       "maneuver": 63,
-      "speed": 47,
-      "hitPoints": 186
+      "speed": 46,
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19507,19 +19507,19 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10472,
+    "price": 10354,
     "weight": 420.0,
-    "tier": 7.375792,
+    "tier": 7.328395,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 2,
+      "chargeDamage": 3,
       "maneuver": 65,
-      "speed": 48,
-      "hitPoints": 189
+      "speed": 47,
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19528,19 +19528,19 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11960,
+    "price": 12524,
     "weight": 420.0,
-    "tier": 7.95453644,
+    "tier": 8.16449,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 67,
       "speed": 48,
-      "hitPoints": 192
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19549,19 +19549,19 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15095,
+    "price": 14917,
     "weight": 420.0,
-    "tier": 9.067386,
+    "tier": 9.00760651,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 69,
-      "speed": 50,
-      "hitPoints": 195
+      "speed": 49,
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -19570,19 +19570,19 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17401,
+    "price": 17218,
     "weight": 420.0,
-    "tier": 9.814344,
+    "tier": 9.757032,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 5,
       "maneuver": 70,
-      "speed": 51,
-      "hitPoints": 198
+      "speed": 50,
+      "hitPoints": 201
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -19171,17 +19171,17 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15812,
+    "price": 16591,
     "weight": 450.0,
-    "tier": 9.305339,
+    "tier": 9.557849,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
-      "maneuver": 72,
+      "chargeDamage": 7,
+      "maneuver": 74,
       "speed": 43,
       "hitPoints": 219
     },
@@ -19192,17 +19192,17 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18693,
+    "price": 19412,
     "weight": 450.0,
-    "tier": 10.211257,
+    "tier": 10.4262953,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 9,
-      "maneuver": 73,
+      "chargeDamage": 8,
+      "maneuver": 75,
       "speed": 44,
       "hitPoints": 222
     },
@@ -19213,17 +19213,17 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 20418,
+    "price": 21251,
     "weight": 450.0,
-    "tier": 10.7208557,
+    "tier": 10.9591351,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 9,
-      "maneuver": 73,
+      "chargeDamage": 8,
+      "maneuver": 75,
       "speed": 45,
       "hitPoints": 225
     },
@@ -19234,17 +19234,17 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 24275,
+    "price": 24943,
     "weight": 450.0,
-    "tier": 11.7874956,
+    "tier": 11.9636717,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 10,
-      "maneuver": 74,
+      "chargeDamage": 9,
+      "maneuver": 76,
       "speed": 46,
       "hitPoints": 228
     },
@@ -19255,17 +19255,17 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 26418,
+    "price": 27215,
     "weight": 450.0,
-    "tier": 12.3438768,
+    "tier": 12.5450792,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 10,
-      "maneuver": 74,
+      "chargeDamage": 9,
+      "maneuver": 76,
       "speed": 47,
       "hitPoints": 231
     },
@@ -19276,17 +19276,17 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 6936,
+    "price": 7423,
     "weight": 450.0,
-    "tier": 5.81050348,
+    "tier": 6.04603052,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 4,
-      "maneuver": 64,
+      "chargeDamage": 3,
+      "maneuver": 66,
       "speed": 39,
       "hitPoints": 204
     },
@@ -19297,17 +19297,17 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8459,
+    "price": 9031,
     "weight": 450.0,
-    "tier": 6.52374554,
+    "tier": 6.77499628,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 5,
-      "maneuver": 66,
+      "chargeDamage": 4,
+      "maneuver": 68,
       "speed": 40,
       "hitPoints": 207
     },
@@ -19318,17 +19318,17 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10305,
+    "price": 10959,
     "weight": 450.0,
-    "tier": 7.30855227,
+    "tier": 7.56927633,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 6,
-      "maneuver": 68,
+      "chargeDamage": 5,
+      "maneuver": 70,
       "speed": 41,
       "hitPoints": 210
     },
@@ -19339,17 +19339,17 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12564,
+    "price": 13282,
     "weight": 450.0,
-    "tier": 8.179463,
+    "tier": 8.439761,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 7,
-      "maneuver": 70,
+      "chargeDamage": 6,
+      "maneuver": 72,
       "speed": 42,
       "hitPoints": 213
     },
@@ -19360,17 +19360,17 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14778,
+    "price": 15500,
     "weight": 450.0,
-    "tier": 8.96065,
+    "tier": 9.202708,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 8,
-      "maneuver": 71,
+      "chargeDamage": 7,
+      "maneuver": 73,
       "speed": 43,
       "hitPoints": 216
     },
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16119,
+    "price": 16660,
     "weight": 420.0,
-    "tier": 9.405501,
+    "tier": 9.580141,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19393,7 +19393,7 @@
       "chargeDamage": 5,
       "maneuver": 72,
       "speed": 48,
-      "hitPoints": 198
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18371,
+    "price": 18984,
     "weight": 420.0,
-    "tier": 10.113595,
+    "tier": 10.2989645,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19414,7 +19414,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 49,
-      "hitPoints": 201
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 20099,
+    "price": 20764,
     "weight": 420.0,
-    "tier": 10.6282539,
+    "tier": 10.820447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19435,7 +19435,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 50,
-      "hitPoints": 204
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23154,
+    "price": 23910,
     "weight": 420.0,
-    "tier": 11.4869175,
+    "tier": 11.690567,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19456,7 +19456,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 51,
-      "hitPoints": 207
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 25268,
+    "price": 26085,
     "weight": 420.0,
-    "tier": 12.0482607,
+    "tier": 12.2591181,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19477,7 +19477,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 52,
-      "hitPoints": 210
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7489,
+    "price": 7750,
     "weight": 420.0,
-    "tier": 6.077647,
+    "tier": 6.200236,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19498,7 +19498,7 @@
       "chargeDamage": 3,
       "maneuver": 64,
       "speed": 44,
-      "hitPoints": 183
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8968,
+    "price": 9280,
     "weight": 420.0,
-    "tier": 6.74791336,
+    "tier": 6.88217068,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19519,7 +19519,7 @@
       "chargeDamage": 3,
       "maneuver": 66,
       "speed": 45,
-      "hitPoints": 186
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10861,
+    "price": 11236,
     "weight": 420.0,
-    "tier": 7.530829,
+    "tier": 7.67751741,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19540,7 +19540,7 @@
       "chargeDamage": 4,
       "maneuver": 68,
       "speed": 46,
-      "hitPoints": 189
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12943,
+    "price": 13388,
     "weight": 420.0,
-    "tier": 8.317475,
+    "tier": 8.477386,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19561,7 +19561,7 @@
       "chargeDamage": 4,
       "maneuver": 70,
       "speed": 47,
-      "hitPoints": 192
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14975,
+    "price": 15484,
     "weight": 420.0,
-    "tier": 9.027238,
+    "tier": 9.197222,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19582,7 +19582,7 @@
       "chargeDamage": 5,
       "maneuver": 71,
       "speed": 48,
-      "hitPoints": 195
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -20095,16 +20095,16 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23555,
+    "price": 23347,
     "weight": 420.0,
-    "tier": 11.5951042,
+    "tier": 11.5390072,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 4,
+      "chargeDamage": 3,
       "maneuver": 82,
       "speed": 46,
       "hitPoints": 210

--- a/items.json
+++ b/items.json
@@ -19171,9 +19171,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16428,
+    "price": 15812,
     "weight": 450.0,
-    "tier": 9.505461,
+    "tier": 9.305339,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19181,7 +19181,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 73,
+      "maneuver": 72,
       "speed": 43,
       "hitPoints": 219
     },
@@ -19192,9 +19192,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19405,
+    "price": 18693,
     "weight": 450.0,
-    "tier": 10.4243555,
+    "tier": 10.211257,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19202,7 +19202,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 74,
+      "maneuver": 73,
       "speed": 44,
       "hitPoints": 222
     },
@@ -19213,9 +19213,9 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 21203,
+    "price": 20418,
     "weight": 450.0,
-    "tier": 10.9455223,
+    "tier": 10.7208557,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19223,7 +19223,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 9,
-      "maneuver": 74,
+      "maneuver": 73,
       "speed": 45,
       "hitPoints": 225
     },
@@ -19234,9 +19234,9 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 25183,
+    "price": 24275,
     "weight": 450.0,
-    "tier": 12.0262079,
+    "tier": 11.7874956,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19244,7 +19244,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 10,
-      "maneuver": 75,
+      "maneuver": 74,
       "speed": 46,
       "hitPoints": 228
     },
@@ -19255,9 +19255,9 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 27415,
+    "price": 26418,
     "weight": 450.0,
-    "tier": 12.5950489,
+    "tier": 12.3438768,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19265,7 +19265,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 10,
-      "maneuver": 75,
+      "maneuver": 74,
       "speed": 47,
       "hitPoints": 231
     },
@@ -19276,9 +19276,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7234,
+    "price": 6936,
     "weight": 450.0,
-    "tier": 5.95558548,
+    "tier": 5.81050348,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19286,7 +19286,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 65,
+      "maneuver": 64,
       "speed": 39,
       "hitPoints": 204
     },
@@ -19297,9 +19297,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8814,
+    "price": 8459,
     "weight": 450.0,
-    "tier": 6.68071556,
+    "tier": 6.52374554,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19307,7 +19307,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 67,
+      "maneuver": 66,
       "speed": 40,
       "hitPoints": 207
     },
@@ -19318,9 +19318,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10728,
+    "price": 10305,
     "weight": 450.0,
-    "tier": 7.47807,
+    "tier": 7.30855227,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19328,7 +19328,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 69,
+      "maneuver": 68,
       "speed": 41,
       "hitPoints": 210
     },
@@ -19339,9 +19339,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13066,
+    "price": 12564,
     "weight": 450.0,
-    "tier": 8.362206,
+    "tier": 8.179463,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19349,7 +19349,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 71,
+      "maneuver": 70,
       "speed": 42,
       "hitPoints": 213
     },
@@ -19360,9 +19360,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15359,
+    "price": 14778,
     "weight": 450.0,
-    "tier": 9.155558,
+    "tier": 8.96065,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19370,7 +19370,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 72,
+      "maneuver": 71,
       "speed": 43,
       "hitPoints": 216
     },
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16660,
+    "price": 16119,
     "weight": 420.0,
-    "tier": 9.580141,
+    "tier": 9.405501,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19393,7 +19393,7 @@
       "chargeDamage": 5,
       "maneuver": 72,
       "speed": 48,
-      "hitPoints": 201
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18984,
+    "price": 18371,
     "weight": 420.0,
-    "tier": 10.2989645,
+    "tier": 10.113595,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19414,7 +19414,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 49,
-      "hitPoints": 204
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 20764,
+    "price": 20099,
     "weight": 420.0,
-    "tier": 10.820447,
+    "tier": 10.6282539,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19435,7 +19435,7 @@
       "chargeDamage": 5,
       "maneuver": 73,
       "speed": 50,
-      "hitPoints": 207
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23910,
+    "price": 23154,
     "weight": 420.0,
-    "tier": 11.690567,
+    "tier": 11.4869175,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19456,7 +19456,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 51,
-      "hitPoints": 210
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 26085,
+    "price": 25268,
     "weight": 420.0,
-    "tier": 12.2591181,
+    "tier": 12.0482607,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19477,7 +19477,7 @@
       "chargeDamage": 6,
       "maneuver": 74,
       "speed": 52,
-      "hitPoints": 213
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7750,
+    "price": 7489,
     "weight": 420.0,
-    "tier": 6.200236,
+    "tier": 6.077647,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19498,7 +19498,7 @@
       "chargeDamage": 3,
       "maneuver": 64,
       "speed": 44,
-      "hitPoints": 186
+      "hitPoints": 183
     },
     "weapons": []
   },
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9280,
+    "price": 8968,
     "weight": 420.0,
-    "tier": 6.88217068,
+    "tier": 6.74791336,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19519,7 +19519,7 @@
       "chargeDamage": 3,
       "maneuver": 66,
       "speed": 45,
-      "hitPoints": 189
+      "hitPoints": 186
     },
     "weapons": []
   },
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11236,
+    "price": 10861,
     "weight": 420.0,
-    "tier": 7.67751741,
+    "tier": 7.530829,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19540,7 +19540,7 @@
       "chargeDamage": 4,
       "maneuver": 68,
       "speed": 46,
-      "hitPoints": 192
+      "hitPoints": 189
     },
     "weapons": []
   },
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13388,
+    "price": 12943,
     "weight": 420.0,
-    "tier": 8.477386,
+    "tier": 8.317475,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19561,7 +19561,7 @@
       "chargeDamage": 4,
       "maneuver": 70,
       "speed": 47,
-      "hitPoints": 195
+      "hitPoints": 192
     },
     "weapons": []
   },
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15484,
+    "price": 14975,
     "weight": 420.0,
-    "tier": 9.197222,
+    "tier": 9.027238,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19582,7 +19582,7 @@
       "chargeDamage": 5,
       "maneuver": 71,
       "speed": 48,
-      "hitPoints": 198
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -20095,16 +20095,16 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23347,
+    "price": 23555,
     "weight": 420.0,
-    "tier": 11.5390072,
+    "tier": 11.5951042,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 82,
       "speed": 46,
       "hitPoints": 210

--- a/items.json
+++ b/items.json
@@ -6975,9 +6975,9 @@
     "name": "Seleucid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 14413,
+    "price": 14551,
     "weight": 520.0,
-    "tier": 8.835952,
+    "tier": 8.883225,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6987,7 +6987,7 @@
       "chargeDamage": 4,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 230
+      "hitPoints": 231
     },
     "weapons": []
   },
@@ -6996,9 +6996,9 @@
     "name": "Seleucid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 15370,
+    "price": 15506,
     "weight": 520.0,
-    "tier": 9.15946,
+    "tier": 9.204619,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7008,7 +7008,7 @@
       "chargeDamage": 5,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 248
+      "hitPoints": 249
     },
     "weapons": []
   },
@@ -7017,9 +7017,9 @@
     "name": "Parthian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 16115,
+    "price": 16271,
     "weight": 520.0,
-    "tier": 9.404481,
+    "tier": 9.454871,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7029,7 +7029,7 @@
       "chargeDamage": 4,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 230
+      "hitPoints": 231
     },
     "weapons": []
   },
@@ -7038,9 +7038,9 @@
     "name": "Parthian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 17225,
+    "price": 17379,
     "weight": 520.0,
-    "tier": 9.759111,
+    "tier": 9.807319,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7050,7 +7050,7 @@
       "chargeDamage": 5,
       "maneuver": 82,
       "speed": 36,
-      "hitPoints": 248
+      "hitPoints": 249
     },
     "weapons": []
   },
@@ -7059,9 +7059,9 @@
     "name": "Achaemenian Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 19817,
+    "price": 20002,
     "weight": 520.0,
-    "tier": 10.5457993,
+    "tier": 10.5999737,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7071,7 +7071,7 @@
       "chargeDamage": 5,
       "maneuver": 84,
       "speed": 38,
-      "hitPoints": 239
+      "hitPoints": 240
     },
     "weapons": []
   },
@@ -7080,9 +7080,9 @@
     "name": "Achaemenian Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 21143,
+    "price": 21326,
     "weight": 520.0,
-    "tier": 10.9285612,
+    "tier": 10.9804239,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7092,7 +7092,7 @@
       "chargeDamage": 6,
       "maneuver": 83,
       "speed": 37,
-      "hitPoints": 257
+      "hitPoints": 258
     },
     "weapons": []
   },
@@ -7101,9 +7101,9 @@
     "name": "Padisha",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 26380,
+    "price": 25931,
     "weight": 520.0,
-    "tier": 12.33442,
+    "tier": 12.2194681,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7113,7 +7113,7 @@
       "chargeDamage": 7,
       "maneuver": 86,
       "speed": 38,
-      "hitPoints": 260
+      "hitPoints": 258
     },
     "weapons": []
   },
@@ -7122,9 +7122,9 @@
     "name": "Pack Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 4601,
+    "price": 4779,
     "weight": 520.0,
-    "tier": 4.546,
+    "tier": 4.651889,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7134,7 +7134,7 @@
       "chargeDamage": 2,
       "maneuver": 72,
       "speed": 29,
-      "hitPoints": 212
+      "hitPoints": 216
     },
     "weapons": []
   },
@@ -7143,9 +7143,9 @@
     "name": "Pratihara Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 6515,
+    "price": 6394,
     "weight": 520.0,
-    "tier": 5.59981155,
+    "tier": 5.538042,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7155,7 +7155,7 @@
       "chargeDamage": 2,
       "maneuver": 76,
       "speed": 30,
-      "hitPoints": 224
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -7164,9 +7164,9 @@
     "name": "Qedarite Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 7912,
+    "price": 7767,
     "weight": 520.0,
-    "tier": 6.275274,
+    "tier": 6.20829725,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7176,7 +7176,7 @@
       "chargeDamage": 3,
       "maneuver": 77,
       "speed": 31,
-      "hitPoints": 230
+      "hitPoints": 228
     },
     "weapons": []
   },
@@ -7185,9 +7185,9 @@
     "name": "Palmyrene Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 9572,
+    "price": 9400,
     "weight": 520.0,
-    "tier": 7.00575924,
+    "tier": 6.93329,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7197,7 +7197,7 @@
       "chargeDamage": 4,
       "maneuver": 78,
       "speed": 32,
-      "hitPoints": 236
+      "hitPoints": 234
     },
     "weapons": []
   },
@@ -7206,9 +7206,9 @@
     "name": "Sargonid Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 10526,
+    "price": 10628,
     "weight": 520.0,
-    "tier": 7.39731646,
+    "tier": 7.43830967,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7218,7 +7218,7 @@
       "chargeDamage": 4,
       "maneuver": 80,
       "speed": 34,
-      "hitPoints": 221
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -7227,9 +7227,9 @@
     "name": "Sargonid Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 11246,
+    "price": 11346,
     "weight": 520.0,
-    "tier": 7.68140936,
+    "tier": 7.72047329,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7239,7 +7239,7 @@
       "chargeDamage": 5,
       "maneuver": 79,
       "speed": 33,
-      "hitPoints": 239
+      "hitPoints": 240
     },
     "weapons": []
   },
@@ -7248,9 +7248,9 @@
     "name": "Nabatean Light Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 11801,
+    "price": 11916,
     "weight": 520.0,
-    "tier": 7.894321,
+    "tier": 7.93814945,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7260,7 +7260,7 @@
       "chargeDamage": 4,
       "maneuver": 81,
       "speed": 35,
-      "hitPoints": 221
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -7269,9 +7269,9 @@
     "name": "Nabatean Heavy Camel",
     "culture": "Aserai",
     "type": "Mount",
-    "price": 12638,
+    "price": 12753,
     "weight": 520.0,
-    "tier": 8.206637,
+    "tier": 8.248472,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7281,7 +7281,7 @@
       "chargeDamage": 5,
       "maneuver": 80,
       "speed": 34,
-      "hitPoints": 239
+      "hitPoints": 240
     },
     "weapons": []
   },
@@ -18961,9 +18961,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17009,
+    "price": 16833,
     "weight": 430.0,
-    "tier": 9.69092751,
+    "tier": 9.635215,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18973,7 +18973,7 @@
       "chargeDamage": 6,
       "maneuver": 81,
       "speed": 41,
-      "hitPoints": 211
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -18982,9 +18982,9 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19800,
+    "price": 19599,
     "weight": 430.0,
-    "tier": 10.5408888,
+    "tier": 10.4815845,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18994,7 +18994,7 @@
       "chargeDamage": 7,
       "maneuver": 82,
       "speed": 42,
-      "hitPoints": 214
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19003,9 +19003,9 @@
     "name": "Lusitano Pureblood Destrier",
     "culture": "Battania",
     "type": "Mount",
-    "price": 21797,
+    "price": 21576,
     "weight": 430.0,
-    "tier": 11.11275,
+    "tier": 11.0509443,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19015,7 +19015,7 @@
       "chargeDamage": 7,
       "maneuver": 82,
       "speed": 43,
-      "hitPoints": 217
+      "hitPoints": 216
     },
     "weapons": []
   },
@@ -19024,9 +19024,9 @@
     "name": "Bohemond",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 25395,
+    "price": 25142,
     "weight": 430.0,
-    "tier": 12.0812435,
+    "tier": 12.0155954,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19036,7 +19036,7 @@
       "chargeDamage": 8,
       "maneuver": 83,
       "speed": 44,
-      "hitPoints": 220
+      "hitPoints": 219
     },
     "weapons": []
   },
@@ -19045,9 +19045,9 @@
     "name": "Llamrei",
     "culture": "Battania",
     "type": "Mount",
-    "price": 27860,
+    "price": 27585,
     "weight": 430.0,
-    "tier": 12.7057819,
+    "tier": 12.6374884,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19057,7 +19057,7 @@
       "chargeDamage": 8,
       "maneuver": 83,
       "speed": 45,
-      "hitPoints": 223
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -19066,9 +19066,9 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7948,
+    "price": 7863,
     "weight": 450.0,
-    "tier": 6.29179668,
+    "tier": 6.25273466,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19078,7 +19078,7 @@
       "chargeDamage": 4,
       "maneuver": 73,
       "speed": 37,
-      "hitPoints": 196
+      "hitPoints": 195
     },
     "weapons": []
   },
@@ -19087,9 +19087,9 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9498,
+    "price": 9396,
     "weight": 430.0,
-    "tier": 6.97445774,
+    "tier": 6.931665,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19099,7 +19099,7 @@
       "chargeDamage": 4,
       "maneuver": 75,
       "speed": 38,
-      "hitPoints": 199
+      "hitPoints": 198
     },
     "weapons": []
   },
@@ -19108,9 +19108,9 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11497,
+    "price": 11376,
     "weight": 430.0,
-    "tier": 7.778686,
+    "tier": 7.731916,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19120,7 +19120,7 @@
       "chargeDamage": 5,
       "maneuver": 77,
       "speed": 39,
-      "hitPoints": 202
+      "hitPoints": 201
     },
     "weapons": []
   },
@@ -19129,9 +19129,9 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13676,
+    "price": 13531,
     "weight": 430.0,
-    "tier": 8.57935,
+    "tier": 8.528346,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19141,7 +19141,7 @@
       "chargeDamage": 5,
       "maneuver": 79,
       "speed": 40,
-      "hitPoints": 205
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19150,9 +19150,9 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15911,
+    "price": 15746,
     "weight": 430.0,
-    "tier": 9.337985,
+    "tier": 9.283607,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19162,7 +19162,7 @@
       "chargeDamage": 6,
       "maneuver": 80,
       "speed": 41,
-      "hitPoints": 208
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19171,9 +19171,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17148,
+    "price": 16820,
     "weight": 450.0,
-    "tier": 9.734966,
+    "tier": 9.631062,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19183,7 +19183,7 @@
       "chargeDamage": 8,
       "maneuver": 72,
       "speed": 44,
-      "hitPoints": 221
+      "hitPoints": 219
     },
     "weapons": []
   },
@@ -19192,9 +19192,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 20227,
+    "price": 19848,
     "weight": 450.0,
-    "tier": 10.6654711,
+    "tier": 10.5548964,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19204,7 +19204,7 @@
       "chargeDamage": 9,
       "maneuver": 73,
       "speed": 45,
-      "hitPoints": 224
+      "hitPoints": 222
     },
     "weapons": []
   },
@@ -19213,9 +19213,9 @@
     "name": "Neapolitan Charger",
     "culture": "Empire",
     "type": "Mount",
-    "price": 22074,
+    "price": 21662,
     "weight": 450.0,
-    "tier": 11.1899786,
+    "tier": 11.0750465,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19225,7 +19225,7 @@
       "chargeDamage": 9,
       "maneuver": 73,
       "speed": 46,
-      "hitPoints": 227
+      "hitPoints": 225
     },
     "weapons": []
   },
@@ -19234,9 +19234,9 @@
     "name": "Lionheart",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 26178,
+    "price": 25702,
     "weight": 450.0,
-    "tier": 12.2827349,
+    "tier": 12.1606607,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19246,7 +19246,7 @@
       "chargeDamage": 10,
       "maneuver": 74,
       "speed": 47,
-      "hitPoints": 230
+      "hitPoints": 228
     },
     "weapons": []
   },
@@ -19255,9 +19255,9 @@
     "name": "Bucephalus",
     "culture": "Empire",
     "type": "Mount",
-    "price": 28465,
+    "price": 27950,
     "weight": 450.0,
-    "tier": 12.8547964,
+    "tier": 12.7281122,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19267,7 +19267,7 @@
       "chargeDamage": 10,
       "maneuver": 74,
       "speed": 48,
-      "hitPoints": 233
+      "hitPoints": 231
     },
     "weapons": []
   },
@@ -19276,9 +19276,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7566,
+    "price": 7414,
     "weight": 450.0,
-    "tier": 6.114084,
+    "tier": 6.04196835,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19288,7 +19288,7 @@
       "chargeDamage": 4,
       "maneuver": 64,
       "speed": 40,
-      "hitPoints": 206
+      "hitPoints": 204
     },
     "weapons": []
   },
@@ -19297,9 +19297,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9216,
+    "price": 9032,
     "weight": 450.0,
-    "tier": 6.854764,
+    "tier": 6.775536,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19309,7 +19309,7 @@
       "chargeDamage": 5,
       "maneuver": 66,
       "speed": 41,
-      "hitPoints": 209
+      "hitPoints": 207
     },
     "weapons": []
   },
@@ -19318,9 +19318,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11213,
+    "price": 10991,
     "weight": 450.0,
-    "tier": 7.668689,
+    "tier": 7.581867,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19330,7 +19330,7 @@
       "chargeDamage": 6,
       "maneuver": 68,
       "speed": 42,
-      "hitPoints": 212
+      "hitPoints": 210
     },
     "weapons": []
   },
@@ -19339,9 +19339,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13650,
+    "price": 13383,
     "weight": 450.0,
-    "tier": 8.570456,
+    "tier": 8.475537,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19351,7 +19351,7 @@
       "chargeDamage": 7,
       "maneuver": 70,
       "speed": 43,
-      "hitPoints": 215
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -19360,9 +19360,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16024,
+    "price": 15715,
     "weight": 450.0,
-    "tier": 9.374633,
+    "tier": 9.27346,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19372,7 +19372,7 @@
       "chargeDamage": 8,
       "maneuver": 71,
       "speed": 44,
-      "hitPoints": 218
+      "hitPoints": 216
     },
     "weapons": []
   },

--- a/items.json
+++ b/items.json
@@ -7119,7 +7119,7 @@
   },
   {
     "id": "crpg_camel_17",
-    "name": "Padisha",
+    "name": "Padishah",
     "culture": "Aserai",
     "type": "Mount",
     "price": 25931,

--- a/items.json
+++ b/items.json
@@ -20116,30 +20116,9 @@
     "name": "Sumpter Horse",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 2682,
+    "price": 3726,
     "weight": 420.0,
-    "tier": 3.24377155,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 100,
-      "chargeDamage": 1,
-      "maneuver": 56,
-      "speed": 32,
-      "hitPoints": 200
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount_rouncey_3",
-    "name": "Raymond Rouncey",
-    "culture": "Neutral",
-    "type": "Mount",
-    "price": 3330,
-    "weight": 420.0,
-    "tier": 3.721898,
+    "tier": 3.993084,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20149,6 +20128,27 @@
       "chargeDamage": 1,
       "maneuver": 60,
       "speed": 34,
+      "hitPoints": 200
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_3",
+    "name": "Raymond Rouncey",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 4567,
+    "weight": 420.0,
+    "tier": 4.525363,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 1,
+      "maneuver": 64,
+      "speed": 36,
       "hitPoints": 189
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -18961,9 +18961,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15722,
+    "price": 16246,
     "weight": 430.0,
-    "tier": 9.275743,
+    "tier": 9.446945,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18971,8 +18971,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 81,
-      "speed": 40,
+      "maneuver": 80,
+      "speed": 41,
       "hitPoints": 210
     },
     "weapons": []
@@ -18982,9 +18982,9 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18335,
+    "price": 18924,
     "weight": 430.0,
-    "tier": 10.1026392,
+    "tier": 10.2807808,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18992,8 +18992,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 7,
-      "maneuver": 82,
-      "speed": 41,
+      "maneuver": 81,
+      "speed": 42,
       "hitPoints": 213
     },
     "weapons": []
@@ -19003,9 +19003,9 @@
     "name": "Lusitano Pureblood Destrier",
     "culture": "Battania",
     "type": "Mount",
-    "price": 20207,
+    "price": 20828,
     "weight": 430.0,
-    "tier": 10.6597128,
+    "tier": 10.8387308,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19013,8 +19013,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 7,
-      "maneuver": 82,
-      "speed": 42,
+      "maneuver": 81,
+      "speed": 43,
       "hitPoints": 216
     },
     "weapons": []
@@ -19024,9 +19024,9 @@
     "name": "Bohemond",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23587,
+    "price": 24283,
     "weight": 430.0,
-    "tier": 11.6037531,
+    "tier": 11.7897854,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19034,8 +19034,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 8,
-      "maneuver": 83,
-      "speed": 43,
+      "maneuver": 82,
+      "speed": 44,
       "hitPoints": 219
     },
     "weapons": []
@@ -19045,9 +19045,9 @@
     "name": "Llamrei",
     "culture": "Battania",
     "type": "Mount",
-    "price": 25905,
+    "price": 26636,
     "weight": 430.0,
-    "tier": 12.2127743,
+    "tier": 12.3993654,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19055,8 +19055,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 8,
-      "maneuver": 83,
-      "speed": 44,
+      "maneuver": 82,
+      "speed": 45,
       "hitPoints": 222
     },
     "weapons": []
@@ -19066,9 +19066,9 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7313,
+    "price": 7572,
     "weight": 450.0,
-    "tier": 5.99361658,
+    "tier": 6.11679459,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19076,8 +19076,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 73,
-      "speed": 36,
+      "maneuver": 72,
+      "speed": 37,
       "hitPoints": 195
     },
     "weapons": []
@@ -19087,9 +19087,9 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8746,
+    "price": 9053,
     "weight": 430.0,
-    "tier": 6.65095043,
+    "tier": 6.784462,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19097,8 +19097,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 75,
-      "speed": 37,
+      "maneuver": 74,
+      "speed": 38,
       "hitPoints": 198
     },
     "weapons": []
@@ -19108,9 +19108,9 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10603,
+    "price": 10968,
     "weight": 430.0,
-    "tier": 7.42838,
+    "tier": 7.572814,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19118,8 +19118,8 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 77,
-      "speed": 38,
+      "maneuver": 76,
+      "speed": 39,
       "hitPoints": 201
     },
     "weapons": []
@@ -19129,9 +19129,9 @@
     "name": "Fresian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12622,
+    "price": 13051,
     "weight": 430.0,
-    "tier": 8.200723,
+    "tier": 8.356689,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19139,8 +19139,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 79,
-      "speed": 39,
+      "maneuver": 78,
+      "speed": 40,
       "hitPoints": 204
     },
     "weapons": []
@@ -19150,9 +19150,9 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14711,
+    "price": 15193,
     "weight": 430.0,
-    "tier": 8.937754,
+    "tier": 9.100216,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19160,8 +19160,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 80,
-      "speed": 40,
+      "maneuver": 79,
+      "speed": 41,
       "hitPoints": 207
     },
     "weapons": []
@@ -20011,9 +20011,9 @@
     "name": "Black Forest Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14579,
+    "price": 15365,
     "weight": 420.0,
-    "tier": 8.892787,
+    "tier": 9.157804,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20021,8 +20021,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 78,
-      "speed": 43,
+      "maneuver": 76,
+      "speed": 45,
       "hitPoints": 198
     },
     "weapons": []
@@ -20032,9 +20032,9 @@
     "name": "Bidet Breton Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17316,
+    "price": 18243,
     "weight": 420.0,
-    "tier": 9.78765,
+    "tier": 10.0745325,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20042,8 +20042,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 80,
-      "speed": 44,
+      "maneuver": 78,
+      "speed": 46,
       "hitPoints": 201
     },
     "weapons": []
@@ -20053,9 +20053,9 @@
     "name": "Dzhabe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18564,
+    "price": 19580,
     "weight": 420.0,
-    "tier": 10.1723757,
+    "tier": 10.4761057,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20063,8 +20063,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 81,
-      "speed": 44,
+      "maneuver": 79,
+      "speed": 46,
       "hitPoints": 204
     },
     "weapons": []
@@ -20074,9 +20074,9 @@
     "name": "Karachay Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 21212,
+    "price": 22340,
     "weight": 420.0,
-    "tier": 10.94819,
+    "tier": 11.2639112,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20084,8 +20084,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 82,
-      "speed": 45,
+      "maneuver": 80,
+      "speed": 47,
       "hitPoints": 207
     },
     "weapons": []
@@ -20095,9 +20095,9 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 23347,
+    "price": 24529,
     "weight": 420.0,
-    "tier": 11.5390072,
+    "tier": 11.8546782,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20105,8 +20105,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 82,
-      "speed": 46,
+      "maneuver": 80,
+      "speed": 48,
       "hitPoints": 210
     },
     "weapons": []
@@ -20158,9 +20158,9 @@
     "name": "Fell Pony",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 5931,
+    "price": 6017,
     "weight": 420.0,
-    "tier": 5.29648638,
+    "tier": 5.34199333,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20168,8 +20168,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 69,
-      "speed": 38,
+      "maneuver": 66,
+      "speed": 40,
       "hitPoints": 180
     },
     "weapons": []
@@ -20179,9 +20179,9 @@
     "name": "Welsh Cob",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 6842,
+    "price": 7220,
     "weight": 420.0,
-    "tier": 5.7636447,
+    "tier": 5.94881725,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20189,8 +20189,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 70,
-      "speed": 39,
+      "maneuver": 68,
+      "speed": 41,
       "hitPoints": 183
     },
     "weapons": []
@@ -20200,9 +20200,9 @@
     "name": "Sanhe Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8314,
+    "price": 8769,
     "weight": 420.0,
-    "tier": 6.458555,
+    "tier": 6.660801,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20210,8 +20210,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 72,
-      "speed": 40,
+      "maneuver": 70,
+      "speed": 42,
       "hitPoints": 186
     },
     "weapons": []
@@ -20221,9 +20221,9 @@
     "name": "Megrelakaya Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9931,
+    "price": 10472,
     "weight": 420.0,
-    "tier": 7.155524,
+    "tier": 7.37590265,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20231,8 +20231,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 74,
-      "speed": 41,
+      "maneuver": 72,
+      "speed": 43,
       "hitPoints": 189
     },
     "weapons": []
@@ -20242,9 +20242,9 @@
     "name": "East Anglis Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11843,
+    "price": 12484,
     "weight": 420.0,
-    "tier": 7.9103384,
+    "tier": 8.149946,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20252,8 +20252,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 76,
-      "speed": 42,
+      "maneuver": 74,
+      "speed": 44,
       "hitPoints": 192
     },
     "weapons": []
@@ -20263,9 +20263,9 @@
     "name": "Anadolu Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13580,
+    "price": 14295,
     "weight": 420.0,
-    "tier": 8.54576,
+    "tier": 8.795376,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20273,8 +20273,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 77,
-      "speed": 43,
+      "maneuver": 75,
+      "speed": 45,
       "hitPoints": 195
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -19381,9 +19381,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18160,
+    "price": 18754,
     "weight": 420.0,
-    "tier": 10.0493755,
+    "tier": 10.229785,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19391,8 +19391,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 73,
-      "speed": 49,
+      "maneuver": 71,
+      "speed": 51,
       "hitPoints": 201
     },
     "weapons": []
@@ -19402,9 +19402,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 20690,
+    "price": 21348,
     "weight": 420.0,
-    "tier": 10.7990713,
+    "tier": 10.9864693,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19412,8 +19412,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 74,
-      "speed": 50,
+      "maneuver": 72,
+      "speed": 52,
       "hitPoints": 204
     },
     "weapons": []
@@ -19423,9 +19423,9 @@
     "name": "Darashouri Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 22627,
+    "price": 23299,
     "weight": 420.0,
-    "tier": 11.3427849,
+    "tier": 11.5261393,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19433,8 +19433,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 74,
-      "speed": 51,
+      "maneuver": 72,
+      "speed": 53,
       "hitPoints": 207
     },
     "weapons": []
@@ -19444,9 +19444,9 @@
     "name": "Hengeron",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 25972,
+    "price": 26720,
     "weight": 420.0,
-    "tier": 12.2302046,
+    "tier": 12.420433,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19454,8 +19454,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 75,
-      "speed": 52,
+      "maneuver": 73,
+      "speed": 54,
       "hitPoints": 210
     },
     "weapons": []
@@ -19465,9 +19465,9 @@
     "name": "Shadowfax",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 28333,
+    "price": 29093,
     "weight": 420.0,
-    "tier": 12.822403,
+    "tier": 13.0078049,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19475,8 +19475,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 75,
-      "speed": 53,
+      "maneuver": 73,
+      "speed": 55,
       "hitPoints": 213
     },
     "weapons": []
@@ -19486,9 +19486,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 8476,
+    "price": 8740,
     "weight": 420.0,
-    "tier": 6.531326,
+    "tier": 6.64814949,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19496,8 +19496,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 65,
-      "speed": 45,
+      "maneuver": 63,
+      "speed": 47,
       "hitPoints": 186
     },
     "weapons": []
@@ -19507,9 +19507,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 10150,
+    "price": 10472,
     "weight": 420.0,
-    "tier": 7.245394,
+    "tier": 7.375792,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19517,8 +19517,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 2,
-      "maneuver": 67,
-      "speed": 46,
+      "maneuver": 65,
+      "speed": 48,
       "hitPoints": 189
     },
     "weapons": []
@@ -19528,9 +19528,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 12272,
+    "price": 11960,
     "weight": 420.0,
-    "tier": 8.071199,
+    "tier": 7.95453644,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19538,8 +19538,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 69,
-      "speed": 47,
+      "maneuver": 67,
+      "speed": 48,
       "hitPoints": 192
     },
     "weapons": []
@@ -19549,9 +19549,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 14620,
+    "price": 15095,
     "weight": 420.0,
-    "tier": 8.906923,
+    "tier": 9.067386,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19559,8 +19559,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 71,
-      "speed": 48,
+      "maneuver": 69,
+      "speed": 50,
       "hitPoints": 195
     },
     "weapons": []
@@ -19570,9 +19570,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 16872,
+    "price": 17401,
     "weight": 420.0,
-    "tier": 9.647507,
+    "tier": 9.814344,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19580,8 +19580,8 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 72,
-      "speed": 49,
+      "maneuver": 70,
+      "speed": 51,
       "hitPoints": 198
     },
     "weapons": []
@@ -19801,9 +19801,9 @@
     "name": "Berber Jennet",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16359,
+    "price": 17487,
     "weight": 300.0,
-    "tier": 9.483243,
+    "tier": 9.841122,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19812,7 +19812,7 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 84,
-      "speed": 42,
+      "speed": 43,
       "hitPoints": 195
     },
     "weapons": []
@@ -19822,30 +19822,9 @@
     "name": "Tchenarani Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18921,
+    "price": 20199,
     "weight": 300.0,
-    "tier": 10.2800465,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "mount": {
-      "bodyLength": 95,
-      "chargeDamage": 4,
-      "maneuver": 85,
-      "speed": 43,
-      "hitPoints": 198
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_mount_maneuverable_12",
-    "name": "Asil Purebred Arabian Palfrey",
-    "culture": "Vlandia",
-    "type": "Mount",
-    "price": 20892,
-    "weight": 300.0,
-    "tier": 10.8571081,
+    "tier": 10.6572971,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19855,6 +19834,27 @@
       "chargeDamage": 4,
       "maneuver": 85,
       "speed": 44,
+      "hitPoints": 198
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_maneuverable_12",
+    "name": "Asil Purebred Arabian Palfrey",
+    "culture": "Vlandia",
+    "type": "Mount",
+    "price": 22279,
+    "weight": 300.0,
+    "tier": 11.2468557,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 95,
+      "chargeDamage": 4,
+      "maneuver": 85,
+      "speed": 45,
       "hitPoints": 201
     },
     "weapons": []
@@ -19864,9 +19864,9 @@
     "name": "Marengo",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 23848,
+    "price": 25406,
     "weight": 300.0,
-    "tier": 11.6738739,
+    "tier": 12.084136,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19875,7 +19875,7 @@
       "bodyLength": 95,
       "chargeDamage": 4,
       "maneuver": 86,
-      "speed": 45,
+      "speed": 46,
       "hitPoints": 204
     },
     "weapons": []
@@ -19885,9 +19885,9 @@
     "name": "Baucent",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 26516,
+    "price": 28210,
     "weight": 300.0,
-    "tier": 12.3687677,
+    "tier": 12.79213,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19896,7 +19896,7 @@
       "bodyLength": 95,
       "chargeDamage": 5,
       "maneuver": 86,
-      "speed": 46,
+      "speed": 47,
       "hitPoints": 207
     },
     "weapons": []
@@ -19906,9 +19906,9 @@
     "name": "Irish Hobby",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7737,
+    "price": 8301,
     "weight": 300.0,
-    "tier": 6.194204,
+    "tier": 6.45270348,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19917,7 +19917,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 76,
-      "speed": 38,
+      "speed": 39,
       "hitPoints": 180
     },
     "weapons": []
@@ -19927,9 +19927,9 @@
     "name": "Caspian Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9252,
+    "price": 9918,
     "weight": 300.0,
-    "tier": 6.870263,
+    "tier": 7.150033,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19938,7 +19938,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 78,
-      "speed": 39,
+      "speed": 40,
       "hitPoints": 183
     },
     "weapons": []
@@ -19948,9 +19948,9 @@
     "name": "Marwari Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 11044,
+    "price": 11829,
     "weight": 300.0,
-    "tier": 7.60276127,
+    "tier": 7.90500355,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19959,7 +19959,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 80,
-      "speed": 40,
+      "speed": 41,
       "hitPoints": 186
     },
     "weapons": []
@@ -19969,9 +19969,9 @@
     "name": "Moroccan Barb",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13157,
+    "price": 14080,
     "weight": 300.0,
-    "tier": 8.394953,
+    "tier": 8.72091,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19980,7 +19980,7 @@
       "bodyLength": 95,
       "chargeDamage": 2,
       "maneuver": 82,
-      "speed": 41,
+      "speed": 42,
       "hitPoints": 189
     },
     "weapons": []
@@ -19990,9 +19990,9 @@
     "name": "Morvandiau Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15263,
+    "price": 16311,
     "weight": 300.0,
-    "tier": 9.123802,
+    "tier": 9.467891,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20001,7 +20001,7 @@
       "bodyLength": 95,
       "chargeDamage": 3,
       "maneuver": 83,
-      "speed": 42,
+      "speed": 43,
       "hitPoints": 192
     },
     "weapons": []

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -19,7 +19,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_13" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -36,7 +36,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -53,7 +53,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_11" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +70,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -104,7 +104,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_8" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -121,7 +121,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_7" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -138,7 +138,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_6" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -155,7 +155,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_5" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -172,7 +172,7 @@
   </Item>
       <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="38" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="38" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -223,7 +223,7 @@
   </Item>
     <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="43" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -241,7 +241,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -259,7 +259,7 @@
   </Item>
      <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="7" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="7" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -277,7 +277,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="5" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="5" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="2" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="2" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="65" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="65" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="63" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="63" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="9" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="6" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -753,7 +753,7 @@
   </Item>
       <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="7" body_length="100" is_mountable="true" extra_health="29" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="7" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -771,7 +771,7 @@
   </Item>
    <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="7" body_length="100" is_mountable="true" extra_health="26" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="7" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -789,7 +789,7 @@
   </Item>
     <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="6" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="6" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="4" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="4" body_length="100" is_mountable="true" extra_health="5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="3" body_length="105" is_mountable="true" extra_health="5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="3" body_length="105" is_mountable="true" extra_health="-1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="3" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="3" body_length="105" is_mountable="true" extra_health="-4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -933,7 +933,7 @@
   </Item>
     <Item id="crpg_mount_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -951,7 +951,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -969,7 +969,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -987,7 +987,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1005,7 +1005,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1023,7 +1023,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1041,7 +1041,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1059,7 +1059,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1077,7 +1077,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1095,7 +1095,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1125,77 +1125,77 @@
   </Item>
   <Item id="crpg_camel_16" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_15" name="Achaemenian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_14" name="Achaemenian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_13" name="Parthian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_12" name="Parthian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="29" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_11" name="Tunisian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_camel_10" name="Tunisian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+      <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="29" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_9" name="Nabatean Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_8" name="Nabatean Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="19" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_7" name="Syrian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_6" name="Syrian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="19" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_5" name="Palmyrene War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_4" name="Qedarite War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -223,7 +223,7 @@
   </Item>
     <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -241,7 +241,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -259,7 +259,7 @@
   </Item>
      <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="7" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -277,7 +277,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="5" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="2" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -753,7 +753,7 @@
   </Item>
       <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="7" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -771,7 +771,7 @@
   </Item>
    <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="7" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -789,7 +789,7 @@
   </Item>
     <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="6" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="4" body_length="100" is_mountable="true" extra_health="5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="3" body_length="105" is_mountable="true" extra_health="-1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="3" body_length="105" is_mountable="true" extra_health="-4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -36,7 +36,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +70,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Items>
-  <Item id="crpg_mount_fast_12" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -17,9 +17,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_11" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_13" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -34,9 +34,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount2_fast_10" name="Lusitano Pureblood Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="55" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -51,9 +51,444 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_9" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_11" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="54" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="78" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="77" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_8" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="76" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_7" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="74" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_6" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="72" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_rouncey_5" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="70" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+      <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="69" speed="38" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_mount_rouncey_3" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="60" speed="34" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_mount_rouncey_2" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="56" speed="32" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="0" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="43" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+   <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+     <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="7" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+   <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="5" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="2" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="75" speed="53" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="75" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="74" speed="50" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="53" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="62" speed="52" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-24" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -104,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="60" speed="50" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="67" speed="46" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -121,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="58" speed="48" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-36" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="65" speed="45" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -136,9 +571,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-     <Item id="crpg_mount_charger_12" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+       <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="48" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="9" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -154,9 +589,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_charger_11" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+   <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="47" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -172,9 +607,45 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount2_charger_10" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+     <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="8" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+   <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_black_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -192,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -208,9 +679,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_8" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="8" body_length="105" is_mountable="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="6" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -226,9 +697,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_7" name="Ardennais Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="7" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="5" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -246,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="6" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="4" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -264,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="61" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="-12" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="3" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -280,9 +751,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_balanced_12" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
+      <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="7" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="7" body_length="100" is_mountable="true" extra_health="29" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -298,9 +769,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_balanced_11" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+   <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="6" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="7" body_length="100" is_mountable="true" extra_health="26" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -316,9 +787,45 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount2_balanced_10" name="Parthian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+    <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="46" charge_damage="3" body_length="100" is_mountable="true" extra_health="-1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="6" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_brown_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+   <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_brown_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -336,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="45" charge_damage="3" body_length="100" is_mountable="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="5" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -354,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="2" body_length="100" is_mountable="true" extra_health="-10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="4" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -370,9 +877,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_7" name="Perechon Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="-19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -388,9 +895,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_6" name="Holsteiner Rouncey" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="41" charge_damage="1" body_length="105" is_mountable="true" extra_health="-23" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="3" body_length="105" is_mountable="true" extra_health="5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -406,9 +913,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_5" name="Murgese Rouncey" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="1" body_length="105" is_mountable="true" extra_health="-28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="3" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -424,9 +931,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_12" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+    <Item id="crpg_mount_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -442,9 +949,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_11" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -460,9 +967,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount2_maneuverable_10" name="Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-12" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -478,9 +985,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_9" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-16" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -496,9 +1003,9 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_8" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-21" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -514,9 +1021,45 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_7" name="Mongolian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="steppe_horse">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="steppe_horse">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -534,7 +1077,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-34" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -552,7 +1095,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-40" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -568,57 +1111,105 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mule2_1" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.mule" maneuver="58" speed="30" charge_damage="0" body_length="92" is_mountable="true" extra_health="100" is_pack_animal="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mule2_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+    <Item id="crpg_mule_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.mule" maneuver="60" speed="33" charge_damage="1" body_length="92" is_mountable="true" extra_health="175" is_pack_animal="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel2_11" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_16" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="6" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel2_10" name="Achaemenian War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_15" name="Achaemenian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="35" charge_damage="5" body_length="110" extra_health="54" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_9" name="Parthian War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_14" name="Achaemenian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="34" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_8" name="Nabatean War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_13" name="Parthian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="33" charge_damage="5" body_length="110" extra_health="42" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_7" name="Palmyrene War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_12" name="Parthian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_11" name="Tunisian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+      <Item id="crpg_camel_10" name="Tunisian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_camel_9" name="Nabatean Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_8" name="Nabatean Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_7" name="Syrian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_6" name="Syrian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_camel_5" name="Palmyrene War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_6" name="Qedarite War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_4" name="Qedarite War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="75" speed="31" charge_damage="2" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_5" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_3" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="72" speed="30" charge_damage="2" body_length="110" extra_health="18" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="10" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -476,7 +476,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="steppe_horse">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -401,7 +401,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
@@ -418,7 +418,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
@@ -435,7 +435,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
@@ -452,7 +452,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
@@ -469,7 +469,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
@@ -486,7 +486,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
@@ -503,7 +503,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
@@ -520,7 +520,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
@@ -537,7 +537,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
@@ -554,7 +554,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
@@ -571,7 +571,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-       <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+       <Item id="crpg_mount1_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
@@ -589,7 +589,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+   <Item id="crpg_mount1_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
@@ -607,7 +607,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-     <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+     <Item id="crpg_mount1_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
@@ -625,7 +625,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+   <Item id="crpg_mount1_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="75" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
@@ -643,7 +643,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
@@ -661,7 +661,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="73" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
@@ -679,7 +679,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="72" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
@@ -697,7 +697,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="70" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
@@ -715,7 +715,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="68" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
@@ -733,7 +733,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="66" speed="39" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
@@ -751,7 +751,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
+      <Item id="crpg_mount1_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
@@ -769,7 +769,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+   <Item id="crpg_mount1_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
@@ -787,7 +787,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
+    <Item id="crpg_mount1_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="81" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
@@ -805,7 +805,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+   <Item id="crpg_mount1_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="81" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
@@ -823,7 +823,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="80" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
@@ -841,7 +841,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="79" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
@@ -859,7 +859,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_8" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_8" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
@@ -877,7 +877,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
@@ -895,7 +895,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
@@ -913,7 +913,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="72" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
@@ -931,7 +931,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+    <Item id="crpg_mount1_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -949,7 +949,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -967,7 +967,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -985,7 +985,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="85" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1003,7 +1003,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1021,7 +1021,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="83" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1039,7 +1039,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1057,7 +1057,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1075,7 +1075,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="78" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1093,7 +1093,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1111,109 +1111,109 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mule" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule2_1" name="Mule" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.mule" maneuver="58" speed="30" charge_damage="0" body_length="92" is_mountable="true" extra_health="100" is_pack_animal="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mule_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+    <Item id="crpg_mule2_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.mule" maneuver="60" speed="33" charge_damage="1" body_length="92" is_mountable="true" extra_health="175" is_pack_animal="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_17" name="Padishah" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_17" name="Padishah" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_16" name="Safinat al-Barr" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_16" name="Safinat al-Barr" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="85" speed="37" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+      <Item id="crpg_mount_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="28" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_3" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_3" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_mount_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="53" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="55" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="53" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="50" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="50" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="67" speed="46" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="65" speed="48" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="65" speed="45" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="63" speed="47" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -933,7 +933,7 @@
   </Item>
     <Item id="crpg_mount_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="7" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -951,7 +951,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="4" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -969,7 +969,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -987,7 +987,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1005,7 +1005,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1023,7 +1023,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1041,7 +1041,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1059,7 +1059,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1077,7 +1077,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1095,7 +1095,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1125,13 +1125,13 @@
   </Item>
   <Item id="crpg_camel_16" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="60" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="59" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="57" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
@@ -1143,25 +1143,25 @@
   </Item>
   <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="48" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="29" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="48" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
       <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="29" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
@@ -1173,7 +1173,7 @@
   </Item>
     <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="19" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="21" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
@@ -1185,13 +1185,13 @@
   </Item>
     <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="19" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="21" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="36" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
@@ -1203,13 +1203,13 @@
   </Item>
   <Item id="crpg_camel_3" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="24" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="10" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="12" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -7,7 +7,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -24,7 +24,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -41,7 +41,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -58,7 +58,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -75,7 +75,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -92,7 +92,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -109,7 +109,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -126,7 +126,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -143,7 +143,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -160,7 +160,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -177,7 +177,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -194,7 +194,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -228,7 +228,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_white_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -264,7 +264,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -282,7 +282,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -300,7 +300,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -318,7 +318,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -336,7 +336,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -354,7 +354,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -372,7 +372,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1177,13 +1177,13 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_7" name="Syrian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_7" name="Sargonid Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_6" name="Syrian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_6" name="Sargonid Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -776,7 +776,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="steppe_horse">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -19,7 +19,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_13" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -36,7 +36,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -53,7 +53,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_11" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +70,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -104,7 +104,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_8" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -121,7 +121,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_7" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -138,7 +138,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_6" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="40" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -155,7 +155,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_5" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="39" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -459,7 +459,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -510,7 +510,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -668,7 +668,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1100,7 +1100,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1123,7 +1123,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_17" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_17" name="Padishah" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -223,7 +223,7 @@
   </Item>
     <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="41" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -241,7 +241,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="39" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -259,7 +259,7 @@
   </Item>
      <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -277,7 +277,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -92,7 +92,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="steppe_horse">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="9" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="39" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="36" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="8" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="6" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="5" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="4" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="3" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1129,73 +1129,73 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_15" name="Achaemenian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_14" name="Achaemenian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_13" name="Parthian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_12" name="Parthian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_11" name="Tunisian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+      <Item id="crpg_camel_10" name="Tunisian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_9" name="Nabatean Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_8" name="Nabatean Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_7" name="Syrian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_6" name="Syrian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_5" name="Palmyrene War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_4" name="Qedarite War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -189,7 +189,7 @@
   </Item>
     <Item id="crpg_mount_rouncey_3" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="60" speed="34" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="36" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -206,7 +206,7 @@
   </Item>
     <Item id="crpg_mount_rouncey_2" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="56" speed="32" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="0" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="60" speed="34" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="0" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -7,7 +7,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -24,7 +24,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -58,7 +58,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -75,7 +75,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -109,7 +109,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -126,7 +126,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -160,7 +160,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="horse_white_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -221,14 +221,14 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+    <Item id="crpg_mount_greathorse_14" name="Percheron Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="84" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -264,7 +264,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -282,7 +282,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -300,7 +300,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -318,7 +318,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -354,7 +354,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -390,7 +390,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -442,7 +442,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -459,7 +459,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -510,7 +510,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -544,7 +544,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -561,7 +561,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_white_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
             </MeshMultipliers>
@@ -596,7 +596,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -632,7 +632,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -650,7 +650,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -686,7 +686,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -722,7 +722,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -740,7 +740,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_black_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -758,7 +758,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -776,7 +776,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -794,7 +794,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -830,7 +830,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -848,7 +848,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -859,14 +859,14 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_balanced_8" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -902,7 +902,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1153,13 +1153,13 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_11" name="Tunisian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_11" name="Seleucid Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_camel_10" name="Tunisian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+      <Item id="crpg_camel_10" name="Seleucid Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="55" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="53" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="51" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="50" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="65" speed="48" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="65" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="63" speed="47" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="63" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -223,7 +223,7 @@
   </Item>
     <Item id="crpg_mount_greathorse_14" name="Perechon Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="41" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -241,7 +241,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -259,7 +259,7 @@
   </Item>
      <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="40" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -277,7 +277,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="37" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="35" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="34" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="54" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="53" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="52" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="51" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="67" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="65" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="63" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -753,7 +753,7 @@
   </Item>
       <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -771,7 +771,7 @@
   </Item>
    <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -789,7 +789,7 @@
   </Item>
     <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="40" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="39" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="38" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="36" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -933,7 +933,7 @@
   </Item>
     <Item id="crpg_mount_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="47" charge_damage="5" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -951,7 +951,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_13" name="Marengo" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="86" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="-2" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -969,7 +969,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_12" name="Asil Purebred Arabian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="45" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-5" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -987,7 +987,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="44" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="85" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1005,7 +1005,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1023,7 +1023,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1041,7 +1041,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1059,7 +1059,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1077,7 +1077,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1095,7 +1095,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -19,7 +19,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_13" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -36,7 +36,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -53,7 +53,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_11" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +70,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -104,7 +104,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_8" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -121,7 +121,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_7" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="41" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -138,7 +138,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_6" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="40" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -155,7 +155,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_5" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="39" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -172,7 +172,7 @@
   </Item>
       <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="38" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -753,7 +753,7 @@
   </Item>
       <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -771,7 +771,7 @@
   </Item>
    <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -789,7 +789,7 @@
   </Item>
     <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="40" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="39" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="38" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="36" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="33" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="48" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="30" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="27" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="24" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="21" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="18" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="15" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="12" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="9" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="6" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -753,7 +753,7 @@
   </Item>
       <Item id="crpg_mount_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="23" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -771,7 +771,7 @@
   </Item>
    <Item id="crpg_mount_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -789,7 +789,7 @@
   </Item>
     <Item id="crpg_mount_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount_balanced_8" name="Fresian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1125,91 +1125,91 @@
   </Item>
   <Item id="crpg_camel_16" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="60" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="57" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="48" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="48" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
       <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="21" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="39" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="21" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="36" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="34" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="28" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_camel_3" name="Pratihara Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="24" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="76" speed="30" charge_damage="2" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
     <Item id="crpg_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="12" is_pack_animal="true" is_mountable="true" />
+      <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1005,7 +1005,7 @@
   </Item>
   <Item id="crpg_mount_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1129,73 +1129,73 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_15" name="Achaemenian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_15" name="Achaemenian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="6" body_length="110" extra_health="65" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_14" name="Achaemenian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_13" name="Parthian Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_13" name="Parthian Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_12" name="Parthian Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_11" name="Seleucid Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="55" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_camel_10" name="Seleucid Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+      <Item id="crpg_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_9" name="Nabatean Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_9" name="Nabatean Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_8" name="Nabatean Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_7" name="Sargonid Heavy War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="45" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_camel_6" name="Sargonid Light War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <Item id="crpg_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="25" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_5" name="Palmyrene War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_5" name="Palmyrene Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="78" speed="32" charge_damage="4" body_length="110" extra_health="35" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_4" name="Qedarite War Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_4" name="Qedarite Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="77" speed="31" charge_damage="3" body_length="110" extra_health="30" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1123,9 +1123,15 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_camel_16" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_camel_17" name="Padisha" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="86" speed="38" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+    <Item id="crpg_camel_16" name="Safinat al-Barr" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.camel" maneuver="85" speed="37" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="69" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="67" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="65" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -19,7 +19,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_13" name="Karachay Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="47" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -36,7 +36,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_12" name="Dzhabe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="77" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -53,7 +53,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_11" name="Bidet Breton Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -70,7 +70,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_10" name="Black Forest Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -87,7 +87,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_9" name="Anadolu Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -104,7 +104,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_8" name="East Anglis Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -121,7 +121,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_7" name="Megrelakaya Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="43" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -138,7 +138,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_6" name="Sanhe Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="42" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -155,7 +155,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_5" name="Welsh Cob" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="41" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -172,7 +172,7 @@
   </Item>
       <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -189,7 +189,7 @@
   </Item>
     <Item id="crpg_mount_rouncey_3" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="36" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="62" speed="38" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="69" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="67" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="65" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -632,7 +632,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown2_mat">
+          <Material name="steppe_horse">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -740,7 +740,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="steppe_horse">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -884,7 +884,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_brown_mat">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -956,7 +956,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -974,7 +974,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -992,7 +992,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_white_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1028,7 +1028,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1046,7 +1046,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1064,7 +1064,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_brown2_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1082,7 +1082,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_grey_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
@@ -1100,7 +1100,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="steppe_horse">
+          <Material name="horse_black_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -2,7 +2,7 @@
 <Items>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="46" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -403,7 +403,7 @@
   </Item>
   <Item id="crpg_mount_fast_14" name="Shadowfax" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="52" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -420,7 +420,7 @@
   </Item>
   <Item id="crpg_mount_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -437,7 +437,7 @@
   </Item>
   <Item id="crpg_mount_fast_12" name="Darashouri Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="50" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-17" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -573,7 +573,7 @@
   </Item>
        <Item id="crpg_mount_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="47" charge_damage="10" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -591,7 +591,7 @@
   </Item>
    <Item id="crpg_mount_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="46" charge_damage="10" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -609,7 +609,7 @@
   </Item>
      <Item id="crpg_mount_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="45" charge_damage="9" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="44" charge_damage="9" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="75" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="43" charge_damage="8" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="7" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="6" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="5" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="39" charge_damage="4" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="39" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>


### PR DESCRIPTION
Don't have to approve anytime soon or at all. Could some beta testing be done though?

Added Rouncey and Great Horse archetype. Relevelled and rescaled the tiers and archetypes - plateaus at the higher tiers (if this seems like too little of a difference and/or too many mounts, a regular scale can be put back in which would provide more tier 5 mounts, or the split-tier can be removed altogether to reduce overall amount):
https://docs.google.com/spreadsheets/d/1luwvL72ImLhD-NW47wwFmCOLjAwMrR6LUka5cydIHnI/edit?usp=sharing

Archetypes explained etc on sheet. Also added in a comparison to main for stats, with the Rouncey compared to Balanced mounts, and the Great Horse compared to Charger mounts. Left in Sargonid and Seleucid camels unintentionally, but they fill in the gaps of the tier structure.