### PR TITLE
Mount Rebalancing v1.2

### DIFF
--- a/items.json
+++ b/items.json
@@ -19762,6 +19762,27 @@
     "weapons": []
   },
   {
+    "id": "crpg_mount_greathorse_15",
+    "name": "Lionheart",
+    "culture": "Empire",
+    "type": "Mount",
+    "price": 27707,
+    "weight": 450.0,
+    "tier": 12.6679363,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 105,
+      "chargeDamage": 9,
+      "maneuver": 84,
+      "speed": 41,
+      "hitPoints": 243
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_mount_greathorse_5",
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
@@ -19968,6 +19989,27 @@
       "maneuver": 78,
       "speed": 48,
       "hitPoints": 210
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_mount_rouncey_15",
+    "name": "Kehilan al-Khamsa",
+    "culture": "Neutral",
+    "type": "Mount",
+    "price": 25150,
+    "weight": 420.0,
+    "tier": 12.0175943,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "mount": {
+      "bodyLength": 100,
+      "chargeDamage": 4,
+      "maneuver": 78,
+      "speed": 49,
+      "hitPoints": 213
     },
     "weapons": []
   },
@@ -20414,7 +20456,7 @@
   },
   {
     "id": "crpg_mount1_charger_13",
-    "name": "Lionheart",
+    "name": "Hengeron",
     "culture": "Vlandia",
     "type": "Mount",
     "price": 24943,
@@ -20624,7 +20666,7 @@
   },
   {
     "id": "crpg_mount1_fast_13",
-    "name": "Hengeron",
+    "name": "Muniqi al-Khamsa",
     "culture": "Neutral",
     "type": "Mount",
     "price": 23910,

--- a/items.json
+++ b/items.json
@@ -19661,9 +19661,9 @@
     "name": "Barthais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17238,
+    "price": 16650,
     "weight": 450.0,
-    "tier": 9.763345,
+    "tier": 9.576936,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19671,7 +19671,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 82,
+      "maneuver": 81,
       "speed": 38,
       "hitPoints": 228
     },
@@ -19682,9 +19682,9 @@
     "name": "Brabant Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18849,
+    "price": 18219,
     "weight": 450.0,
-    "tier": 10.2583418,
+    "tier": 10.0673294,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19692,7 +19692,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 83,
+      "maneuver": 82,
       "speed": 38,
       "hitPoints": 231
     },
@@ -19766,9 +19766,9 @@
     "name": "Suffolk Punch Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7247,
+    "price": 6729,
     "weight": 450.0,
-    "tier": 5.961785,
+    "tier": 5.707611,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19776,7 +19776,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 74,
+      "maneuver": 72,
       "speed": 33,
       "hitPoints": 213
     },
@@ -19787,9 +19787,9 @@
     "name": "Boulonnais Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8837,
+    "price": 8216,
     "weight": 450.0,
-    "tier": 6.690727,
+    "tier": 6.41457,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19797,7 +19797,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 76,
+      "maneuver": 74,
       "speed": 34,
       "hitPoints": 216
     },
@@ -19808,9 +19808,9 @@
     "name": "Galloway Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10764,
+    "price": 10022,
     "weight": 450.0,
-    "tier": 7.492402,
+    "tier": 7.19298363,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19818,7 +19818,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 78,
+      "maneuver": 76,
       "speed": 35,
       "hitPoints": 219
     },
@@ -19829,9 +19829,9 @@
     "name": "Poitevin Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12824,
+    "price": 11949,
     "weight": 450.0,
-    "tier": 8.274528,
+    "tier": 7.95053339,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19839,7 +19839,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 80,
+      "maneuver": 78,
       "speed": 36,
       "hitPoints": 222
     },
@@ -19850,9 +19850,9 @@
     "name": "Oberlander Great Horse",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15048,
+    "price": 14534,
     "weight": 450.0,
-    "tier": 9.051661,
+    "tier": 8.877398,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19860,7 +19860,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 81,
+      "maneuver": 80,
       "speed": 37,
       "hitPoints": 225
     },
@@ -20144,9 +20144,9 @@
     "name": "Yunnan Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17369,
+    "price": 16755,
     "weight": 430.0,
-    "tier": 9.804319,
+    "tier": 9.610231,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20154,7 +20154,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 80,
+      "maneuver": 79,
       "speed": 42,
       "hitPoints": 210
     },
@@ -20165,9 +20165,9 @@
     "name": "Auvergne Destrier",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 18924,
+    "price": 18266,
     "weight": 430.0,
-    "tier": 10.2807808,
+    "tier": 10.08158,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20175,7 +20175,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 7,
-      "maneuver": 81,
+      "maneuver": 80,
       "speed": 42,
       "hitPoints": 213
     },
@@ -20249,9 +20249,9 @@
     "name": "Murgese Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7572,
+    "price": 7014,
     "weight": 450.0,
-    "tier": 6.11679459,
+    "tier": 5.8485837,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20259,7 +20259,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 72,
+      "maneuver": 70,
       "speed": 37,
       "hitPoints": 195
     },
@@ -20270,9 +20270,9 @@
     "name": "Holsteiner Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9053,
+    "price": 8392,
     "weight": 430.0,
-    "tier": 6.784462,
+    "tier": 6.493924,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20280,7 +20280,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 74,
+      "maneuver": 72,
       "speed": 38,
       "hitPoints": 198
     },
@@ -20291,9 +20291,9 @@
     "name": "Kathiawadi Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10968,
+    "price": 10183,
     "weight": 430.0,
-    "tier": 7.572814,
+    "tier": 7.25868273,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20301,7 +20301,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 76,
+      "maneuver": 74,
       "speed": 39,
       "hitPoints": 201
     },
@@ -20312,9 +20312,9 @@
     "name": "Friesian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13051,
+    "price": 12128,
     "weight": 430.0,
-    "tier": 8.356689,
+    "tier": 8.017658,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20322,7 +20322,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 78,
+      "maneuver": 76,
       "speed": 40,
       "hitPoints": 204
     },
@@ -20333,9 +20333,9 @@
     "name": "Carthusian Destrier",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15193,
+    "price": 14654,
     "weight": 430.0,
-    "tier": 9.100216,
+    "tier": 8.918327,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20343,7 +20343,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 6,
-      "maneuver": 79,
+      "maneuver": 78,
       "speed": 41,
       "hitPoints": 207
     },
@@ -20354,9 +20354,9 @@
     "name": "Desert Norman Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 17672,
+    "price": 17003,
     "weight": 450.0,
-    "tier": 9.898636,
+    "tier": 9.689158,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20364,7 +20364,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 74,
+      "maneuver": 73,
       "speed": 44,
       "hitPoints": 219
     },
@@ -20375,9 +20375,9 @@
     "name": "Andravida Charger",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 19412,
+    "price": 18693,
     "weight": 450.0,
-    "tier": 10.4262953,
+    "tier": 10.2113171,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20385,7 +20385,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 8,
-      "maneuver": 75,
+      "maneuver": 74,
       "speed": 44,
       "hitPoints": 222
     },
@@ -20459,9 +20459,9 @@
     "name": "Norwegian Fjord Draught",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7423,
+    "price": 6823,
     "weight": 450.0,
-    "tier": 6.04603052,
+    "tier": 5.75440836,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20469,7 +20469,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 3,
-      "maneuver": 66,
+      "maneuver": 64,
       "speed": 39,
       "hitPoints": 204
     },
@@ -20480,9 +20480,9 @@
     "name": "Icelandic Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 9031,
+    "price": 8316,
     "weight": 450.0,
-    "tier": 6.77499628,
+    "tier": 6.459526,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20490,7 +20490,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 4,
-      "maneuver": 68,
+      "maneuver": 66,
       "speed": 40,
       "hitPoints": 207
     },
@@ -20501,9 +20501,9 @@
     "name": "Shire Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10959,
+    "price": 10109,
     "weight": 450.0,
-    "tier": 7.56927633,
+    "tier": 7.22863865,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20511,7 +20511,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 5,
-      "maneuver": 70,
+      "maneuver": 68,
       "speed": 41,
       "hitPoints": 210
     },
@@ -20522,9 +20522,9 @@
     "name": "Ardennes Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 13282,
+    "price": 12275,
     "weight": 450.0,
-    "tier": 8.439761,
+    "tier": 8.072592,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20532,7 +20532,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 6,
-      "maneuver": 72,
+      "maneuver": 70,
       "speed": 42,
       "hitPoints": 213
     },
@@ -20543,9 +20543,9 @@
     "name": "Andalusian Charger",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 15500,
+    "price": 14913,
     "weight": 450.0,
-    "tier": 9.202708,
+    "tier": 9.006035,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20553,7 +20553,7 @@
     "mount": {
       "bodyLength": 105,
       "chargeDamage": 7,
-      "maneuver": 73,
+      "maneuver": 72,
       "speed": 43,
       "hitPoints": 216
     },
@@ -20564,9 +20564,9 @@
     "name": "Ahalteke Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 17651,
+    "price": 16952,
     "weight": 420.0,
-    "tier": 9.892221,
+    "tier": 9.672839,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20574,7 +20574,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 72,
+      "maneuver": 71,
       "speed": 49,
       "hitPoints": 201
     },
@@ -20585,9 +20585,9 @@
     "name": "Datong Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 18984,
+    "price": 18239,
     "weight": 420.0,
-    "tier": 10.2989645,
+    "tier": 10.0734215,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20595,7 +20595,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 73,
+      "maneuver": 72,
       "speed": 49,
       "hitPoints": 204
     },
@@ -20669,9 +20669,9 @@
     "name": "Turkoman Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 7750,
+    "price": 7102,
     "weight": 420.0,
-    "tier": 6.200236,
+    "tier": 5.891725,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20679,7 +20679,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 64,
+      "maneuver": 62,
       "speed": 44,
       "hitPoints": 186
     },
@@ -20690,9 +20690,9 @@
     "name": "Menorquín Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 9280,
+    "price": 8516,
     "weight": 420.0,
-    "tier": 6.88217068,
+    "tier": 6.54915428,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20700,7 +20700,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 3,
-      "maneuver": 66,
+      "maneuver": 64,
       "speed": 45,
       "hitPoints": 189
     },
@@ -20711,9 +20711,9 @@
     "name": "Nisean Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 11236,
+    "price": 10330,
     "weight": 420.0,
-    "tier": 7.67751741,
+    "tier": 7.31866837,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20721,7 +20721,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 68,
+      "maneuver": 66,
       "speed": 46,
       "hitPoints": 192
     },
@@ -20732,9 +20732,9 @@
     "name": "Thessalian Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 13388,
+    "price": 12326,
     "weight": 420.0,
-    "tier": 8.477386,
+    "tier": 8.091337,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20742,7 +20742,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 4,
-      "maneuver": 70,
+      "maneuver": 68,
       "speed": 47,
       "hitPoints": 195
     },
@@ -20753,9 +20753,9 @@
     "name": "Einsiedler Courser",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 15484,
+    "price": 14868,
     "weight": 420.0,
-    "tier": 9.197222,
+    "tier": 8.990841,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20763,7 +20763,7 @@
     "mount": {
       "bodyLength": 100,
       "chargeDamage": 5,
-      "maneuver": 71,
+      "maneuver": 70,
       "speed": 48,
       "hitPoints": 198
     },
@@ -20774,9 +20774,9 @@
     "name": "Berber Jennet",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 16309,
+    "price": 15750,
     "weight": 300.0,
-    "tier": 9.467125,
+    "tier": 9.28492451,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20784,7 +20784,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 3,
-      "maneuver": 84,
+      "maneuver": 83,
       "speed": 43,
       "hitPoints": 189
     },
@@ -20795,9 +20795,9 @@
     "name": "Tchenarani Palfrey",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 17667,
+    "price": 17069,
     "weight": 300.0,
-    "tier": 9.897135,
+    "tier": 9.709838,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20805,7 +20805,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 4,
-      "maneuver": 85,
+      "maneuver": 84,
       "speed": 43,
       "hitPoints": 192
     },
@@ -20879,9 +20879,9 @@
     "name": "Irish Hobby",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 7201,
+    "price": 6690,
     "weight": 300.0,
-    "tier": 5.93948174,
+    "tier": 5.688221,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20889,7 +20889,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 76,
+      "maneuver": 74,
       "speed": 38,
       "hitPoints": 174
     },
@@ -20900,9 +20900,9 @@
     "name": "Caspian Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 8612,
+    "price": 8008,
     "weight": 300.0,
-    "tier": 6.59189034,
+    "tier": 6.3196454,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20910,7 +20910,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 78,
+      "maneuver": 76,
       "speed": 39,
       "hitPoints": 177
     },
@@ -20921,9 +20921,9 @@
     "name": "Marwari Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 10282,
+    "price": 9570,
     "weight": 300.0,
-    "tier": 7.299211,
+    "tier": 7.00477743,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20931,7 +20931,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 80,
+      "maneuver": 78,
       "speed": 40,
       "hitPoints": 180
     },
@@ -20942,9 +20942,9 @@
     "name": "Moroccan Barb",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 12254,
+    "price": 11415,
     "weight": 300.0,
-    "tier": 8.064646,
+    "tier": 7.746775,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20952,7 +20952,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 2,
-      "maneuver": 82,
+      "maneuver": 80,
       "speed": 41,
       "hitPoints": 183
     },
@@ -20963,9 +20963,9 @@
     "name": "Morvandiau Palfrey",
     "culture": "Khuzait",
     "type": "Mount",
-    "price": 14228,
+    "price": 13738,
     "weight": 300.0,
-    "tier": 8.772116,
+    "tier": 8.601491,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20973,7 +20973,7 @@
     "mount": {
       "bodyLength": 95,
       "chargeDamage": 3,
-      "maneuver": 83,
+      "maneuver": 82,
       "speed": 42,
       "hitPoints": 186
     },

--- a/items.json
+++ b/items.json
@@ -19976,16 +19976,16 @@
     "name": "Unmol Rouncey",
     "culture": "Neutral",
     "type": "Mount",
-    "price": 22748,
+    "price": 22953,
     "weight": 420.0,
-    "tier": 11.3760147,
+    "tier": 11.43211,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 100,
-      "chargeDamage": 3,
+      "chargeDamage": 4,
       "maneuver": 78,
       "speed": 48,
       "hitPoints": 210

--- a/items.json
+++ b/items.json
@@ -19724,16 +19724,16 @@
     "name": "English Black Great Horse",
     "culture": "Vlandia",
     "type": "Mount",
-    "price": 22902,
+    "price": 22128,
     "weight": 450.0,
-    "tier": 11.4182129,
+    "tier": 11.2051754,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "mount": {
       "bodyLength": 105,
-      "chargeDamage": 9,
+      "chargeDamage": 8,
       "maneuver": 84,
       "speed": 39,
       "hitPoints": 237

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -277,7 +277,7 @@
   </Item>
    <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -295,7 +295,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_10" name="Barthais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="81" speed="38" charge_damage="7" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -313,7 +313,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_9" name="Oberlander Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="37" charge_damage="7" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -331,7 +331,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_8" name="Poitevin Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="36" charge_damage="6" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -349,7 +349,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_7" name="Galloway Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="35" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="35" charge_damage="6" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -367,7 +367,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_6" name="Boulonnais Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="34" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="34" charge_damage="5" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -385,7 +385,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_5" name="Suffolk Punch Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="33" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="33" charge_damage="4" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -454,7 +454,7 @@
   </Item>
   <Item id="crpg_mount1_fast_11" name="Datong Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -471,7 +471,7 @@
   </Item>
   <Item id="crpg_mount1_fast_10" name="Ahalteke Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="71" speed="49" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -488,7 +488,7 @@
   </Item>
   <Item id="crpg_mount1_fast_9" name="Einsiedler Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="71" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="48" charge_damage="5" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -505,7 +505,7 @@
   </Item>
   <Item id="crpg_mount1_fast_8" name="Thessalian Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="47" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -522,7 +522,7 @@
   </Item>
   <Item id="crpg_mount1_fast_7" name="Nisean Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="46" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-8" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -539,7 +539,7 @@
   </Item>
   <Item id="crpg_mount1_fast_6" name="Menorquín Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="45" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -556,7 +556,7 @@
   </Item>
   <Item id="crpg_mount1_fast_5" name="Turkoman Courser" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="64" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="62" speed="44" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-14" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -627,7 +627,7 @@
   </Item>
    <Item id="crpg_mount1_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="75" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -645,7 +645,7 @@
   </Item>
   <Item id="crpg_mount1_charger_10" name="Desert Norman Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="73" speed="44" charge_damage="7" body_length="105" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -663,7 +663,7 @@
   </Item>
   <Item id="crpg_mount1_charger_9" name="Andalusian Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="73" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="43" charge_damage="7" body_length="105" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -681,7 +681,7 @@
   </Item>
   <Item id="crpg_mount1_charger_8" name="Ardennes Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="42" charge_damage="6" body_length="105" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -699,7 +699,7 @@
   </Item>
   <Item id="crpg_mount1_charger_7" name="Shire Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="70" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="68" speed="41" charge_damage="5" body_length="105" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -717,7 +717,7 @@
   </Item>
   <Item id="crpg_mount1_charger_6" name="Icelandic Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="68" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="66" speed="40" charge_damage="4" body_length="105" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -735,7 +735,7 @@
   </Item>
   <Item id="crpg_mount1_charger_5" name="Norwegian Fjord Draught" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="66" speed="39" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="64" speed="39" charge_damage="3" body_length="105" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -807,7 +807,7 @@
   </Item>
    <Item id="crpg_mount1_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="81" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -825,7 +825,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_10" name="Yunnan Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="79" speed="42" charge_damage="6" body_length="100" is_mountable="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -843,7 +843,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_9" name="Carthusian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="79" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="41" charge_damage="6" body_length="100" is_mountable="true" extra_health="7" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -861,7 +861,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_8" name="Friesian Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="40" charge_damage="5" body_length="100" is_mountable="true" extra_health="4" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -879,7 +879,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_7" name="Kathiawadi Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="39" charge_damage="5" body_length="105" is_mountable="true" extra_health="1" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -897,7 +897,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_6" name="Holsteiner Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="74" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="72" speed="38" charge_damage="4" body_length="105" is_mountable="true" extra_health="-2" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -915,7 +915,7 @@
   </Item>
   <Item id="crpg_mount1_balanced_5" name="Murgese Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.khuzait" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="72" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="70" speed="37" charge_damage="4" body_length="105" is_mountable="true" extra_health="-5" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -987,7 +987,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_11" name="Tchenarani Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="85" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="4" body_length="95" is_mountable="true" extra_health="-8" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1005,7 +1005,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_10" name="Berber Jennet" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="83" speed="43" charge_damage="3" body_length="95" is_mountable="true" extra_health="-11" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1023,7 +1023,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_9" name="Morvandiau Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="83" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="82" speed="42" charge_damage="3" body_length="95" is_mountable="true" extra_health="-14" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1041,7 +1041,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_8" name="Moroccan Barb" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="82" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="80" speed="41" charge_damage="2" body_length="95" is_mountable="true" extra_health="-17" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1059,7 +1059,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_7" name="Marwari Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="80" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="40" charge_damage="2" body_length="95" is_mountable="true" extra_health="-20" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1077,7 +1077,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_6" name="Caspian Palfrey" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="76" speed="39" charge_damage="2" body_length="95" is_mountable="true" extra_health="-23" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
@@ -1095,7 +1095,7 @@
   </Item>
   <Item id="crpg_mount1_maneuverable_5" name="Irish Hobby" mesh="horse_brown" item_category="noble_horse" culture="Culture.khuzait" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="76" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
+      <Horse monster="Monster.horse" maneuver="74" speed="38" charge_damage="2" body_length="95" is_mountable="true" extra_health="-26" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -276,7 +276,7 @@
   </Item>
   <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Items>
+  <Item id="crpg_mount_rouncey_15" name="Kehilan al-Khamsa" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="78" speed="49" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="13" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_grey_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF303030" percentage="1.0" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="78" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
@@ -170,7 +187,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_4" name="Fell Pony" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="64" speed="40" charge_damage="2" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-20" modifier_group="horse">
         <AdditionalMeshes>
@@ -187,7 +204,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_rouncey_3" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_3" name="Raymond Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="62" speed="38" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="-11" modifier_group="horse">
         <AdditionalMeshes>
@@ -204,7 +221,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_rouncey_2" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount_rouncey_2" name="Sumpter Horse" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="60" speed="34" charge_damage="1" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="0" modifier_group="horse">
         <AdditionalMeshes>
@@ -221,7 +238,25 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_greathorse_14" name="Percheron Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_15" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+    <ItemComponent>
+      <Horse monster="Monster.horse" maneuver="84" speed="41" charge_damage="9" body_length="105" is_mountable="true" extra_health="43" modifier_group="horse">
+        <AdditionalMeshes>
+          <Mesh name="horse_mane" affected_by_cover="true" />
+        </AdditionalMeshes>
+        <Materials>
+          <Material name="horse_white_mat">
+            <MeshMultipliers>
+              <MeshMultiplier mesh_multiplier="FF010101" percentage="0.75" />
+              <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />
+            </MeshMultipliers>
+          </Material>
+        </Materials>
+      </Horse>
+    </ItemComponent>
+    <Flags Civilian="true" />
+  </Item>
+  <Item id="crpg_mount_greathorse_14" name="Percheron Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="84" speed="40" charge_damage="9" body_length="105" is_mountable="true" extra_health="40" modifier_group="horse">
         <AdditionalMeshes>
@@ -239,7 +274,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_13" name="English Black Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="84" speed="39" charge_damage="9" body_length="105" is_mountable="true" extra_health="37" modifier_group="horse">
         <AdditionalMeshes>
@@ -257,7 +292,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-     <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_12" name="Comtois Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="83" speed="39" charge_damage="8" body_length="105" is_mountable="true" extra_health="34" modifier_group="horse">
         <AdditionalMeshes>
@@ -275,7 +310,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount_greathorse_11" name="Brabant Great Horse" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="38" charge_damage="8" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
@@ -418,7 +453,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-  <Item id="crpg_mount1_fast_13" name="Hengeron" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
+  <Item id="crpg_mount1_fast_13" name="Muniqi al-Khamsa" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="51" charge_damage="6" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
@@ -571,7 +606,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-       <Item id="crpg_mount1_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_14" name="Bucephalus" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="47" charge_damage="9" body_length="105" is_mountable="true" extra_health="31" modifier_group="horse">
         <AdditionalMeshes>
@@ -589,7 +624,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount1_charger_13" name="Lionheart" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_13" name="Hengeron" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="76" speed="46" charge_damage="9" body_length="105" is_mountable="true" extra_health="28" modifier_group="horse">
         <AdditionalMeshes>
@@ -607,7 +642,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-     <Item id="crpg_mount1_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_12" name="Neapolitan Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.empire" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="75" speed="45" charge_damage="8" body_length="105" is_mountable="true" extra_health="25" modifier_group="horse">
         <AdditionalMeshes>
@@ -625,7 +660,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount1_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_charger_11" name="Andravida Charger" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="450" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="74" speed="44" charge_damage="8" body_length="105" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
@@ -751,7 +786,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_mount1_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_14" name="Llamrei" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="45" charge_damage="8" body_length="100" is_mountable="true" extra_health="22" modifier_group="horse">
         <AdditionalMeshes>
@@ -769,7 +804,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount1_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_13" name="Bohemond" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="82" speed="44" charge_damage="8" body_length="100" is_mountable="true" extra_health="19" modifier_group="horse">
         <AdditionalMeshes>
@@ -787,7 +822,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount1_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_12" name="Lusitano Pureblood Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.battania" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="81" speed="43" charge_damage="7" body_length="100" is_mountable="true" extra_health="16" modifier_group="horse">
         <AdditionalMeshes>
@@ -805,7 +840,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-   <Item id="crpg_mount1_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
+  <Item id="crpg_mount1_balanced_11" name="Auvergne Destrier" mesh="horse_brown" is_merchandise="false" item_category="noble_horse" subtype="horse" culture="Culture.vlandia" weight="430" difficulty="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="80" speed="42" charge_damage="7" body_length="100" is_mountable="true" extra_health="13" modifier_group="horse">
         <AdditionalMeshes>
@@ -931,7 +966,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount1_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
+  <Item id="crpg_mount1_maneuverable_14" name="Baucent" mesh="horse_brown" item_category="noble_horse" culture="Culture.vlandia" subtype="horse" weight="300" difficulty="0" appearance="0" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.horse" maneuver="86" speed="46" charge_damage="5" body_length="95" is_mountable="true" extra_health="1" skeleton_scale="khuzait_horse">
         <AdditionalMeshes>
@@ -1117,7 +1152,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mule2_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
+  <Item id="crpg_mule2_2" name="Chadz" mesh="mule_mesh" item_category="sumpter_horse" weight="300" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.mule" maneuver="60" speed="33" charge_damage="1" body_length="92" is_mountable="true" extra_health="175" is_pack_animal="true" />
     </ItemComponent>
@@ -1129,7 +1164,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_16" name="Safinat al-Barr" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_16" name="Safinat al-Barr" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="85" speed="37" charge_damage="7" body_length="110" extra_health="58" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
@@ -1141,7 +1176,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_14" name="Achaemenian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="84" speed="38" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
@@ -1153,19 +1188,19 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_12" name="Parthian Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="83" speed="37" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_11" name="Seleucid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="5" body_length="110" extra_health="49" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-      <Item id="crpg_mount_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_10" name="Seleucid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="82" speed="36" charge_damage="4" body_length="110" extra_health="31" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
@@ -1177,19 +1212,19 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_8" name="Nabatean Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="81" speed="35" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_7" name="Sargonid Heavy Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="79" speed="33" charge_damage="5" body_length="110" extra_health="40" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_6" name="Sargonid Light Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="80" speed="34" charge_damage="4" body_length="110" extra_health="22" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>
@@ -1213,7 +1248,7 @@
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
-    <Item id="crpg_mount_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
+  <Item id="crpg_mount_camel_2" name="Pack Camel" mesh="camel_mesh" item_category="sumpter_horse" culture="Culture.aserai" weight="520" Type="Horse">
     <ItemComponent>
       <Horse monster="Monster.camel" maneuver="72" speed="29" charge_damage="2" body_length="110" extra_health="16" is_pack_animal="true" is_mountable="true" />
     </ItemComponent>

--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -19,7 +19,7 @@
   </Item>
   <Item id="crpg_mount_rouncey_14" name="Unmol Rouncey" mesh="horse_brown" item_category="noble_horse" difficulty="0" weight="420" Type="Horse">
     <ItemComponent>
-      <Horse monster="Monster.horse" maneuver="78" speed="48" charge_damage="3" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
+      <Horse monster="Monster.horse" maneuver="78" speed="48" charge_damage="4" body_length="100" is_mountable="true" is_pack_animal="true" extra_health="10" modifier_group="horse">
         <AdditionalMeshes>
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>


### PR DESCRIPTION
As before, small maneuver structure change. This xml is functional, however. 

Removed part of the split tier for maneuver (two tiers sharing same value) towards the top, as it seemed slightly redundant/excessive. It has actually led to nice options comparatively amidst the lowest tiers. The structure seems to make more sense overall as well.

Apologies for committing another PR before first one even made it to patch - however imo it would make more sense to release it with these changes than to worry about applying these changes after a patch, once people have repurchased mounts, etc.

Easy to compare document showing all mounts:
https://docs.google.com/spreadsheets/d/1luwvL72ImLhD-NW47wwFmCOLjAwMrR6LUka5cydIHnI/edit?usp=sharing

Also, see Champion Mounts.