### PR TITLE
ReworkMidTier2hSwords

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -5034,10 +5034,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="0.70">
+  <CraftingPiece id="crpg_western_2hsword_t3_blade" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5229,11 +5229,11 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_2hsword_t4_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.15">
+  <CraftingPiece id="crpg_ridged_2hsword_t4_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.18">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="1.3" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -5409,8 +5409,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_battania_2hsword_1_t2_blade" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Cut" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="1.00" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5481,8 +5481,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_battania_2hsword_2_t3_blade" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.07">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5862,10 +5862,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_justicier_2hsword_blade" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.45">
+  <CraftingPiece id="crpg_justicier_2hsword_blade" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.47">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.1" />
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -3150,9 +3150,9 @@
     "name": "Iron Broadsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 928,
+    "price": 1208,
     "weight": 1.84,
-    "tier": 1.8541683,
+    "tier": 2.239231,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3172,10 +3172,10 @@
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
-        "swingDamage": 24,
+        "swingDamage": 25,
         "swingDamageType": "Cut",
         "swingSpeed": 97
       }
@@ -3186,9 +3186,9 @@
     "name": "Highland Broadsword",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 3022,
+    "price": 4102,
     "weight": 1.82,
-    "tier": 4.09065628,
+    "tier": 4.932007,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3207,10 +3207,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 80
       },
@@ -3228,10 +3228,10 @@
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 97
       },
@@ -3248,10 +3248,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 80
       }
@@ -15238,9 +15238,9 @@
     "name": "Justicier",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 1048,
-    "weight": 2.1,
-    "tier": 2.02536345,
+    "price": 3774,
+    "weight": 2.27,
+    "tier": 4.68924475,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -15252,20 +15252,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 117,
-        "balance": 0.68,
-        "handling": 85,
+        "length": 127,
+        "balance": 0.53,
+        "handling": 83,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 11,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 26,
+        "thrustSpeed": 91,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 86
       }
     ]
   },
@@ -25325,9 +25325,9 @@
     "name": "Ridged Great Saber",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 4057,
-    "weight": 1.85,
-    "tier": 4.89896059,
+    "price": 5141,
+    "weight": 1.91,
+    "tier": 5.64338636,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -25337,20 +25337,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
-        "balance": 0.95,
-        "handling": 89,
+        "length": 114,
+        "balance": 0.9,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
-        "swingDamage": 28,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 97
       }
     ]
   },
@@ -33492,9 +33492,9 @@
     "name": "Tapered Two-Hander",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 886,
-    "weight": 1.48,
-    "tier": 1.79250336,
+    "price": 3200,
+    "weight": 2.45,
+    "tier": 4.23856068,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33506,19 +33506,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 133,
-        "balance": 0.38,
-        "handling": 84,
+        "length": 145,
+        "balance": 0.0,
+        "handling": 67,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 20,
+        "thrustSpeed": 82,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 55
       },
       {
         "class": "TwoHandedSword",
@@ -33526,20 +33526,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 133,
-        "balance": 0.93,
-        "handling": 89,
+        "length": 145,
+        "balance": 0.29,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 20,
+        "thrustSpeed": 89,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 78
       },
       {
         "class": "OneHandedSword",
@@ -33547,19 +33547,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 133,
-        "balance": 0.38,
-        "handling": 84,
+        "length": 145,
+        "balance": 0.0,
+        "handling": 67,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 20,
+        "thrustSpeed": 82,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 55
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -220,7 +220,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_justicier_2hsword" name="{=a47UTuL6}Justicier" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_justicier_2hsword_blade" Type="Blade" scale_factor="112" />
+      <Piece id="crpg_justicier_2hsword_blade" Type="Blade" scale_factor="122" />
       <Piece id="crpg_justicier_2hsword_guard" Type="Guard" />
       <Piece id="crpg_justicier_2hsword_handle" Type="Handle" scale_factor="96" />
       <Piece id="crpg_justicier_2hsword_pommel" Type="Pommel" scale_factor="93" />
@@ -1430,7 +1430,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_western_2hsword_t3" name="{=ekUvh8Em}Tapered Two-Hander" crafting_template="crpg_TwoHandedSword" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_western_2hsword_t3_blade" Type="Blade" scale_factor="145" />
+      <Piece id="crpg_western_2hsword_t3_blade" Type="Blade" scale_factor="159" />
       <Piece id="crpg_western_2hsword_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_western_2hsword_t3_handle" Type="Handle" scale_factor="105" />
       <Piece id="crpg_western_2hsword_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1478,7 +1478,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_ridged_2hsword_t4" name="{=mMtKWolp}Ridged Great Saber" crafting_template="crpg_TwoHandedSword" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_ridged_2hsword_t4_blade" Type="Blade" scale_factor="104" />
+      <Piece id="crpg_ridged_2hsword_t4_blade" Type="Blade" scale_factor="107" />
       <Piece id="crpg_ridged_2hsword_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_ridged_2hsword_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_ridged_2hsword_t4_pommel" Type="Pommel" scale_factor="100" />


### PR DESCRIPTION
Buffed some mid-tier 2h swords and a low tier 2h.


Tapered two-hander 
swing damage: 20 ->34
swing speed: 81 ->78
thrust damage: 12 ->16
thrust speed: 90 ->89
reach: 133 ->145
handling: 84 ->78

Iron Broadsword
swing damage: 24 ->25
swing speed: 97 ->97
thrust damage: 9 ->10
thrust speed: 94 ->94
reach: 104 ->104
handling: 89 ->89

Highland Broadsword
swing damage: 27 ->28
swing speed: 80 ->97
thrust damage: 12 ->14
thrust speed: 88 ->94
reach: 113 ->113
handling: 84 ->89

Ridged Great Saber
swing damage: 28 ->29
swing speed: 98 ->97
thrust damage: 13 ->14
thrust speed: 94 ->94
reach: 118 ->114
handling: 89 ->88

Justicier
swing damage: 26 ->32
swing speed: 90 ->86
thrust damage: 11 ->14
thrust speed: 92 ->97
reach: 117 ->127
handling: 85 ->83
