### PR TITLE
Hanzo steel and goedendag

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -215,9 +215,9 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-    <CraftingPiece id="crpg_eastern_long_steel_mace_t4_blade" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.39 " full_scale="true" excluded_item_usage_features="thrust">
+    <CraftingPiece id="crpg_eastern_long_steel_mace_t4_blade" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.41 " full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.4" />
+      <Swing damage_type="Blunt" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -5288,7 +5288,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_2hsword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.50" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_cleaver_2hsword_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.40" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
@@ -5982,7 +5982,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bos_handle" name="{=}Stick for the Boulder" tier="1" piece_type="Handle" mesh="greataxe_handle" length="129" weight="1.2" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
+  <CraftingPiece id="crpg_bos_handle" name="{=}Stick for the Boulder" tier="1" piece_type="Handle" mesh="greataxe_handle" length="129" weight="1.7" excluded_item_usage_features="long" CraftingCost="100" is_default="true">
 <BuildData piece_offset="14.9"/>
 <Materials>
 <Material id="Wood" count="1"/>
@@ -6131,7 +6131,7 @@
 <Material id="Wood" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_gada_blade" name="{=}Gada Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="1.35" full_scale="true" excluded_item_usage_features="shield:thrust">
+<CraftingPiece id="crpg_gada_blade" name="{=}Gada Head" tier="2" piece_type="Blade" mesh="gada_blade" length="27.9" weight="1.42" full_scale="true" excluded_item_usage_features="shield:thrust">
 <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
 <Swing damage_type="Blunt" damage_factor="2.9"/>
 </BladeData>
@@ -6221,7 +6221,7 @@
   <CraftingPiece id="crpg_heavy_blacksmith_hammer_head" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="1.7" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-13.5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.3" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -6279,7 +6279,7 @@
   <CraftingPiece id="crpg_maul_head" name="{=}Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.70" full_scale="true" excluded_item_usage_features="">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.4" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -6299,7 +6299,7 @@
   <CraftingPiece id="crpg_long_maul_head" name="{=}Long Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.1" full_scale="true" excluded_item_usage_features="">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.4" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -6337,7 +6337,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_claymore_blade" name="{=}Claymore Blade" tier="4" piece_type="Blade" mesh="claymore_blade" culture="Culture.battania" length="111" weight="0.40">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.6"/>
+      <Thrust damage_type="Pierce" damage_factor="2.4"/>
       <Swing damage_type="Cut" damage_factor="4.2"/>
     </BladeData>
     <Materials>
@@ -6414,11 +6414,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_goedendag_head" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="0.6" >
+  <CraftingPiece id="crpg_heavy_goedendag_head" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.1" >
     <BuildData piece_offset="0" />
     <BladeData stack_amount="1" blade_length="30.5" blade_width="8.5" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="3.0" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6428,7 +6428,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_goedendag_handle" name="{=}Heavy Goedendag Handle" tier="4" piece_type="Handle" mesh="goedendag_2h_handle" length="98.5" weight="0.7" >
+  <CraftingPiece id="crpg_heavy_goedendag_handle" name="{=}Heavy Goedendag Handle" tier="4" piece_type="Handle" mesh="goedendag_2h_handle" length="98.5" weight="1.5" >
     <BuildData piece_offset="25.0" next_piece_offset="25.0" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -6575,52 +6575,52 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_blade_red" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.0" >
+  <CraftingPiece id="crpg_katana_blade_red" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2" >
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.6"/>
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_blade_blue" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.0" >
+  <CraftingPiece id="crpg_katana_blade_blue" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2" >
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_blue">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.6"/>
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_blade_green" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.0" >
+  <CraftingPiece id="crpg_katana_blade_green" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2" >
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.6"/>
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_blade_yellow" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.0" >
+  <CraftingPiece id="crpg_katana_blade_yellow" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2" >
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.6"/>
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_blade_black" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.0" >
+  <CraftingPiece id="crpg_katana_blade_black" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2" >
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_black">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.6"/>
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_guard" name="{=}Katana Guard" tier="4" piece_type="Guard" mesh="katana_guard" culture="Culture.khuzait" length="3.73" weight="0.24">
+  <CraftingPiece id="crpg_katana_guard" name="{=}Katana Guard" tier="4" piece_type="Guard" mesh="katana_guard" culture="Culture.khuzait" length="3.73" weight="1.0">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -6657,7 +6657,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_katana_pommel" name="{=}Katana Pommel" tier="3" piece_type="Pommel" mesh="katana_pommel" culture="Culture.khuzait" length="2.97" weight="0.18">
+  <CraftingPiece id="crpg_katana_pommel" name="{=}Katana Pommel" tier="3" piece_type="Pommel" mesh="katana_pommel" culture="Culture.khuzait" length="2.97" weight="0.6">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -6279,7 +6279,7 @@
   <CraftingPiece id="crpg_maul_head" name="{=}Maul Head" tier="1" piece_type="Blade" mesh="maul_head" length="12" weight="1.70" full_scale="true" excluded_item_usage_features="">
     <BuildData piece_offset="-11.0" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.8" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -5634,6 +5634,44 @@
     "weapons": []
   },
   {
+    "id": "crpg_bec_de_corbin",
+    "name": "Bec De Corbin",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 2404,
+    "weight": 2.4,
+    "tier": 3.2347157,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 141,
+        "balance": 0.0,
+        "handling": 59,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 22,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 35,
+        "swingDamageType": "Pierce",
+        "swingSpeed": 68
+      }
+    ]
+  },
+  {
     "id": "crpg_belted_leather_boots",
     "name": "Belted Leather Boots",
     "culture": "Battania",
@@ -6869,12 +6907,12 @@
   },
   {
     "id": "crpg_buckler",
-    "name": "Buckler",
+    "name": "Round Buckler",
     "culture": "Sturgia",
     "type": "Shield",
-    "price": 9115,
+    "price": 5715,
     "weight": 1.0,
-    "tier": 9.928137,
+    "tier": 7.63329029,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone",
@@ -6882,25 +6920,101 @@
     ],
     "weapons": [
       {
-        "class": "LargeShield",
+        "class": "SmallShield",
         "itemUsage": "hand_shield",
         "accuracy": 100,
         "missileSpeed": 0,
         "stackAmount": 200,
         "length": 15,
         "balance": 0.0,
-        "handling": 110,
-        "bodyArmor": 15,
+        "handling": 86,
+        "bodyArmor": 8,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
         ],
         "thrustDamage": 5,
         "thrustDamageType": "Blunt",
-        "thrustSpeed": 110,
+        "thrustSpeed": 86,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
         "swingSpeed": 100
+      }
+    ]
+  },
+  {
+    "id": "crpg_burgundian_glaive",
+    "name": "Burgundian Glaive",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 1153,
+    "weight": 2.0,
+    "tier": 1.96433771,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 189,
+        "balance": 0.0,
+        "handling": 59,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 30,
+        "swingDamageType": "Cut",
+        "swingSpeed": 69
+      }
+    ]
+  },
+  {
+    "id": "crpg_burgundian_poleaxe",
+    "name": "Burgundian Poleaxe",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 5239,
+    "weight": 2.4,
+    "tier": 5.240514,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 128,
+        "balance": 0.32,
+        "handling": 70,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 25,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 89,
+        "swingDamage": 37,
+        "swingDamageType": "Cut",
+        "swingSpeed": 79
       }
     ]
   },
@@ -7296,9 +7410,9 @@
     "name": "Claymore",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 13819,
-    "weight": 2.7,
-    "tier": 9.92845249,
+    "price": 16554,
+    "weight": 2.6,
+    "tier": 10.9691048,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7322,6 +7436,27 @@
         "swingDamage": 42,
         "swingDamageType": "Cut",
         "swingSpeed": 81
+      },
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 116,
+        "balance": 0.64,
+        "handling": 72,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 26,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 42,
+        "swingDamageType": "Cut",
+        "swingSpeed": 89
       }
     ]
   },
@@ -11788,6 +11923,44 @@
     ]
   },
   {
+    "id": "crpg_french_voulge",
+    "name": "French Voulge",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 10822,
+    "weight": 1.8,
+    "tier": 7.985214,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 134,
+        "balance": 0.75,
+        "handling": 79,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 24,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 94,
+        "swingDamage": 27,
+        "swingDamageType": "Cut",
+        "swingSpeed": 92
+      }
+    ]
+  },
+  {
     "id": "crpg_fulcum_standard_t2",
     "name": "Fulcum Standard",
     "culture": "Empire",
@@ -12462,6 +12635,25 @@
     "weapons": []
   },
   {
+    "id": "crpg_great_prankh_helm",
+    "name": "Round Top Great Helmet",
+    "culture": "Vlandia",
+    "type": "HeadArmor",
+    "price": 9448,
+    "weight": 3.8,
+    "tier": 8.903204,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 56,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_greataxe",
     "name": "Greataxe",
     "culture": "Battania",
@@ -12923,9 +13115,9 @@
     "name": "Heavy Blacksmith Hammer",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 18520,
-    "weight": 2.8,
-    "tier": 11.66524,
+    "price": 31111,
+    "weight": 2.7,
+    "tier": 15.4458466,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -12954,6 +13146,30 @@
         "swingDamage": 33,
         "swingDamageType": "Blunt",
         "swingSpeed": 70
+      },
+      {
+        "class": "TwoHandedMace",
+        "itemUsage": "twohanded_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 85,
+        "balance": 0.15,
+        "handling": 73,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "TwoHandIdleOnMount",
+          "MultiplePenetration",
+          "CanKnockDown"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 87,
+        "swingDamage": 33,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 74
       }
     ]
   },
@@ -12990,6 +13206,43 @@
         "swingDamage": 45,
         "swingDamageType": "Cut",
         "swingSpeed": 78
+      }
+    ]
+  },
+  {
+    "id": "crpg_heavy_goedendag",
+    "name": "Heavy Goedendag",
+    "culture": "Sturgia",
+    "type": "TwoHandedWeapon",
+    "price": 770214,
+    "weight": 1.3,
+    "tier": 81.35886,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 74,
+        "balance": 1.0,
+        "handling": 92,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "MultiplePenetration"
+        ],
+        "thrustDamage": 25,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 30,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 105
       }
     ]
   },
@@ -15049,6 +15302,27 @@
         "swingDamage": 25,
         "swingDamageType": "Pierce",
         "swingSpeed": 87
+      },
+      {
+        "class": "OneHandedAxe",
+        "itemUsage": "onehanded_shield_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 71,
+        "balance": 0.6,
+        "handling": 85,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "BonusAgainstShield"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 93,
+        "swingDamage": 25,
+        "swingDamageType": "Pierce",
+        "swingSpeed": 87
       }
     ]
   },
@@ -15125,6 +15399,176 @@
         "swingDamage": 24,
         "swingDamageType": "Cut",
         "swingSpeed": 75
+      }
+    ]
+  },
+  {
+    "id": "crpg_katana_black",
+    "name": "Black Katana",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 32123,
+    "weight": 1.65,
+    "tier": 15.7130718,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 102,
+        "balance": 1.0,
+        "handling": 90,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 102
+      }
+    ]
+  },
+  {
+    "id": "crpg_katana_blue",
+    "name": "Blue Katana",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 32123,
+    "weight": 1.65,
+    "tier": 15.7130718,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 102,
+        "balance": 1.0,
+        "handling": 90,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 102
+      }
+    ]
+  },
+  {
+    "id": "crpg_katana_green",
+    "name": "Green Katana",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 32123,
+    "weight": 1.65,
+    "tier": 15.7130718,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 102,
+        "balance": 1.0,
+        "handling": 90,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 102
+      }
+    ]
+  },
+  {
+    "id": "crpg_katana_red",
+    "name": "Red Katana",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 32123,
+    "weight": 1.65,
+    "tier": 15.7130718,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 102,
+        "balance": 1.0,
+        "handling": 90,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 102
+      }
+    ]
+  },
+  {
+    "id": "crpg_katana_yellow",
+    "name": "Yellow Katana",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 32123,
+    "weight": 1.65,
+    "tier": 15.7130718,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 102,
+        "balance": 1.0,
+        "handling": 90,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 102
       }
     ]
   },
@@ -15534,6 +15978,25 @@
       "bodyArmor": 16,
       "armArmor": 2,
       "legArmor": 5,
+      "materialType": "Leather"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_khuzait_lamellar_strapped",
+    "name": "Reinforced Leather Armor",
+    "culture": "Khuzait",
+    "type": "BodyArmor",
+    "price": 1908,
+    "weight": 7.010831,
+    "tier": 4.48649073,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 24,
+      "armArmor": 6,
+      "legArmor": 12,
       "materialType": "Leather"
     },
     "weapons": []
@@ -17354,6 +17817,39 @@
     "weapons": []
   },
   {
+    "id": "crpg_light_goedendag",
+    "name": "Light Goedendag",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 83049,
+    "weight": 0.69,
+    "tier": 35.9198227,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 42,
+        "balance": 1.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 21,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 117
+      }
+    ]
+  },
+  {
     "id": "crpg_light_harness",
     "name": "Light Harness",
     "culture": "Neutral",
@@ -17539,6 +18035,43 @@
         "swingDamage": 49,
         "swingDamageType": "Cut",
         "swingSpeed": 76
+      }
+    ]
+  },
+  {
+    "id": "crpg_long_buckler",
+    "name": "Oval Buckler",
+    "culture": "Sturgia",
+    "type": "Shield",
+    "price": 9741,
+    "weight": 1.2,
+    "tier": 10.3004417,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone",
+      "HeldInOffHand"
+    ],
+    "weapons": [
+      {
+        "class": "SmallShield",
+        "itemUsage": "hand_shield",
+        "accuracy": 100,
+        "missileSpeed": 0,
+        "stackAmount": 220,
+        "length": 24,
+        "balance": 0.0,
+        "handling": 80,
+        "bodyArmor": 8,
+        "flags": [
+          "HasHitPoints",
+          "CanBlockRanged"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 80,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 100
       }
     ]
   },
@@ -18227,6 +18760,29 @@
         "swingDamage": 28,
         "swingDamageType": "Blunt",
         "swingSpeed": 81
+      },
+      {
+        "class": "TwoHandedMace",
+        "itemUsage": "twohanded_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 84,
+        "balance": 0.39,
+        "handling": 77,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "TwoHandIdleOnMount",
+          "MultiplePenetration"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 92,
+        "swingDamage": 28,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 81
       }
     ]
   },
@@ -18391,9 +18947,9 @@
     "name": "Great Maul",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 17904,
-    "weight": 3.08,
-    "tier": 11.451273,
+    "price": 60267,
+    "weight": 2.7,
+    "tier": 21.9362831,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18422,6 +18978,63 @@
         "swingDamage": 34,
         "swingDamageType": "Blunt",
         "swingSpeed": 71
+      },
+      {
+        "class": "TwoHandedMace",
+        "itemUsage": "twohanded_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 81,
+        "balance": 0.25,
+        "handling": 75,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "TwoHandIdleOnMount",
+          "MultiplePenetration",
+          "CanKnockDown"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 87,
+        "swingDamage": 34,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 77
+      }
+    ]
+  },
+  {
+    "id": "crpg_medium_goedendag",
+    "name": "Medium Goedendag",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 519364,
+    "weight": 0.69,
+    "tier": 91.56154,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 56,
+        "balance": 1.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 20,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 25,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 114
       }
     ]
   },
@@ -18613,6 +19226,39 @@
         "swingDamage": 0,
         "swingDamageType": "Undefined",
         "swingSpeed": 64
+      }
+    ]
+  },
+  {
+    "id": "crpg_military_hammer",
+    "name": "Military Hammer",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 121901,
+    "weight": 0.69,
+    "tier": 43.7620239,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 49,
+        "balance": 1.0,
+        "handling": 110,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 18,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 100,
+        "swingDamage": 25,
+        "swingDamageType": "Pierce",
+        "swingSpeed": 115
       }
     ]
   },
@@ -23249,6 +23895,77 @@
     "weapons": []
   },
   {
+    "id": "crpg_peasant_hammer_1_t1",
+    "name": "Blacksmith Hammer",
+    "culture": "Neutral",
+    "type": "OneHandedWeapon",
+    "price": 750,
+    "weight": 2.4,
+    "tier": 2.432588,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 32,
+        "balance": 0.67,
+        "handling": 99,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 84,
+        "swingDamage": 20,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 90
+      }
+    ]
+  },
+  {
+    "id": "crpg_peasant_hammer_2_t1",
+    "name": "Wooden Hammer",
+    "culture": "Neutral",
+    "type": "OneHandedWeapon",
+    "price": 481,
+    "weight": 2.48,
+    "tier": 1.74985242,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 45,
+        "balance": 0.59,
+        "handling": 97,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "MultiplePenetration"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 83,
+        "swingDamage": 15,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      }
+    ]
+  },
+  {
     "id": "crpg_peasant_hatchet_1_t1",
     "name": "Hatchet",
     "culture": "Neutral",
@@ -24060,6 +24777,25 @@
     "weapons": []
   },
   {
+    "id": "crpg_pothelm",
+    "name": "Roundtop Full Helm",
+    "culture": "Vlandia",
+    "type": "HeadArmor",
+    "price": 8026,
+    "weight": 3.4,
+    "tier": 8.515432,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 53,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_practice_spear_t1",
     "name": "Bludgeon Staff",
     "culture": "Neutral",
@@ -24692,6 +25428,25 @@
     "weapons": []
   },
   {
+    "id": "crpg_roningasa",
+    "name": "Roningasa",
+    "culture": "Vlandia",
+    "type": "HeadArmor",
+    "price": 50,
+    "weight": 0.1,
+    "tier": 0.18080914,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 1,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Cloth"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_rough_bearskin",
     "name": "Rough Bearskin",
     "culture": "Battania",
@@ -24975,6 +25730,124 @@
     "weapons": []
   },
   {
+    "id": "crpg_rus_armour",
+    "name": "Vaegir Coat of Plates",
+    "culture": "Sturgia",
+    "type": "BodyArmor",
+    "price": 10663,
+    "weight": 16.38,
+    "tier": 7.29118347,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor"
+    ],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 46,
+      "armArmor": 14,
+      "legArmor": 14,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_armour1",
+    "name": "Vaegir Coat of Plates",
+    "culture": "Sturgia",
+    "type": "BodyArmor",
+    "price": 10663,
+    "weight": 16.38,
+    "tier": 7.29118347,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor"
+    ],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 46,
+      "armArmor": 14,
+      "legArmor": 14,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_noble",
+    "name": "Vaegir Noble Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_regular",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_regular2",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_open_helm",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 6207,
+    "weight": 3.11,
+    "tier": 7.93595743,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 49,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_sa_1ChurburghBoots",
     "name": "Plate Boots",
     "culture": "Vlandia",
@@ -25204,6 +26077,44 @@
       "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_sallet_base_nochin",
+    "name": "Western Sallet",
+    "culture": "Vlandia",
+    "type": "HeadArmor",
+    "price": 9448,
+    "weight": 3.8,
+    "tier": 8.903204,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 56,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_sallet_no_visor_nochin",
+    "name": "Western open Sallet",
+    "culture": "Vlandia",
+    "type": "HeadArmor",
+    "price": 3808,
+    "weight": 2.47,
+    "tier": 6.931793,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 42,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
     },
     "weapons": []
   },
@@ -25580,12 +26491,12 @@
   },
   {
     "id": "crpg_sherpherds",
-    "name": "Shepherd Axe",
-    "culture": "Battania",
+    "name": "Shepherd's Axe",
+    "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1129,
-    "weight": 0.97,
-    "tier": 3.21909142,
+    "price": 4009,
+    "weight": 0.8,
+    "tier": 7.01292324,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -25611,6 +26522,27 @@
         "swingDamage": 25,
         "swingDamageType": "Cut",
         "swingSpeed": 92
+      },
+      {
+        "class": "OneHandedAxe",
+        "itemUsage": "onehanded_shield_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 61,
+        "balance": 1.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "BonusAgainstShield"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 98,
+        "swingDamage": 25,
+        "swingDamageType": "Cut",
+        "swingSpeed": 106
       }
     ]
   },
@@ -25663,6 +26595,29 @@
       "Civilian"
     ],
     "weapons": [
+      {
+        "class": "TwoHandedMace",
+        "itemUsage": "twohanded_axe",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 81,
+        "balance": 0.44,
+        "handling": 78,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "BonusAgainstShield",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 93,
+        "swingDamage": 33,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      },
       {
         "class": "TwoHandedMace",
         "itemUsage": "twohanded_axe",
@@ -25871,6 +26826,44 @@
         "swingDamage": 0,
         "swingDamageType": "Undefined",
         "swingSpeed": 56
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_poleaxe",
+    "name": "Simple Poleaxe",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 1229,
+    "weight": 2.4,
+    "tier": 2.05589271,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 145,
+        "balance": 0.13,
+        "handling": 65,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 22,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 89,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 74
       }
     ]
   },
@@ -26193,6 +27186,30 @@
     "requirement": 0,
     "flags": [],
     "weapons": [
+      {
+        "class": "Stone",
+        "itemUsage": "stone",
+        "accuracy": 100,
+        "missileSpeed": 40,
+        "stackAmount": 10,
+        "length": 10,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "Consumable",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "AmmoBreaksOnBounceBack"
+        ],
+        "thrustDamage": 8,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 102
+      },
       {
         "class": "Stone",
         "itemUsage": "stone",
@@ -26902,6 +27919,44 @@
       "materialType": "Plate"
     },
     "weapons": []
+  },
+  {
+    "id": "crpg_spiked_polehammer",
+    "name": "Spiked Polehammer",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 1470,
+    "weight": 2.4,
+    "tier": 2.32981586,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 148,
+        "balance": 0.0,
+        "handling": 58,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 21,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 30,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 65
+      }
+    ]
   },
   {
     "id": "crpg_standard_of_courage_t2",
@@ -30870,6 +31925,44 @@
     "weapons": []
   },
   {
+    "id": "crpg_vaegir_helm",
+    "name": "War Mask",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 8428,
+    "weight": 3.6,
+    "tier": 8.629949,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 54,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_vaegir_helm_open",
+    "name": "War helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 6207,
+    "weight": 3.11,
+    "tier": 7.93595743,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 49,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_varangian_bra_basic",
     "name": "Decorated Leather Harness",
     "culture": "Empire",
@@ -32362,6 +33455,39 @@
     ]
   },
   {
+    "id": "crpg_warhammer",
+    "name": "Warhammer",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 69598,
+    "weight": 0.69,
+    "tier": 32.78522,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 45,
+        "balance": 1.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 19,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 23,
+        "swingDamageType": "Pierce",
+        "swingSpeed": 117
+      }
+    ]
+  },
+  {
     "id": "crpg_western_2hsword_t3",
     "name": "Tapered Two-Hander",
     "culture": "Vlandia",
@@ -32476,9 +33602,9 @@
     "name": "Western chain shoulders",
     "culture": "Vlandia",
     "type": "ShoulderArmor",
-    "price": 618,
-    "weight": 0.55,
-    "tier": 4.44859171,
+    "price": 544,
+    "weight": 1.55,
+    "tier": 4.27529669,
     "requirement": 0,
     "flags": [],
     "armor": {

--- a/items.json
+++ b/items.json
@@ -18985,9 +18985,9 @@
     "name": "Great Maul",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 11949,
+    "price": 8937,
     "weight": 2.7,
-    "tier": 9.156282,
+    "tier": 7.77400827,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19013,7 +19013,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 86,
-        "swingDamage": 28,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
         "swingSpeed": 71
       },
@@ -19037,7 +19037,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 34,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
         "swingSpeed": 77
       }

--- a/items.json
+++ b/items.json
@@ -5672,44 +5672,6 @@
     ]
   },
   {
-    "id": "crpg_bec_de_corbin",
-    "name": "Bec De Corbin",
-    "culture": "Neutral",
-    "type": "Polearm",
-    "price": 2404,
-    "weight": 2.4,
-    "tier": 3.2347157,
-    "requirement": 0,
-    "flags": [
-      "CanBePickedUpFromCorpse"
-    ],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 141,
-        "balance": 0.0,
-        "handling": 59,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 22,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 35,
-        "swingDamageType": "Pierce",
-        "swingSpeed": 68
-      }
-    ]
-  },
-  {
     "id": "crpg_belted_leather_boots",
     "name": "Belted Leather Boots",
     "culture": "Battania",
@@ -13252,9 +13214,9 @@
     "name": "Heavy Goedendag",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 770214,
-    "weight": 1.3,
-    "tier": 81.35886,
+    "price": 9658,
+    "weight": 2.6,
+    "tier": 8.123679,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13267,8 +13229,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 74,
-        "balance": 1.0,
-        "handling": 92,
+        "balance": 0.61,
+        "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -13277,10 +13239,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 105
+        "swingSpeed": 88
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -5672,6 +5672,44 @@
     ]
   },
   {
+    "id": "crpg_bec_de_corbin",
+    "name": "Bec De Corbin",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 2404,
+    "weight": 2.4,
+    "tier": 3.2347157,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 141,
+        "balance": 0.0,
+        "handling": 59,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 22,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 35,
+        "swingDamageType": "Pierce",
+        "swingSpeed": 68
+      }
+    ]
+  },
+  {
     "id": "crpg_belted_leather_boots",
     "name": "Belted Leather Boots",
     "culture": "Battania",
@@ -6305,9 +6343,9 @@
     "name": "Boulder on a Stick",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 17345,
-    "weight": 2.6,
-    "tier": 11.2538586,
+    "price": 9080,
+    "weight": 3.1,
+    "tier": 7.84462643,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6318,8 +6356,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.2,
-        "handling": 70,
+        "balance": 0.1,
+        "handling": 68,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -6330,10 +6368,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
+        "thrustSpeed": 84,
         "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 75
+        "swingSpeed": 72
       }
     ]
   },
@@ -7410,9 +7448,9 @@
     "name": "Claymore",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 16554,
+    "price": 14158,
     "weight": 2.6,
-    "tier": 10.9691048,
+    "tier": 10.0626392,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7430,7 +7468,7 @@
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 42,
@@ -7451,7 +7489,7 @@
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 42,
@@ -7465,9 +7503,9 @@
     "name": "Harvesting Season",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 12070,
-    "weight": 2.85,
-    "tier": 9.208065,
+    "price": 13777,
+    "weight": 2.73,
+    "tier": 9.911543,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7478,7 +7516,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.4,
+        "balance": 0.43,
         "handling": 67,
         "bodyArmor": 2,
         "flags": [
@@ -7488,10 +7526,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 82
       }
     ]
   },
@@ -9380,9 +9418,9 @@
     "name": "Long Steel Mace",
     "culture": "Khuzait",
     "type": "TwoHandedWeapon",
-    "price": 20358,
-    "weight": 1.89,
-    "tier": 12.2837963,
+    "price": 12373,
+    "weight": 1.96,
+    "tier": 9.33632851,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9393,8 +9431,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 135,
-        "balance": 0.15,
-        "handling": 69,
+        "balance": 0.12,
+        "handling": 68,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -9404,9 +9442,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 92,
-        "swingDamage": 34,
+        "swingDamage": 33,
         "swingDamageType": "Blunt",
-        "swingSpeed": 74
+        "swingSpeed": 73
       }
     ]
   },
@@ -12327,9 +12365,9 @@
     "name": "Gada",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 15881,
-    "weight": 2.35,
-    "tier": 10.721365,
+    "price": 10786,
+    "weight": 2.42,
+    "tier": 8.645648,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -12340,8 +12378,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.21,
-        "handling": 73,
+        "balance": 0.15,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -12354,7 +12392,7 @@
         "thrustSpeed": 89,
         "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 76
+        "swingSpeed": 74
       }
     ]
   },
@@ -13115,9 +13153,9 @@
     "name": "Heavy Blacksmith Hammer",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 31111,
+    "price": 10763,
     "weight": 2.7,
-    "tier": 15.4458466,
+    "tier": 8.6355505,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -13143,7 +13181,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 86,
-        "swingDamage": 33,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
         "swingSpeed": 70
       },
@@ -13167,7 +13205,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 33,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
         "swingSpeed": 74
       }
@@ -15407,9 +15445,9 @@
     "name": "Black Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 32123,
-    "weight": 1.65,
-    "tier": 15.7130718,
+    "price": 13923,
+    "weight": 2.03,
+    "tier": 9.969487,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15421,18 +15459,18 @@
         "stackAmount": 0,
         "length": 102,
         "balance": 1.0,
-        "handling": 90,
+        "handling": 80,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 100
       }
     ]
   },
@@ -15441,9 +15479,9 @@
     "name": "Blue Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 32123,
-    "weight": 1.65,
-    "tier": 15.7130718,
+    "price": 13923,
+    "weight": 2.03,
+    "tier": 9.969487,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15455,18 +15493,18 @@
         "stackAmount": 0,
         "length": 102,
         "balance": 1.0,
-        "handling": 90,
+        "handling": 80,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 100
       }
     ]
   },
@@ -15475,9 +15513,9 @@
     "name": "Green Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 32123,
-    "weight": 1.65,
-    "tier": 15.7130718,
+    "price": 13923,
+    "weight": 2.03,
+    "tier": 9.969487,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15489,18 +15527,18 @@
         "stackAmount": 0,
         "length": 102,
         "balance": 1.0,
-        "handling": 90,
+        "handling": 80,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 100
       }
     ]
   },
@@ -15509,9 +15547,9 @@
     "name": "Red Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 32123,
-    "weight": 1.65,
-    "tier": 15.7130718,
+    "price": 13923,
+    "weight": 2.03,
+    "tier": 9.969487,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15523,18 +15561,18 @@
         "stackAmount": 0,
         "length": 102,
         "balance": 1.0,
-        "handling": 90,
+        "handling": 80,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 100
       }
     ]
   },
@@ -15543,9 +15581,9 @@
     "name": "Yellow Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 32123,
-    "weight": 1.65,
-    "tier": 15.7130718,
+    "price": 13923,
+    "weight": 2.03,
+    "tier": 9.969487,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -15557,18 +15595,18 @@
         "stackAmount": 0,
         "length": 102,
         "balance": 1.0,
-        "handling": 90,
+        "handling": 80,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 100
       }
     ]
   },
@@ -18223,9 +18261,9 @@
     "name": "Long Maul",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 31278,
+    "price": 11176,
     "weight": 1.68,
-    "tier": 15.4904222,
+    "tier": 8.8197,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18251,7 +18289,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 93,
-        "swingDamage": 34,
+        "swingDamage": 30,
         "swingDamageType": "Blunt",
         "swingSpeed": 65
       }
@@ -18947,9 +18985,9 @@
     "name": "Great Maul",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 60267,
+    "price": 11949,
     "weight": 2.7,
-    "tier": 21.9362831,
+    "tier": 9.156282,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -18975,7 +19013,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 86,
-        "swingDamage": 34,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
         "swingSpeed": 71
       },


### PR DESCRIPTION
PR theme video: https://www.youtube.com/watch?v=wAkCLpMtjlM

will keith roleplay mode unlocked (katanas balanced) 
goedendag balanced
all 2h weps above t10 brought down (maces) 
crushthrough weps may need additional nerfs in the future (imo)

also - all the new stuff needs thumbnails still i think, but i dont have the meshes locally (i think??) so exporting creates black squares 

