### PR TITLE
Replace Simple Short Spear nerf glaive and hoplite

### DIFF
--- a/items.json
+++ b/items.json
@@ -13961,7 +13961,7 @@
     "culture": "Vlandia",
     "type": "Polearm",
     "price": 7930,
-    "weight": 0.83,
+    "weight": 1.9,
     "tier": 6.68435526,
     "requirement": 0,
     "flags": [],
@@ -13974,7 +13974,7 @@
         "stackAmount": 0,
         "length": 152,
         "balance": 0.0,
-        "handling": 76,
+        "handling": 73,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -13984,7 +13984,7 @@
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
+        "thrustSpeed": 84,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
         "swingSpeed": 58
@@ -16239,7 +16239,7 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 95,
+        "thrustSpeed": 84,
         "swingDamage": 41,
         "swingDamageType": "Cut",
         "swingSpeed": 84
@@ -32007,12 +32007,12 @@
   },
   {
     "id": "crpg_western_spear_2_t2",
-    "name": "Simple Short Spear",
+    "name": "War Spear", 
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 471,
+    "price": 12871,
     "weight": 1.08,
-    "tier": 0.975268245,
+    "tier": 8.975268245,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32024,18 +32024,18 @@
         "stackAmount": 0,
         "length": 156,
         "balance": 0.0,
-        "handling": 72,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "WideGrip"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 28,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
-        "swingDamage": 14,
+        "swingDamage": 36,
         "swingDamageType": "Blunt",
-        "swingSpeed": 49
+        "swingSpeed": 89
       },
       {
         "class": "TwoHandedPolearm",

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -448,7 +448,7 @@
       <Piece id="crpg_western_spear_1_t2_handle" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_western_spear_2_t2" name="{=bue69aD4}Simple Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_western_spear_2_t2" name="{=bue69aD4}War Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_western_spear_2_t2_blade" Type="Blade" scale_factor="90" />
       <Piece id="crpg_western_spear_2_t2_handle" Type="Handle" scale_factor="90" />


### PR DESCRIPTION
1) I replaced Simple Short Spear with War Spear, a popular weapon from Warband
2) Nerfed the thrust speed on Glaive, because a lot of people were complaining about it being OP
3) Nerfed the Hoplite Spear by increasing weight and reducing thrust speed making it more like its supposed tier

