### PR TITLE
Polearm change

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1505,10 +1505,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.6">
+  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.60">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="5.2" />
+      <Thrust damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1258,7 +1258,7 @@
   <CraftingPiece id="crpg_easter_polesword_t4_blade" name="{=3ged5Ozt}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.5">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2" />
-      <Swing damage_type="Cut" damage_factor="5" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -1368,7 +1368,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="0.8" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Pierce" damage_factor="3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1434,10 +1434,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.38	">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.5">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1467,9 +1467,9 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_polearm_1_t5_blade" name="{=PmPxx2gK}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.55" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_battania_polearm_1_t5_blade" name="{=PmPxx2gK}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.60" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -1478,25 +1478,25 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_polearm_1_t5_blade" name="{=wait0O6m}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.5" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_sturgia_polearm_1_t5_blade" name="{=wait0O6m}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.57" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="5" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.34">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.43">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.4" />
+      <Thrust damage_type="Cut" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.55">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.6">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="4.1" />
@@ -1514,11 +1514,11 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.43">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.45">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1837,7 +1837,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -2336,11 +2336,11 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.6">
+  <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Cut" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Thrust damage_type="Cut" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6046,10 +6046,10 @@
 <Material id="Wood" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_war_scythe_blade" name="{=}War Scythe Blade" tier="2" piece_type="Blade" mesh="warscythe_head" length="120" weight="0.6" excluded_item_usage_features="shield:thrust">
+<CraftingPiece id="crpg_war_scythe_blade" name="{=}War Scythe Blade" tier="2" piece_type="Blade" mesh="warscythe_head" length="120" weight="0.72" excluded_item_usage_features="shield:thrust">
 <BuildData piece_offset="-20"/>
 <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-<Swing damage_type="Cut" damage_factor="4.3"/>
+<Swing damage_type="Cut" damage_factor="4.4"/>
 </BladeData>
 <Materials>
 <Material id="Iron3" count="4"/>
@@ -6158,8 +6158,8 @@
 </CraftingPiece>
 <CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.2" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Blunt" damage_factor="1.6" />
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Thrust damage_type="Blunt" damage_factor="1.7" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6435,10 +6435,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.5">
+  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.7">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4"/>
-      <Swing damage_type="Cut" damage_factor="2.7"/>
+      <Thrust damage_type="Pierce" damage_factor="2.3"/>
+      <Swing damage_type="Cut" damage_factor="3.7"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6453,10 +6453,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade" name="Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.5">
+  <CraftingPiece id="crpg_burgundian_glaive_blade" name="Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
-      <Swing damage_type="Cut" damage_factor="3.0"/>
+      <Thrust damage_type="Pierce" damage_factor="2.2"/>
+      <Swing damage_type="Cut" damage_factor="4.4"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6471,10 +6471,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.9">
+  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.77">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5"/>
-      <Swing damage_type="Cut" damage_factor="3.7"/>
+      <Swing damage_type="Cut" damage_factor="4.2"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6489,10 +6489,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
     </CraftingPiece>
-  <CraftingPiece id="crpg_simple_poleaxe_blade" name="Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.9">
+  <CraftingPiece id="crpg_simple_poleaxe_blade" name="Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.7">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2"/>
-      <Swing damage_type="Cut" damage_factor="3.5"/>
+      <Thrust damage_type="Pierce" damage_factor="2.4"/>
+      <Swing damage_type="Cut" damage_factor="4.4"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6507,10 +6507,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.9">
+  <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.50">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2"/>
-      <Swing damage_type="Pierce" damage_factor="3.5"/>
+      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Swing damage_type="Pierce" damage_factor="3.0"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6525,7 +6525,7 @@
         <Material id="Wood" count="1"/>
       </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade" name="Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.9">
+  <CraftingPiece id="crpg_spiked_polehammer_blade" name="Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.5">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.1"/>
       <Swing damage_type="Blunt" damage_factor="3.0"/>

--- a/items.json
+++ b/items.json
@@ -158,14 +158,14 @@
     "name": "Legionary Studded Harness",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 295,
+    "price": 2355,
     "weight": 0.9793919,
-    "tier": 3.500862,
+    "tier": 6.58162,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 7,
+      "bodyArmor": 17,
       "armArmor": 4,
       "legArmor": 0,
       "materialType": "Plate"
@@ -177,15 +177,15 @@
     "name": "Plate Pauldrons",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 151,
+    "price": 503,
     "weight": 0.8207818,
-    "tier": 2.70612574,
+    "tier": 4.17194366,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 0,
-      "armArmor": 8,
+      "bodyArmor": 8,
+      "armArmor": 5,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -272,9 +272,9 @@
     "name": "Bronze Pauldrons with Neck Guard",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 1483,
+    "price": 1792,
     "weight": 2.167811,
-    "tier": 5.769159,
+    "tier": 6.09115839,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -282,7 +282,7 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 13,
-      "armArmor": 6,
+      "armArmor": 7,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -293,17 +293,17 @@
     "name": "Bronze Pauldrons ",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 90,
+    "price": 523,
     "weight": 0.5331134,
-    "tier": 2.0547235,
+    "tier": 4.22359848,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 0,
-      "armArmor": 6,
+      "bodyArmor": 8,
+      "armArmor": 5,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -371,18 +371,18 @@
     "name": "Aketon",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 85,
+    "price": 1022,
     "weight": 2.077283,
-    "tier": 1.395525,
+    "tier": 3.72942066,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
+      "bodyArmor": 23,
       "armArmor": 3,
-      "legArmor": 2,
+      "legArmor": 3,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -886,18 +886,18 @@
     "name": "Southern Reinforced Mail Vest",
     "culture": "Aserai",
     "type": "BodyArmor",
-    "price": 966,
+    "price": 14854,
     "weight": 6.965938,
-    "tier": 3.66696239,
+    "tier": 7.986067,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 26,
-      "armArmor": 3,
-      "legArmor": 3,
+      "bodyArmor": 40,
+      "armArmor": 18,
+      "legArmor": 13,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -1728,9 +1728,9 @@
     "name": "Robe over Mail Shirt",
     "culture": "Aserai",
     "type": "BodyArmor",
-    "price": 2971,
+    "price": 3533,
     "weight": 9.225823,
-    "tier": 5.097323,
+    "tier": 5.35476351,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -1738,8 +1738,8 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 28,
-      "armArmor": 8,
-      "legArmor": 13,
+      "armArmor": 13,
+      "legArmor": 8,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -3056,18 +3056,18 @@
     "name": "Leather Armor",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 1243,
+    "price": 1098,
     "weight": 5.048733,
-    "tier": 3.95506835,
+    "tier": 3.81064153,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 22,
-      "armArmor": 6,
-      "legArmor": 6,
+      "bodyArmor": 26,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -8459,16 +8459,16 @@
     "name": "Decorated Plate Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 1367,
+    "price": 2615,
     "weight": 1.402491,
-    "tier": 6.91897964,
+    "tier": 8.302775,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 20,
+      "legArmor": 24,
       "materialType": "Plate"
     },
     "weapons": []
@@ -8478,15 +8478,15 @@
     "name": "Decorated Imperial Gauntlets",
     "culture": "Empire",
     "type": "HandArmor",
-    "price": 1814,
+    "price": 3486,
     "weight": 3.244425,
-    "tier": 6.95581865,
+    "tier": 8.346983,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
-      "armArmor": 20,
+      "armArmor": 24,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -9914,18 +9914,18 @@
     "name": "Cured Studded Leather Armor",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 950,
+    "price": 3980,
     "weight": 4.729927,
-    "tier": 3.64785051,
+    "tier": 5.53891373,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 18,
-      "armArmor": 6,
-      "legArmor": 8,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Leather"
     },
     "weapons": []
@@ -10207,13 +10207,13 @@
     "name": "Jeweled Plumed Battle Crown",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 4739,
+    "price": 3106,
     "weight": 2.740113,
-    "tier": 7.36641645,
+    "tier": 6.547925,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 45,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10226,13 +10226,13 @@
     "name": "Imperial Plumed Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5813,
+    "price": 3018,
     "weight": 3.018642,
-    "tier": 7.794133,
+    "tier": 6.495111,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 48,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10267,13 +10267,13 @@
     "name": "Jeweled Crown",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1945,
+    "price": 998,
     "weight": 1.799568,
-    "tier": 5.735575,
+    "tier": 4.723415,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 34,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10286,15 +10286,15 @@
     "name": "Golden Laurel Crown",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 53,
+    "price": 56,
     "weight": 0.1014857,
-    "tier": 0.903980136,
+    "tier": 1.08477616,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "armor": {
-      "headArmor": 5,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10328,9 +10328,9 @@
     "name": "Ladies Dress",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 105,
+    "price": 89,
     "weight": 1.221603,
-    "tier": 1.59974384,
+    "tier": 1.43852937,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -10338,9 +10338,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 7,
-      "armArmor": 2,
-      "legArmor": 4,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -10350,9 +10350,9 @@
     "name": "Red Dress",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 78,
+    "price": 91,
     "weight": 0.8207818,
-    "tier": 1.31048286,
+    "tier": 1.46169245,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -10361,7 +10361,7 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 6,
-      "armArmor": 2,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
     },
@@ -10372,13 +10372,13 @@
     "name": "Royal Cataphract Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 7039,
+    "price": 7556,
     "weight": 3.306017,
-    "tier": 8.215069,
+    "tier": 8.376148,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 51,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10391,13 +10391,13 @@
     "name": "Lord Helmet with Metal Strips",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5439,
+    "price": 7858,
     "weight": 2.924803,
-    "tier": 7.65232754,
+    "tier": 8.466405,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 47,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10410,18 +10410,18 @@
     "name": "Cavalryman Mail Shirt",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 3029,
+    "price": 11763,
     "weight": 8.73775,
-    "tier": 5.12542534,
+    "tier": 7.491006,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 27,
-      "armArmor": 10,
-      "legArmor": 11,
+      "bodyArmor": 40,
+      "armArmor": 13,
+      "legArmor": 18,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -10431,9 +10431,9 @@
     "name": "Horseman Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 62,
+    "price": 52,
     "weight": 0.1753114,
-    "tier": 1.82122278,
+    "tier": 1.09273362,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -10442,7 +10442,7 @@
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 5,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -10452,13 +10452,13 @@
     "name": "Imperial Jeweled Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5439,
+    "price": 7858,
     "weight": 2.924803,
-    "tier": 7.65232754,
+    "tier": 8.466405,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 47,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10667,17 +10667,17 @@
     "name": "Decorated Legionary Mail",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 4010,
+    "price": 10498,
     "weight": 10.89783,
-    "tier": 5.55055,
+    "tier": 7.25995827,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 30,
-      "armArmor": 8,
+      "bodyArmor": 40,
+      "armArmor": 13,
       "legArmor": 18,
       "materialType": "Chainmail"
     },
@@ -10688,17 +10688,17 @@
     "name": "Ornate Legionary Scale Mail",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 5572,
+    "price": 9750,
     "weight": 12.49636,
-    "tier": 6.088809,
+    "tier": 7.113463,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 36,
-      "armArmor": 8,
+      "bodyArmor": 40,
+      "armArmor": 13,
       "legArmor": 18,
       "materialType": "Plate"
     },
@@ -10709,13 +10709,13 @@
     "name": "Palatine Guard Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5081,
+    "price": 3076,
     "weight": 2.831956,
-    "tier": 7.509759,
+    "tier": 6.53022528,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 46,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10992,15 +10992,15 @@
     "name": "Bronze Plate Pauldrons",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 115,
+    "price": 513,
     "weight": 0.6717997,
-    "tier": 2.3827734,
+    "tier": 4.1982193,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 0,
-      "armArmor": 7,
+      "bodyArmor": 8,
+      "armArmor": 5,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -11011,15 +11011,15 @@
     "name": "Iron Plate Pauldrons",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 151,
+    "price": 503,
     "weight": 0.8207818,
-    "tier": 2.70612574,
+    "tier": 4.17194366,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 0,
-      "armArmor": 8,
+      "bodyArmor": 8,
+      "armArmor": 5,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -11102,9 +11102,9 @@
     "name": "Short Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 52,
+    "price": 95,
     "weight": 0.1751825,
-    "tier": 0.5706096,
+    "tier": 1.50433445,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11113,9 +11113,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 0,
-      "legArmor": 0,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -11335,9 +11335,9 @@
     "name": "Infantryman Gambeson",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 523,
+    "price": 5322,
     "weight": 3.419776,
-    "tier": 3.028619,
+    "tier": 6.01099968,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11345,9 +11345,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 15,
-      "armArmor": 4,
-      "legArmor": 7,
+      "bodyArmor": 28,
+      "armArmor": 13,
+      "legArmor": 8,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -11357,9 +11357,9 @@
     "name": "Infantryman Gambeson over Leather Jacket",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 624,
+    "price": 5128,
     "weight": 3.816213,
-    "tier": 3.20317221,
+    "tier": 5.948748,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11367,8 +11367,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 4,
+      "bodyArmor": 28,
+      "armArmor": 13,
       "legArmor": 8,
       "materialType": "Cloth"
     },
@@ -11379,9 +11379,9 @@
     "name": "Infantryman Gambeson with Skirts",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 624,
+    "price": 5128,
     "weight": 3.816213,
-    "tier": 3.20317221,
+    "tier": 5.948748,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11389,8 +11389,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 4,
+      "bodyArmor": 28,
+      "armArmor": 13,
       "legArmor": 8,
       "materialType": "Cloth"
     },
@@ -11401,9 +11401,9 @@
     "name": "Infantryman Gambeson with Straps",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 624,
+    "price": 5128,
     "weight": 3.816213,
-    "tier": 3.20317221,
+    "tier": 5.948748,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11411,8 +11411,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 4,
+      "bodyArmor": 28,
+      "armArmor": 13,
       "legArmor": 8,
       "materialType": "Cloth"
     },
@@ -11423,9 +11423,9 @@
     "name": "Infantryman Long Gambeson",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 698,
+    "price": 5010,
     "weight": 4.075933,
-    "tier": 3.31868339,
+    "tier": 5.909984,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11433,8 +11433,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 5,
+      "bodyArmor": 28,
+      "armArmor": 13,
       "legArmor": 8,
       "materialType": "Cloth"
     },
@@ -11445,18 +11445,18 @@
     "name": "Auxiliary Armor",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 695,
+    "price": 1192,
     "weight": 4.001147,
-    "tier": 3.31347775,
+    "tier": 3.90557671,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 17,
-      "armArmor": 4,
-      "legArmor": 8,
+      "bodyArmor": 26,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -11466,18 +11466,18 @@
     "name": "Auxiliary Armor with Straps",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 771,
+    "price": 1173,
     "weight": 4.188975,
-    "tier": 3.42280841,
+    "tier": 3.88749385,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 18,
-      "armArmor": 4,
-      "legArmor": 8,
+      "bodyArmor": 26,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -11487,15 +11487,15 @@
     "name": "Legionary Padded Straps",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 468,
+    "price": 2015,
     "weight": 1.221603,
-    "tier": 4.07808971,
+    "tier": 6.29745865,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 9,
-      "armArmor": 4,
+      "bodyArmor": 13,
+      "armArmor": 7,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -11541,13 +11541,13 @@
     "name": "Feathered Spangenhelm over Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3807,
+    "price": 928,
     "weight": 2.470721,
-    "tier": 6.93163824,
+    "tier": 4.621093,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 42,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -11706,9 +11706,9 @@
     "name": "Fine Town Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 56,
+    "price": 52,
     "weight": 0.1254426,
-    "tier": 1.46048379,
+    "tier": 1.09536278,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11717,7 +11717,7 @@
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 4,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -11727,9 +11727,9 @@
     "name": "Rich Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 51,
+    "price": 95,
     "weight": 0.2160417,
-    "tier": 0.5306698,
+    "tier": 1.50140727,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11737,9 +11737,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 2,
-      "armArmor": 1,
-      "legArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -11808,9 +11808,9 @@
     "name": "Folded Town Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 56,
+    "price": 52,
     "weight": 0.1254426,
-    "tier": 1.46048379,
+    "tier": 1.09536278,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11819,7 +11819,7 @@
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 4,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -11829,9 +11829,9 @@
     "name": "Military Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 58,
+    "price": 93,
     "weight": 0.4770266,
-    "tier": 0.895203352,
+    "tier": 1.48347962,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -11839,8 +11839,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
     },
@@ -12820,9 +12820,9 @@
     "name": "Half Apron",
     "culture": "Neutral",
     "type": "BodyArmor",
-    "price": 53,
+    "price": 94,
     "weight": 0.2901902,
-    "tier": 0.6707019,
+    "tier": 1.49618125,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -12830,9 +12830,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 3,
-      "armArmor": 1,
-      "legArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -13289,13 +13289,13 @@
     "name": "Heavy Nasalhelm over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5813,
+    "price": 7781,
     "weight": 3.018642,
-    "tier": 7.794133,
+    "tier": 8.443645,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 48,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -13308,13 +13308,13 @@
     "name": "Heavy Nasalhelm over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 7039,
+    "price": 7556,
     "weight": 3.306017,
-    "tier": 8.215069,
+    "tier": 8.376148,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 51,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -13327,15 +13327,15 @@
     "name": "Heavy Nasalhelm over Padding",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5813,
+    "price": 7781,
     "weight": 3.018642,
-    "tier": 7.794133,
+    "tier": 8.443645,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 48,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -13348,15 +13348,15 @@
     "name": "Heavy Nasalhelm over Laced Cloth",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5081,
+    "price": 7936,
     "weight": 2.831956,
-    "tier": 7.509759,
+    "tier": 8.489293,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 46,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -13484,13 +13484,13 @@
     "name": "Helmet with Faceguard",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 743,
+    "price": 3773,
     "weight": 1.134645,
-    "tier": 4.321307,
+    "tier": 6.91409063,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 25,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -13503,9 +13503,9 @@
     "name": "Hemp Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 58,
+    "price": 93,
     "weight": 0.4770266,
-    "tier": 0.895203352,
+    "tier": 1.48347962,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -13513,8 +13513,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
     },
@@ -14335,16 +14335,16 @@
     "name": "Cloth Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 50,
+    "price": 56,
     "weight": 0.02567407,
-    "tier": 0.362943858,
+    "tier": 1.08883154,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
       "Civilian"
     ],
     "armor": {
-      "headArmor": 2,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14357,13 +14357,13 @@
     "name": "Goggled Cataphract Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 7483,
+    "price": 16072,
     "weight": 3.403728,
-    "tier": 8.353923,
+    "tier": 10.2817507,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 52,
+      "headArmor": 64,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14376,18 +14376,18 @@
     "name": "Cataphract Lamellar Armor",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 13954,
+    "price": 21650,
     "weight": 20.72603,
-    "tier": 7.850629,
+    "tier": 8.850129,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 48,
-      "armArmor": 14,
-      "legArmor": 24,
+      "bodyArmor": 52,
+      "armArmor": 23,
+      "legArmor": 18,
       "materialType": "Plate"
     },
     "weapons": []
@@ -14397,18 +14397,18 @@
     "name": "Luxury Lamellar Vest over Leather",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 2993,
+    "price": 5337,
     "weight": 7.695641,
-    "tier": 5.108132,
+    "tier": 6.01577473,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 33,
-      "armArmor": 6,
-      "legArmor": 7,
+      "bodyArmor": 38,
+      "armArmor": 8,
+      "legArmor": 8,
       "materialType": "Plate"
     },
     "weapons": []
@@ -14418,14 +14418,14 @@
     "name": "Heavy Lamellar Pauldrons",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 3954,
+    "price": 4514,
     "weight": 3.526454,
-    "tier": 7.60683775,
+    "tier": 7.89048338,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 17,
+      "bodyArmor": 18,
       "armArmor": 9,
       "legArmor": 0,
       "materialType": "Plate"
@@ -14459,13 +14459,13 @@
     "name": "Mail Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 330,
+    "price": 1142,
     "weight": 0.7517617,
-    "tier": 3.33549166,
+    "tier": 4.91546154,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 19,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14478,18 +14478,18 @@
     "name": "Infantryman Mail over Leather",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 2524,
+    "price": 14854,
     "weight": 6.965938,
-    "tier": 4.8643384,
+    "tier": 7.986067,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 31,
-      "armArmor": 6,
-      "legArmor": 6,
+      "bodyArmor": 40,
+      "armArmor": 18,
+      "legArmor": 13,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -14499,18 +14499,18 @@
     "name": "Infantryman Mail over Striped Leather",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 2524,
+    "price": 14854,
     "weight": 6.965938,
-    "tier": 4.8643384,
+    "tier": 7.986067,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 31,
-      "armArmor": 6,
-      "legArmor": 6,
+      "bodyArmor": 40,
+      "armArmor": 18,
+      "legArmor": 13,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -14520,18 +14520,18 @@
     "name": "Infantryman Mail Vest",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 3347,
+    "price": 12782,
     "weight": 9.473157,
-    "tier": 5.273401,
+    "tier": 7.66387272,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 26,
-      "armArmor": 12,
-      "legArmor": 12,
+      "bodyArmor": 40,
+      "armArmor": 18,
+      "legArmor": 13,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -14541,15 +14541,15 @@
     "name": "Legionary Helm",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2333,
+    "price": 3391,
     "weight": 1.960666,
-    "tier": 6.039774,
+    "tier": 6.71086,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 36,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14562,9 +14562,9 @@
     "name": "Infantryman Rough Gambeson",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 779,
+    "price": 4896,
     "weight": 4.341292,
-    "tier": 3.43279958,
+    "tier": 5.871894,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -14572,8 +14572,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 6,
+      "bodyArmor": 28,
+      "armArmor": 13,
       "legArmor": 8,
       "materialType": "Cloth"
     },
@@ -14584,15 +14584,15 @@
     "name": "Lightweight Padded Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 153,
+    "price": 56,
     "weight": 0.4754905,
-    "tier": 2.48735118,
+    "tier": 1.06600761,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "armor": {
-      "headArmor": 14,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14626,9 +14626,9 @@
     "name": "Toga",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 152,
+    "price": 87,
     "weight": 1.562045,
-    "tier": 1.92253506,
+    "tier": 1.42047179,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -14636,9 +14636,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 8,
-      "armArmor": 4,
-      "legArmor": 3,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -14648,16 +14648,16 @@
     "name": "Heavy Scale Armor over Mail Hauberk",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 19156,
+    "price": 41104,
     "weight": 23.02404,
-    "tier": 8.560322,
+    "tier": 10.524107,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 57,
-      "armArmor": 16,
-      "legArmor": 20,
+      "bodyArmor": 64,
+      "armArmor": 25,
+      "legArmor": 25,
       "materialType": "Plate"
     },
     "weapons": []
@@ -14768,15 +14768,15 @@
     "name": "Legionary Reinforced Studded Harness",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 483,
+    "price": 1988,
     "weight": 1.323371,
-    "tier": 4.11764765,
+    "tier": 6.27319431,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 7,
-      "armArmor": 6,
+      "bodyArmor": 13,
+      "armArmor": 7,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -14916,13 +14916,13 @@
     "name": "Feathered Spangenhelm",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 838,
+    "price": 1074,
     "weight": 1.203399,
-    "tier": 4.482219,
+    "tier": 4.827006,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 26,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14935,13 +14935,13 @@
     "name": "Feathered Spangenhelm over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2333,
+    "price": 980,
     "weight": 1.960666,
-    "tier": 6.039774,
+    "tier": 4.69760227,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 36,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14954,13 +14954,13 @@
     "name": "Spangenhelm over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3807,
+    "price": 3198,
     "weight": 2.470721,
-    "tier": 6.93163824,
+    "tier": 6.60156,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 42,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14973,15 +14973,15 @@
     "name": "Iron Legionary Helm over Cloth",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5081,
+    "price": 3076,
     "weight": 2.831956,
-    "tier": 7.509759,
+    "tier": 6.53022528,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 46,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -14994,13 +14994,13 @@
     "name": "Iron Nasalhelm over Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5813,
+    "price": 3018,
     "weight": 3.018642,
-    "tier": 7.794133,
+    "tier": 6.495111,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 48,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -15013,13 +15013,13 @@
     "name": "Iron Nasalhelm over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5813,
+    "price": 7781,
     "weight": 3.018642,
-    "tier": 7.794133,
+    "tier": 8.443645,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 48,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -15032,13 +15032,13 @@
     "name": "Iron Nasalhelm over Padding",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5081,
+    "price": 3076,
     "weight": 2.831956,
-    "tier": 7.509759,
+    "tier": 6.53022528,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 46,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -15051,13 +15051,13 @@
     "name": "Iron Roundkettle over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1310,
+    "price": 1036,
     "weight": 1.491529,
-    "tier": 5.11634445,
+    "tier": 4.775255,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 30,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -15070,13 +15070,13 @@
     "name": "Iron Roundkettle over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2333,
+    "price": 3391,
     "weight": 1.960666,
-    "tier": 6.039774,
+    "tier": 6.71086,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 36,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -15089,13 +15089,13 @@
     "name": "Iron Spiked Kettle over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1770,
+    "price": 3492,
     "weight": 1.720762,
-    "tier": 5.58213568,
+    "tier": 6.76622438,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 33,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -16939,16 +16939,16 @@
     "name": "Lamellar Plate Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 1159,
+    "price": 5990,
     "weight": 1.29863,
-    "tier": 6.598599,
+    "tier": 10.41884,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 19,
+      "legArmor": 30,
       "materialType": "Plate"
     },
     "weapons": []
@@ -16958,15 +16958,15 @@
     "name": "Lamellar Plate Gauntlets",
     "culture": "Empire",
     "type": "HandArmor",
-    "price": 2782,
+    "price": 7336,
     "weight": 4.001147,
-    "tier": 7.84181166,
+    "tier": 10.22845,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
-      "armArmor": 23,
+      "armArmor": 30,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -16996,9 +16996,9 @@
     "name": "Lamellar with Scale Skirt",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 16996,
+    "price": 18670,
     "weight": 22.55802,
-    "tier": 8.285603,
+    "tier": 8.500581,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -17006,7 +17006,7 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 52,
-      "armArmor": 16,
+      "armArmor": 18,
       "legArmor": 23,
       "materialType": "Plate"
     },
@@ -17195,9 +17195,9 @@
     "name": "Leather Apron",
     "culture": "Neutral",
     "type": "BodyArmor",
-    "price": 63,
+    "price": 92,
     "weight": 0.6110581,
-    "tier": 1.04249811,
+    "tier": 1.47475338,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -17205,8 +17205,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 2,
+      "bodyArmor": 6,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Leather"
     },
@@ -17276,15 +17276,15 @@
     "name": "Leather Cap",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 66,
+    "price": 56,
     "weight": 0.2053926,
-    "tier": 1.43914938,
+    "tier": 1.079362,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "armor": {
-      "headArmor": 8,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -17439,9 +17439,9 @@
     "name": "Leather Scale Armor",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 80,
+    "price": 4276,
     "weight": 3.889836,
-    "tier": 1.32454252,
+    "tier": 5.65214252,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -17449,9 +17449,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Leather"
     },
     "weapons": []
@@ -17580,9 +17580,9 @@
     "name": "Leather Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 276,
+    "price": 1378,
     "weight": 2.446993,
-    "tier": 2.4372716,
+    "tier": 4.07797146,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -17590,9 +17590,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 12,
-      "armArmor": 2,
-      "legArmor": 7,
+      "bodyArmor": 26,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -17602,9 +17602,49 @@
     "name": "Spangenhelm over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3261,
+    "price": 945,
     "weight": 2.296359,
-    "tier": 6.637725,
+    "tier": 4.6464076,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor"
+    ],
+    "armor": {
+      "headArmor": 28,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_leatherlame_feathered_spangenhelm_over_mail",
+    "name": "Feathered Spangenhelm over Mail",
+    "culture": "Empire",
+    "type": "HeadArmor",
+    "price": 3198,
+    "weight": 2.470721,
+    "tier": 6.60156,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 40,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_leatherlame_nasalhelm_over_imperial_leather",
+    "name": "Iron Nasalhelm over Leather",
+    "culture": "Empire",
+    "type": "HeadArmor",
+    "price": 3167,
+    "weight": 2.559484,
+    "tier": 6.58359671,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -17619,57 +17659,17 @@
     "weapons": []
   },
   {
-    "id": "crpg_leatherlame_feathered_spangenhelm_over_mail",
-    "name": "Feathered Spangenhelm over Mail",
-    "culture": "Empire",
-    "type": "HeadArmor",
-    "price": 3807,
-    "weight": 2.470721,
-    "tier": 6.93163824,
-    "requirement": 0,
-    "flags": [],
-    "armor": {
-      "headArmor": 42,
-      "bodyArmor": 0,
-      "armArmor": 0,
-      "legArmor": 0,
-      "materialType": "Plate"
-    },
-    "weapons": []
-  },
-  {
-    "id": "crpg_leatherlame_nasalhelm_over_imperial_leather",
-    "name": "Iron Nasalhelm over Leather",
-    "culture": "Empire",
-    "type": "HeadArmor",
-    "price": 4103,
-    "weight": 2.559484,
-    "tier": 7.07736635,
-    "requirement": 0,
-    "flags": [
-      "UseTeamColor"
-    ],
-    "armor": {
-      "headArmor": 43,
-      "bodyArmor": 0,
-      "armArmor": 0,
-      "legArmor": 0,
-      "materialType": "Plate"
-    },
-    "weapons": []
-  },
-  {
     "id": "crpg_leatherlame_nasalhelm_over_imperial_mail",
     "name": "Bronze Nasalhelm over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2770,
+    "price": 3325,
     "weight": 2.126303,
-    "tier": 6.340465,
+    "tier": 6.674173,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 38,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -17682,15 +17682,15 @@
     "name": "Roundkettle Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2333,
+    "price": 3391,
     "weight": 1.960666,
-    "tier": 6.039774,
+    "tier": 6.71086,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 36,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -17703,13 +17703,13 @@
     "name": "Roundkettle over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1310,
+    "price": 1036,
     "weight": 1.491529,
-    "tier": 5.11634445,
+    "tier": 4.775255,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 30,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -17722,18 +17722,18 @@
     "name": "Legionary Mail",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 7180,
+    "price": 3828,
     "weight": 14.6806,
-    "tier": 6.53510046,
+    "tier": 5.477952,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 34,
-      "armArmor": 15,
-      "legArmor": 18,
+      "bodyArmor": 38,
+      "armArmor": 8,
+      "legArmor": 8,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -18262,9 +18262,9 @@
     "name": "Long Padded Robe",
     "culture": "Aserai",
     "type": "BodyArmor",
-    "price": 83,
+    "price": 4767,
     "weight": 2.770139,
-    "tier": 1.36571479,
+    "tier": 5.82783461,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -18272,9 +18272,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -18526,13 +18526,13 @@
     "name": "Mail Coif with Helmet Padding",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 285,
+    "price": 1152,
     "weight": 0.6932,
-    "tier": 3.167786,
+    "tier": 4.92766762,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 18,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -23234,13 +23234,13 @@
     "name": "Open Mail Coif",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 285,
+    "price": 1152,
     "weight": 0.6932,
-    "tier": 3.167786,
+    "tier": 4.92766762,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 18,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -23373,18 +23373,18 @@
     "name": "Padded Cloth with Strips",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 358,
+    "price": 4767,
     "weight": 2.770139,
-    "tier": 2.67256236,
+    "tier": 5.82783461,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 14,
-      "armArmor": 2,
-      "legArmor": 7,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -23394,18 +23394,18 @@
     "name": "Padded Footman Coat",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 78,
+    "price": 4880,
     "weight": 4.379655,
-    "tier": 1.30868244,
+    "tier": 5.86650753,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 13,
+      "legArmor": 8,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -23476,9 +23476,9 @@
     "name": "Padded Leather Shirt",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 624,
+    "price": 4304,
     "weight": 3.816213,
-    "tier": 3.20317221,
+    "tier": 5.66275024,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -23486,9 +23486,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 4,
-      "legArmor": 8,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Leather"
     },
     "weapons": []
@@ -23517,9 +23517,9 @@
     "name": "Padded Mittens",
     "culture": "Empire",
     "type": "HandArmor",
-    "price": 185,
+    "price": 420,
     "weight": 0.9793918,
-    "tier": 3.37385416,
+    "tier": 4.498472,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23527,7 +23527,7 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
-      "armArmor": 9,
+      "armArmor": 12,
       "legArmor": 0,
       "materialType": "Cloth"
     },
@@ -23538,18 +23538,18 @@
     "name": "Padded Short Coat",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 544,
+    "price": 922,
     "weight": 3.106376,
-    "tier": 3.06653285,
+    "tier": 3.61454487,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 15,
-      "armArmor": 7,
-      "legArmor": 2,
+      "bodyArmor": 23,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -23578,9 +23578,9 @@
     "name": "Patched Gambeson",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 409,
+    "price": 4653,
     "weight": 3.004161,
-    "tier": 2.79478383,
+    "tier": 5.78835964,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -23588,9 +23588,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 14,
-      "armArmor": 3,
-      "legArmor": 7,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -23600,17 +23600,17 @@
     "name": "Legionary Cape",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 1705,
+    "price": 1786,
     "weight": 2.198272,
-    "tier": 6.00473976,
+    "tier": 6.08516,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 4,
+      "bodyArmor": 13,
+      "armArmor": 7,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -23877,9 +23877,9 @@
     "name": "Commoner Clothes",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 58,
+    "price": 93,
     "weight": 0.4770266,
-    "tier": 0.895203352,
+    "tier": 1.48347962,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -23887,8 +23887,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
     },
@@ -24470,16 +24470,16 @@
     "name": "Pilgrim Hood",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 50,
+    "price": 56,
     "weight": 0.04716628,
-    "tier": 0.5438363,
+    "tier": 1.08767259,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
       "Civilian"
     ],
     "armor": {
-      "headArmor": 3,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -24535,16 +24535,16 @@
     "name": "Splint Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 1862,
+    "price": 924,
     "weight": 1.61804,
-    "tier": 7.551558,
+    "tier": 6.178547,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 22,
+      "legArmor": 18,
       "materialType": "Plate"
     },
     "weapons": []
@@ -24554,15 +24554,15 @@
     "name": "Plated Striped Vambraces",
     "culture": "Empire",
     "type": "HandArmor",
-    "price": 2429,
+    "price": 1198,
     "weight": 3.74306,
-    "tier": 7.55021334,
+    "tier": 6.17744732,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
-      "armArmor": 22,
+      "armArmor": 18,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -24592,13 +24592,13 @@
     "name": "Plumed Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 5439,
+    "price": 3047,
     "weight": 2.924803,
-    "tier": 7.65232754,
+    "tier": 6.5126195,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 47,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -25656,13 +25656,13 @@
     "name": "Light Roundkettle over Leather",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 505,
+    "price": 1113,
     "weight": 0.936664,
-    "tier": 3.83277321,
+    "tier": 4.878075,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 22,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -25675,13 +25675,13 @@
     "name": "Roundkettle over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1945,
+    "price": 3458,
     "weight": 1.799568,
-    "tier": 5.735575,
+    "tier": 6.747735,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 34,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -25694,15 +25694,15 @@
     "name": "Roundkettle over Padding",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 1452,
+    "price": 1026,
     "weight": 1.566723,
-    "tier": 5.27252865,
+    "tier": 4.76228428,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 31,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -25715,13 +25715,131 @@
     "name": "Roundkettle over Laced Cloth",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 838,
+    "price": 1074,
     "weight": 1.203399,
-    "tier": 4.482219,
+    "tier": 4.827006,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 26,
+      "headArmor": 28,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_armour",
+    "name": "Vaegir Coat of Plates",
+    "culture": "Sturgia",
+    "type": "BodyArmor",
+    "price": 10663,
+    "weight": 16.38,
+    "tier": 7.29118347,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor"
+    ],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 46,
+      "armArmor": 14,
+      "legArmor": 14,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_armour1",
+    "name": "Vaegir Coat of Plates",
+    "culture": "Sturgia",
+    "type": "BodyArmor",
+    "price": 10663,
+    "weight": 16.38,
+    "tier": 7.29118347,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor"
+    ],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 46,
+      "armArmor": 14,
+      "legArmor": 14,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_noble",
+    "name": "Vaegir Noble Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_regular",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_helm_regular2",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 7037,
+    "weight": 3.31,
+    "tier": 8.214173,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 51,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_rus_open_helm",
+    "name": "Vaegir Helmet",
+    "culture": "Sturgia",
+    "type": "HeadArmor",
+    "price": 6207,
+    "weight": 3.11,
+    "tier": 7.93595743,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 49,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -26681,9 +26799,9 @@
     "name": "Short Padded Robe",
     "culture": "Aserai",
     "type": "BodyArmor",
-    "price": 83,
+    "price": 5802,
     "weight": 2.574646,
-    "tier": 1.37374151,
+    "tier": 6.158151,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -26691,9 +26809,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 13,
+      "legArmor": 8,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -26966,18 +27084,18 @@
     "name": "Sleeveless Padded Coat",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 656,
+    "price": 4276,
     "weight": 3.889836,
-    "tier": 3.25426388,
+    "tier": 5.65214252,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 18,
-      "armArmor": 2,
-      "legArmor": 9,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -26987,9 +27105,9 @@
     "name": "Sleeveless Padded Short Coat",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 82,
+    "price": 4685,
     "weight": 2.936653,
-    "tier": 1.359094,
+    "tier": 5.79958248,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -26997,9 +27115,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 8,
+      "legArmor": 13,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -27885,13 +28003,13 @@
     "name": "Spiked Kettle over Mail",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 942,
+    "price": 3701,
     "weight": 1.27349,
-    "tier": 4.64217234,
+    "tier": 6.87729263,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 27,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -27904,15 +28022,15 @@
     "name": "Spiked Kettle over Padding",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3008,
+    "price": 953,
     "weight": 2.210786,
-    "tier": 6.489519,
+    "tier": 4.659142,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
-      "headArmor": 39,
+      "headArmor": 28,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -28820,9 +28938,9 @@
     "name": "Strapped Leather Boots",
     "culture": "Empire",
     "type": "LegArmor",
-    "price": 62,
+    "price": 52,
     "weight": 0.1753114,
-    "tier": 1.82122278,
+    "tier": 1.09273362,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -28831,7 +28949,7 @@
       "headArmor": 0,
       "bodyArmor": 0,
       "armArmor": 0,
-      "legArmor": 5,
+      "legArmor": 3,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -29157,15 +29275,15 @@
     "name": "Neckguard with Bronze Plate Pauldrons",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 2031,
+    "price": 4997,
     "weight": 2.54253,
-    "tier": 6.31143475,
+    "tier": 8.114702,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 14,
-      "armArmor": 7,
+      "bodyArmor": 18,
+      "armArmor": 9,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -29176,18 +29294,18 @@
     "name": "Studded Leather Coat",
     "culture": "Aserai",
     "type": "BodyArmor",
-    "price": 86,
+    "price": 1056,
     "weight": 1.784997,
-    "tier": 1.40935,
+    "tier": 3.766367,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
+      "bodyArmor": 23,
       "armArmor": 3,
-      "legArmor": 2,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -30783,13 +30901,13 @@
     "name": "Tall Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 2770,
+    "price": 3325,
     "weight": 2.126303,
-    "tier": 6.340465,
+    "tier": 6.674173,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 38,
+      "headArmor": 40,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -31108,9 +31226,9 @@
     "name": "Tied Cloth Tunic",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 56,
+    "price": 94,
     "weight": 0.3712929,
-    "tier": 0.8095433,
+    "tier": 1.49058771,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -31118,9 +31236,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 1,
-      "legArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -31750,9 +31868,9 @@
     "name": "Tunic with Rolled Cloth",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 85,
+    "price": 90,
     "weight": 0.9561659,
-    "tier": 1.39096224,
+    "tier": 1.45361817,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -31761,8 +31879,8 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 6,
-      "armArmor": 2,
-      "legArmor": 3,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -31772,9 +31890,9 @@
     "name": "Tunic with Shoulder Pads",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 70,
+    "price": 91,
     "weight": 0.7133473,
-    "tier": 1.17716837,
+    "tier": 1.468296,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -31782,8 +31900,8 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 5,
-      "armArmor": 2,
+      "bodyArmor": 6,
+      "armArmor": 3,
       "legArmor": 2,
       "materialType": "Cloth"
     },
@@ -31967,15 +32085,15 @@
     "name": "Decorated Leather Harness",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 311,
+    "price": 2308,
     "weight": 1.122585,
-    "tier": 3.56461334,
+    "tier": 6.54440641,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 4,
-      "armArmor": 7,
+      "bodyArmor": 17,
+      "armArmor": 4,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -31986,15 +32104,15 @@
     "name": "Decorated Leather Harness over Mail",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 3975,
+    "price": 4923,
     "weight": 3.598177,
-    "tier": 7.61815929,
+    "tier": 8.081426,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 16,
-      "armArmor": 10,
+      "bodyArmor": 22,
+      "armArmor": 6,
       "legArmor": 0,
       "materialType": "Chainmail"
     },
@@ -32005,17 +32123,17 @@
     "name": "Decorated Leather Harness with Padding",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 1284,
+    "price": 5751,
     "weight": 2.137492,
-    "tier": 5.533109,
+    "tier": 8.433963,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 10,
-      "armArmor": 8,
+      "bodyArmor": 22,
+      "armArmor": 6,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -32026,17 +32144,17 @@
     "name": "Caped Leather Harness",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 393,
+    "price": 2270,
     "weight": 1.24679,
-    "tier": 3.8524437,
+    "tier": 6.51312447,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 5,
-      "armArmor": 7,
+      "bodyArmor": 17,
+      "armArmor": 4,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -32047,15 +32165,15 @@
     "name": "Decorated Leather Harness over Scale",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 6841,
+    "price": 9231,
     "weight": 4.690566,
-    "tier": 8.844338,
+    "tier": 9.595982,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 19,
-      "armArmor": 12,
+      "bodyArmor": 25,
+      "armArmor": 9,
       "legArmor": 0,
       "materialType": "Plate"
     },
@@ -32506,15 +32624,15 @@
     "name": "Austere Crown",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 51,
+    "price": 56,
     "weight": 0.07261725,
-    "tier": 0.724206567,
+    "tier": 1.08630979,
     "requirement": 0,
     "flags": [
       "Civilian"
     ],
     "armor": {
-      "headArmor": 4,
+      "headArmor": 6,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -33251,9 +33369,9 @@
     "name": "Rich Dress",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 53,
+    "price": 94,
     "weight": 0.2901902,
-    "tier": 0.6707019,
+    "tier": 1.49618125,
     "requirement": 0,
     "flags": [
       "UseTeamColor",
@@ -33261,9 +33379,9 @@
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 3,
-      "armArmor": 1,
-      "legArmor": 1,
+      "bodyArmor": 6,
+      "armArmor": 3,
+      "legArmor": 2,
       "materialType": "Cloth"
     },
     "weapons": []
@@ -34972,15 +35090,15 @@
     "name": "Woven Leather Bracers",
     "culture": "Empire",
     "type": "HandArmor",
-    "price": 86,
+    "price": 53,
     "weight": 0.5331134,
-    "tier": 2.29187512,
+    "tier": 1.14593756,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
       "bodyArmor": 0,
-      "armArmor": 6,
+      "armArmor": 3,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -34991,18 +35109,18 @@
     "name": "Boarskin Leather Coat",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 465,
+    "price": 1274,
     "weight": 3.244425,
-    "tier": 2.91537523,
+    "tier": 3.9839592,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 14,
-      "armArmor": 4,
-      "legArmor": 7,
+      "bodyArmor": 26,
+      "armArmor": 3,
+      "legArmor": 3,
       "materialType": "Leather"
     },
     "weapons": []
@@ -35012,15 +35130,15 @@
     "name": "Woven Leather Shoulders",
     "culture": "Empire",
     "type": "ShoulderArmor",
-    "price": 231,
+    "price": 500,
     "weight": 0.8651426,
-    "tier": 3.20764279,
+    "tier": 4.164308,
     "requirement": 0,
     "flags": [],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 4,
+      "bodyArmor": 8,
+      "armArmor": 5,
       "legArmor": 0,
       "materialType": "Leather"
     },
@@ -35031,18 +35149,18 @@
     "name": "Woven Leather Vest",
     "culture": "Vlandia",
     "type": "BodyArmor",
-    "price": 85,
+    "price": 6095,
     "weight": 2.137492,
-    "tier": 1.39277613,
+    "tier": 6.24347925,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 6,
-      "armArmor": 3,
-      "legArmor": 2,
+      "bodyArmor": 28,
+      "armArmor": 13,
+      "legArmor": 8,
       "materialType": "Leather"
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -14376,9 +14376,9 @@
     "name": "Cataphract Lamellar Armor",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 21650,
+    "price": 19676,
     "weight": 20.72603,
-    "tier": 8.850129,
+    "tier": 8.62297,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -14386,8 +14386,8 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 52,
-      "armArmor": 23,
-      "legArmor": 18,
+      "armArmor": 18,
+      "legArmor": 23,
       "materialType": "Plate"
     },
     "weapons": []

--- a/items.json
+++ b/items.json
@@ -10207,13 +10207,13 @@
     "name": "Jeweled Plumed Battle Crown",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3106,
+    "price": 8015,
     "weight": 2.740113,
-    "tier": 6.547925,
+    "tier": 8.512302,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 40,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10226,13 +10226,13 @@
     "name": "Imperial Plumed Helmet",
     "culture": "Empire",
     "type": "HeadArmor",
-    "price": 3018,
+    "price": 7781,
     "weight": 3.018642,
-    "tier": 6.495111,
+    "tier": 8.443645,
     "requirement": 0,
     "flags": [],
     "armor": {
-      "headArmor": 40,
+      "headArmor": 52,
       "bodyArmor": 0,
       "armArmor": 0,
       "legArmor": 0,
@@ -10667,9 +10667,9 @@
     "name": "Decorated Legionary Mail",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 10498,
+    "price": 11880,
     "weight": 10.89783,
-    "tier": 7.25995827,
+    "tier": 7.511342,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
@@ -10677,8 +10677,8 @@
     "armor": {
       "headArmor": 0,
       "bodyArmor": 40,
-      "armArmor": 13,
-      "legArmor": 18,
+      "armArmor": 18,
+      "legArmor": 13,
       "materialType": "Chainmail"
     },
     "weapons": []
@@ -10688,17 +10688,17 @@
     "name": "Ornate Legionary Scale Mail",
     "culture": "Empire",
     "type": "BodyArmor",
-    "price": 9750,
+    "price": 29186,
     "weight": 12.49636,
-    "tier": 7.113463,
+    "tier": 9.596278,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 40,
-      "armArmor": 13,
+      "bodyArmor": 52,
+      "armArmor": 23,
       "legArmor": 18,
       "materialType": "Plate"
     },

--- a/items.json
+++ b/items.json
@@ -4698,9 +4698,9 @@
     "name": "Rhomphaia",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 22207,
-    "weight": 1.35,
-    "tier": 11.9037714,
+    "price": 12165,
+    "weight": 1.41,
+    "tier": 8.530093,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4711,8 +4711,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 184,
-        "balance": 0.28,
-        "handling": 67,
+        "balance": 0.23,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -4724,9 +4724,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 96,
-        "swingDamage": 47,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 77
       }
     ]
   },
@@ -5638,9 +5638,9 @@
     "name": "Bec De Corbin",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 2404,
-    "weight": 2.4,
-    "tier": 3.2347157,
+    "price": 16112,
+    "weight": 1.91,
+    "tier": 9.978577,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5652,9 +5652,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 141,
-        "balance": 0.0,
-        "handling": 59,
+        "length": 124,
+        "balance": 0.47,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5662,12 +5662,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 35,
+        "thrustSpeed": 93,
+        "swingDamage": 30,
         "swingDamageType": "Pierce",
-        "swingSpeed": 68
+        "swingSpeed": 84
       }
     ]
   },
@@ -5718,9 +5718,9 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 23531,
+    "price": 13892,
     "weight": 1.91,
-    "tier": 12.2855167,
+    "tier": 9.188915,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5744,7 +5744,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 93,
-        "swingDamage": 48,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }
@@ -6947,9 +6947,9 @@
     "name": "Burgundian Glaive",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 1153,
-    "weight": 2.0,
-    "tier": 1.96433771,
+    "price": 15642,
+    "weight": 1.78,
+    "tier": 9.816252,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -6962,8 +6962,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.0,
-        "handling": 59,
+        "balance": 0.21,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -6971,12 +6971,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 30,
+        "thrustSpeed": 93,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 69
+        "swingSpeed": 76
       }
     ]
   },
@@ -6985,9 +6985,9 @@
     "name": "Burgundian Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 5239,
-    "weight": 2.4,
-    "tier": 5.240514,
+    "price": 15591,
+    "weight": 2.27,
+    "tier": 9.798337,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -7000,8 +7000,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.32,
-        "handling": 70,
+        "balance": 0.41,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -7011,10 +7011,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 37,
+        "thrustSpeed": 91,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -9107,9 +9107,9 @@
     "name": "Polesword",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 13524,
+    "price": 8916,
     "weight": 1.75,
-    "tier": 9.051901,
+    "tier": 7.150599,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9132,7 +9132,7 @@
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
-        "swingDamage": 50,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
         "swingSpeed": 65
       }
@@ -11030,9 +11030,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 19825,
-    "weight": 1.72,
-    "tier": 11.1870556,
+    "price": 15657,
+    "weight": 1.84,
+    "tier": 9.821469,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11043,8 +11043,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 169,
-        "balance": 0.44,
-        "handling": 72,
+        "balance": 0.33,
+        "handling": 69,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -11052,12 +11052,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
-        "swingDamage": 38,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 80
       }
     ]
   },
@@ -11927,9 +11927,9 @@
     "name": "French Voulge",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 10822,
-    "weight": 1.8,
-    "tier": 7.985214,
+    "price": 15986,
+    "weight": 1.99,
+    "tier": 9.935265,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -11941,9 +11941,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 134,
-        "balance": 0.75,
-        "handling": 79,
+        "length": 133,
+        "balance": 0.61,
+        "handling": 75,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -11951,12 +11951,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 27,
+        "thrustSpeed": 93,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 88
       }
     ]
   },
@@ -16531,9 +16531,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 18860,
-    "weight": 1.63,
-    "tier": 10.88465,
+    "price": 15045,
+    "weight": 1.68,
+    "tier": 9.606287,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16544,8 +16544,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 147,
-        "balance": 0.48,
-        "handling": 72,
+        "balance": 0.44,
+        "handling": 71,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16555,10 +16555,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 95,
+        "thrustSpeed": 94,
         "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 83
       }
     ]
   },
@@ -16567,9 +16567,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 26735,
-    "weight": 1.35,
-    "tier": 13.16743,
+    "price": 15356,
+    "weight": 1.44,
+    "tier": 9.716146,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16580,8 +16580,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.22,
-        "handling": 65,
+        "balance": 0.12,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16589,12 +16589,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 25,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 96,
+        "thrustSpeed": 95,
         "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 73
       }
     ]
   },
@@ -18004,9 +18004,9 @@
     "name": "Long Bardiche",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 26524,
-    "weight": 1.65,
-    "tier": 13.1111193,
+    "price": 15553,
+    "weight": 1.7,
+    "tier": 9.784965,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18018,9 +18018,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 161,
-        "balance": 0.21,
-        "handling": 67,
+        "length": 158,
+        "balance": 0.17,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -18029,12 +18029,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 49,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 75
       }
     ]
   },
@@ -18162,9 +18162,9 @@
     "name": "Long Hafted Spiked Mace",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 23168,
-    "weight": 1.83,
-    "tier": 12.182004,
+    "price": 13559,
+    "weight": 1.87,
+    "tier": 9.065113,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18176,8 +18176,8 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 154,
-        "balance": 0.2,
+        "length": 155,
+        "balance": 0.17,
         "handling": 67,
         "bodyArmor": 0,
         "flags": [
@@ -18187,10 +18187,10 @@
           "TwoHandIdleOnMount",
           "MultiplePenetration"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 17,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 93,
-        "swingDamage": 27,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
         "swingSpeed": 75
       }
@@ -26952,9 +26952,9 @@
     "name": "Simple Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 1229,
-    "weight": 2.4,
-    "tier": 2.05589271,
+    "price": 13780,
+    "weight": 2.2,
+    "tier": 9.14757,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -26967,8 +26967,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 145,
-        "balance": 0.13,
-        "handling": 65,
+        "balance": 0.29,
+        "handling": 69,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -26976,12 +26976,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 35,
+        "thrustSpeed": 91,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 78
       }
     ]
   },
@@ -28043,9 +28043,9 @@
     "name": "Spiked Polehammer",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 1470,
-    "weight": 2.4,
-    "tier": 2.32981586,
+    "price": 15580,
+    "weight": 2.0,
+    "tier": 9.794424,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28058,8 +28058,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 148,
-        "balance": 0.0,
-        "handling": 58,
+        "balance": 0.23,
+        "handling": 67,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28069,10 +28069,10 @@
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 92,
         "swingDamage": 30,
         "swingDamageType": "Blunt",
-        "swingSpeed": 65
+        "swingSpeed": 76
       }
     ]
   },
@@ -30217,9 +30217,9 @@
     "name": "Warrazor",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 24049,
-    "weight": 1.13,
-    "tier": 12.4318876,
+    "price": 13186,
+    "weight": 1.2,
+    "tier": 8.924627,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30230,8 +30230,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.25,
-        "handling": 64,
+        "balance": 0.19,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30239,12 +30239,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 50,
+        "thrustSpeed": 97,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 75
       },
       {
         "class": "TwoHandedPolearm",
@@ -30253,8 +30253,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.25,
-        "handling": 64,
+        "balance": 0.19,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30262,12 +30262,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 50,
+        "thrustSpeed": 97,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 75
       }
     ]
   },
@@ -33137,9 +33137,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 27446,
-    "weight": 1.45,
-    "tier": 13.35587,
+    "price": 15798,
+    "weight": 1.47,
+    "tier": 9.870372,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -33152,7 +33152,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.4,
+        "balance": 0.38,
         "handling": 66,
         "bodyArmor": 0,
         "flags": [
@@ -33162,12 +33162,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 96,
-        "swingDamage": 47,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 81
       }
     ]
   },
@@ -33541,9 +33541,9 @@
     "name": "War Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 18971,
-    "weight": 1.68,
-    "tier": 10.9199886,
+    "price": 12402,
+    "weight": 1.78,
+    "tier": 8.623309,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -33554,8 +33554,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 169,
-        "balance": 0.4,
-        "handling": 70,
+        "balance": 0.31,
+        "handling": 68,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -33566,9 +33566,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 43,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 79
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -11066,9 +11066,9 @@
     "name": "Fine Steel Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 24065,
+    "price": 12611,
     "weight": 1.29,
-    "tier": 12.4365244,
+    "tier": 8.704589,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11088,10 +11088,10 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 25,
         "thrustDamageType": "Cut",
         "thrustSpeed": 96,
-        "swingDamage": 52,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
         "swingSpeed": 71
       }

--- a/items/arm_armors.xml
+++ b/items/arm_armors.xml
@@ -128,31 +128,31 @@
   </Item>
   <Item id="crpg_woven_leather_bracers" name="{=fUmehyHq}Woven Leather Bracers" mesh="vlandia_leather_stripes_bracers" culture="Culture.empire" weight="0.5331134" appearance="1" Type="HandArmor">
     <ItemComponent>
-      <Armor arm_armor="6" covers_hands="false" modifier_group="leather" material_type="Leather" />
+      <Armor arm_armor="3" covers_hands="false" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_padded_mitten" name="{=J3YHMkL3}Padded Mittens" mesh="padded_vambrace_a_mitten" culture="Culture.empire" weight="0.9793918" difficulty="0" appearance="1" Type="HandArmor">
     <ItemComponent>
-      <Armor arm_armor="9" covers_hands="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor arm_armor="12" covers_hands="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_plated_strip_gauntlets" name="{=ulaMq9HL}Plated Striped Vambraces" mesh="empire_plated_gauntlets" culture="Culture.empire" weight="3.74306" appearance="1.3" Type="HandArmor">
     <ItemComponent>
-      <Armor arm_armor="22" covers_hands="false" modifier_group="plate" material_type="Plate" />
+      <Armor arm_armor="18" covers_hands="false" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_lamellar_plate_gauntlets" name="{=XGX6DbFL}Lamellar Plate Gauntlets" mesh="imperial_gauntlets" culture="Culture.empire" weight="4.001147" appearance="3" Type="HandArmor">
     <ItemComponent>
-      <Armor arm_armor="23" covers_hands="true" modifier_group="plate" material_type="Plate" />
+      <Armor arm_armor="30" covers_hands="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_decorated_imperial_gauntlets" name="{=2XEbqNQz}Decorated Imperial Gauntlets" mesh="empire_plate_armor_gauntlets" culture="Culture.empire" weight="3.244425" appearance="3" Type="HandArmor">
     <ItemComponent>
-      <Armor arm_armor="20" covers_hands="true" modifier_group="plate" material_type="Plate" />
+      <Armor arm_armor="24" covers_hands="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>

--- a/items/body_armors.xml
+++ b/items/body_armors.xml
@@ -1219,13 +1219,13 @@
   </Item>
   <Item id="crpg_empire_legion_a" name="{=mBVCyRY5}Decorated Legionary Mail" mesh="empire_legion_a" subtype="body_armor" culture="Culture.empire" weight="10.89783" difficulty="0" appearance="5.5" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="40" leg_armor="18" arm_armor="13" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="13" arm_armor="18" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_legion_b" name="{=7HbspP6x}Ornate Legionary Scale Mail" mesh="empire_legion_b" subtype="body_armor" culture="Culture.empire" weight="12.49636" difficulty="0" appearance="6.0" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="40" leg_armor="18" arm_armor="13" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="52" leg_armor="18" arm_armor="23" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>

--- a/items/body_armors.xml
+++ b/items/body_armors.xml
@@ -1213,7 +1213,7 @@
   </Item>
   <Item id="crpg_imperial_lamellar" name="{=LMo6MaQS}Cataphract Lamellar Armor" mesh="imperial_lamellar_a" subtype="body_armor" culture="Culture.empire" weight="20.72603" difficulty="0" appearance="3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="52" leg_armor="18" arm_armor="23" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="52" leg_armor="23" arm_armor="18" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>

--- a/items/body_armors.xml
+++ b/items/body_armors.xml
@@ -104,7 +104,7 @@
   </Item>
   <Item id="crpg_short_padded_robe" name="{=QzAvlan7}Short Padded Robe" subtype="body_armor" lod_atlas_index="11" mesh="sarranid_gambeson_v3" culture="Culture.aserai" weight="2.574646" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" has_gender_variations="false" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
@@ -116,7 +116,7 @@
   </Item>
   <Item id="crpg_studded_leather_coat" name="{=XkL1Re8b}Studded Leather Coat" lod_atlas_index="12" mesh="bandit_leather_a" culture="Culture.aserai" weight="1.784997" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="23" leg_armor="3" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -128,13 +128,13 @@
   </Item>
   <Item id="crpg_aserai_robe_c_chain" name="{=gSWtpl8a}Robe over Mail Shirt" lod_atlas_index="5" mesh="aserai_robe_c_chain" culture="Culture.aserai" weight="9.225823" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="28" leg_armor="13" arm_armor="8" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Chainmail" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_long_padded_robe" name="{=0SsLGsXk}Long Padded Robe" lod_atlas_index="10" mesh="sarranid_gambeson_v2" culture="Culture.aserai" weight="2.770139" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" has_gender_variations="false" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
@@ -236,7 +236,7 @@
   </Item>
   <Item id="crpg_aserai_chain_plate_armor_c" name="{=Mm1QAtPx}Southern Reinforced Mail Vest" lod_atlas_index="3" mesh="aserai_chain_plate_armor_c" culture="Culture.aserai" weight="6.965938" appearance="4" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="26" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="13" arm_armor="18" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -656,13 +656,13 @@
   </Item>
   <Item id="crpg_padded_leather_shirt" name="{=tiTTWhpW}Padded Leather Shirt" mesh="armor_roman_padded_leather_shirt" culture="Culture.vlandia" weight="3.816213" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_padded_coat" name="{=QbfOXJas}Padded Footman Coat" subtype="body_armor" mesh="padded_coat_a" culture="Culture.vlandia" weight="4.379655" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -680,37 +680,37 @@
   </Item>
   <Item id="crpg_aketon" name="{=7b8Cwogx}Aketon" mesh="crossbow_armor" culture="Culture.vlandia" weight="2.077283" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="23" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_sleeveless_padded_short_coat" name="{=bz5lXkHS}Sleeveless Padded Short Coat" mesh="padded_coat_d" culture="Culture.vlandia" subtype="body_armor" weight="2.936653" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_sleeveless_padded_coat" name="{=lZ93DOrn}Sleeveless Padded Coat" subtype="body_armor" mesh="padded_coat_b" culture="Culture.vlandia" weight="3.889836" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="18" leg_armor="9" arm_armor="2" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_padded_short_coat" name="{=4pqIsPhp}Padded Short Coat" mesh="padded_coat_c" culture="Culture.vlandia" weight="3.106376" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="15" leg_armor="2" arm_armor="7" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="23" leg_armor="3" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_leather_scale_armor" name="{=PL5SG9hI}Leather Scale Armor" mesh="vlandia_leather_scale_armor" subtype="body_armor" culture="Culture.vlandia" weight="3.889836" difficulty="0" appearance="1" Type="BodyArmor" multiplayer_item="false">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_woven_leather_vest" name="{=LgftnHPs}Woven Leather Vest" subtype="body_armor" mesh="archers_leather_vest" culture="Culture.vlandia" weight="2.137492" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -1015,217 +1015,217 @@
   </Item>
   <Item id="crpg_peasant_costume" name="{=gbRVBOLH}Commoner Clothes" mesh="peasant_costume_a" culture="Culture.empire" weight="0.4770266" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="2" arm_armor="1" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_fine_town_tunic" name="{=vbPBXiPC}Rich Tunic" mesh="casual_02" culture="Culture.empire" weight="0.2160417" appearance="2" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="2" leg_armor="1" arm_armor="1" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_hemp_tunic" name="{=yTWOMSmv}Hemp Tunic" mesh="armor_hemp_tunic" culture="Culture.empire" subtype="body_armor" weight="0.4770266" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="2" arm_armor="1" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_tied_cloth_tunic" name="{=MQ8LCvCE}Tied Cloth Tunic" mesh="roman_cloth_tunic_a" culture="Culture.empire" subtype="body_armor" weight="0.3712929" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="1" arm_armor="1" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_vlandian_dress" name="{=eRZK8Kbp}Rich Dress" mesh="vlandian_dress" culture="Culture.empire" weight="0.2901902" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="3" leg_armor="1" arm_armor="1" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_dress" name="{=JsmnUp0T}Ladies Dress" mesh="empire_dress" culture="Culture.empire" weight="1.221603" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="7" leg_armor="4" arm_armor="2" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_dress_b" name="{=VqFV9LS4}Red Dress" mesh="empire_dress_b" culture="Culture.empire" weight="0.8207818" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="2" arm_armor="2" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_footmans_tunic" name="{=2AcfBbCR}Military Tunic" mesh="armor_roman_military_tunic" culture="Culture.empire" subtype="body_armor" weight="0.4770266" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="2" arm_armor="1" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_tunic_with_shoulder_pads" name="{=y3oIzUEp}Tunic with Shoulder Pads" mesh="roman_cloth_tunic_b" culture="Culture.empire" weight="0.7133473" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="5" leg_armor="2" arm_armor="2" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_tunic_with_rolled_cloth" name="{=QaysED62}Tunic with Rolled Cloth" mesh="armor_tunic_with_rolled_cloth" culture="Culture.empire" subtype="body_armor" weight="0.9561659" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="6" leg_armor="3" arm_armor="2" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_imperial_robes" name="{=R45H8quo}Toga" mesh="empire_outfit_a" culture="Culture.empire" weight="1.562045" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="8" leg_armor="3" arm_armor="4" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="false" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_padded_cloth_with_strips" name="{=JKRQ8RDA}Padded Cloth with Strips" mesh="empire_armor_a" culture="Culture.empire" subtype="body_armor" weight="2.770139" difficulty="0" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="14" leg_armor="7" arm_armor="2" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_leather_tunic" name="{=ZqTFQeai}Leather Tunic" mesh="leather_tunic" culture="Culture.empire" weight="2.446993" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="12" leg_armor="7" arm_armor="2" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="26" leg_armor="3" arm_armor="3" has_gender_variations="true" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_patched_gambeson" name="{=Jhshwa48}Patched Gambeson" mesh="bandit_4" culture="Culture.empire" weight="3.004161" difficulty="0" appearance="0.8" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="14" leg_armor="7" arm_armor="3" has_gender_variations="true" covers_body="false" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" has_gender_variations="true" covers_body="false" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_imperial_padded_cloth" name="{=CqMQXzUd}Infantryman Rough Gambeson" mesh="empire_fabric_armor" culture="Culture.empire" weight="4.341292" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="6" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_a" name="{=aJLikenm}Infantryman Gambeson" mesh="empire_warrior_padded_armor_a" culture="Culture.empire" weight="3.419776" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="15" leg_armor="7" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_c" name="{=cEhDJAQp}Infantryman Gambeson with Skirts" mesh="empire_warrior_padded_armor_c" culture="Culture.empire" weight="3.816213" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_d" name="{=CLTk2CMs}Infantryman Gambeson with Straps" mesh="empire_warrior_padded_armor_d" culture="Culture.empire" weight="3.816213" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_e" name="{=1BXuUR3s}Infantryman Long Gambeson" mesh="empire_warrior_padded_armor_e" culture="Culture.empire" weight="4.075933" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="5" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_f" name="{=GTaxqBcv}Auxiliary Armor" mesh="empire_warrior_padded_armor_f" culture="Culture.empire" weight="4.001147" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="17" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="26" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_g" name="{=T2POVRtg}Auxiliary Armor with Straps" mesh="empire_warrior_padded_armor_g" culture="Culture.empire" weight="4.188975" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="18" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="26" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_eastern_studded_leather" name="{=n7e0y95m}Cured Studded Leather Armor" mesh="khuzait_leather_armor_b" culture="Culture.empire" weight="4.729927" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="18" leg_armor="8" arm_armor="6" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="28" leg_armor="13" arm_armor="8" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_basic_imperial_leather_armor" name="{=LSaIs3DB}Leather Armor" mesh="empire_leather_armor" culture="Culture.empire" weight="5.048733" appearance="1.3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="22" leg_armor="6" arm_armor="6" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="26" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_woven_leather_coat" name="{=wE7RWmIF}Boarskin Leather Coat" mesh="vlandia_leather_stripes" culture="Culture.empire" weight="3.244425" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="14" leg_armor="7" arm_armor="4" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="26" leg_armor="3" arm_armor="3" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_b" name="{=XNQPPIaA}Infantryman Gambeson over Leather Jacket" mesh="empire_warrior_padded_armor_b" culture="Culture.empire" weight="3.816213" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="16" leg_armor="8" arm_armor="4" covers_body="true" modifier_group="cloth" material_type="Cloth" />
+      <Armor body_armor="28" leg_armor="8" arm_armor="13" covers_body="true" modifier_group="cloth" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_mail_over_stripped_leather" name="{=zadVVah1}Infantryman Mail over Striped Leather" mesh="empire_armor_d" culture="Culture.empire" subtype="body_armor" weight="6.965938" difficulty="0" appearance="1.3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="31" leg_armor="6" arm_armor="6" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="13" arm_armor="18" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_horseman_armor" name="{=wJ4Y9IFc}Cavalryman Mail Shirt" subtype="body_armor" mesh="empire_horseman_armor" culture="Culture.empire" weight="8.73775" difficulty="0" appearance="1.3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="27" leg_armor="11" arm_armor="10" has_gender_variations="true" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="18" arm_armor="13" has_gender_variations="true" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_mail_over_leather" name="{=l5PPS5lG}Infantryman Mail over Leather" mesh="empire_armor_c" culture="Culture.empire" weight="6.965938" appearance="10.1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="31" leg_armor="6" arm_armor="6" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="13" arm_armor="18" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_mail_vest" name="{=Kr8b1bxY}Infantryman Mail Vest" mesh="empire_armor_e" culture="Culture.empire" subtype="body_armor" weight="9.473157" difficulty="0" appearance="1.5" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="26" leg_armor="12" arm_armor="12" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="13" arm_armor="18" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_scale_armor" name="{=VQSdhQE3}Heavy Scale Armor over Mail Hauberk" mesh="imperial_lamellar_b" subtype="body_armor" culture="Culture.empire" weight="23.02404" difficulty="0" appearance="3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="57" leg_armor="20" arm_armor="16" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="64" leg_armor="25" arm_armor="25" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_imperial_lamellar_over_leather" name="{=x3lcf2Do}Luxury Lamellar Vest over Leather" mesh="empire_plate_armor" culture="Culture.empire" weight="7.695641" appearance="1.3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="33" leg_armor="7" arm_armor="6" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="38" leg_armor="8" arm_armor="8" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_lamellar_with_scale_skirt" name="{=zGXZJFOb}Lamellar with Scale Skirt" mesh="imperial_lamellar_c" culture="Culture.empire" weight="22.55802" appearance="3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="52" leg_armor="23" arm_armor="16" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="52" leg_armor="23" arm_armor="18" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_legionary_mail" name="{=PTKyNh2O}Legionary Mail" mesh="empire_armor_b" culture="Culture.empire" subtype="body_armor" weight="14.6806" difficulty="0" appearance="1.3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="34" leg_armor="18" arm_armor="15" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="38" leg_armor="8" arm_armor="8" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_lamellar" name="{=LMo6MaQS}Cataphract Lamellar Armor" mesh="imperial_lamellar_a" subtype="body_armor" culture="Culture.empire" weight="20.72603" difficulty="0" appearance="3" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="48" leg_armor="24" arm_armor="14" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="52" leg_armor="18" arm_armor="23" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_legion_a" name="{=mBVCyRY5}Decorated Legionary Mail" mesh="empire_legion_a" subtype="body_armor" culture="Culture.empire" weight="10.89783" difficulty="0" appearance="5.5" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="30" leg_armor="18" arm_armor="8" covers_body="true" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="40" leg_armor="18" arm_armor="13" covers_body="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_legion_b" name="{=7HbspP6x}Ornate Legionary Scale Mail" mesh="empire_legion_b" subtype="body_armor" culture="Culture.empire" weight="12.49636" difficulty="0" appearance="6.0" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="36" leg_armor="18" arm_armor="8" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="40" leg_armor="18" arm_armor="13" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -1279,7 +1279,7 @@
   </Item>
   <Item id="crpg_empire_short_dress" name="{=KdbHrcQx}Short Tunic" mesh="empire_short_dress" culture="Culture.empire" weight="0.1751825" difficulty="0" appearance="0.1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="0" has_gender_variations="true" covers_body="false" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" has_gender_variations="true" covers_body="false" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" DoesNotHideChest="true" UseTeamColor="true" />
   </Item>
@@ -1375,7 +1375,7 @@
   </Item>
   <Item id="crpg_half_apron" name="{=FOJHPU5N}Half Apron" mesh="costume_merchant_v3" culture="Culture.neutral_culture" weight="0.2901902" appearance="1" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="3" leg_armor="1" arm_armor="1" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
@@ -1387,7 +1387,7 @@
   </Item>
   <Item id="crpg_leather_apron" name="{=r0Ln9bAp}Leather Apron" mesh="costume_merchant" subtype="body_armor" culture="Culture.neutral_culture" weight="0.6110581" difficulty="0" appearance="0.4" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="4" leg_armor="2" arm_armor="2" covers_body="true" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="6" leg_armor="2" arm_armor="3" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" Civilian="true" />
   </Item>

--- a/items/head_armors.xml
+++ b/items/head_armors.xml
@@ -1471,13 +1471,13 @@
   </Item>
   <Item id="crpg_empire_battle_crown_west" name="{=EOplBvKz}Imperial Plumed Helmet" subtype="head_armor" mesh="empire_battle_crown_west" culture="Culture.empire" is_merchandise="false" weight="3.018642" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_battle_crown_north" name="{=AK0lNDmN}Jeweled Plumed Battle Crown" subtype="head_armor" mesh="empire_battle_crown_north" culture="Culture.empire" is_merchandise="false" weight="2.740113" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>

--- a/items/head_armors.xml
+++ b/items/head_armors.xml
@@ -1172,7 +1172,7 @@
   </Item>
   <Item id="crpg_imperial_padded_coif" name="{=3Q2F2BKD}Lightweight Padded Coif" subtype="head_armor" mesh="empire_helmet_b" culture="Culture.empire" weight="0.4754905" difficulty="0" appearance="0.6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="14" has_gender_variations="false" hair_cover_type="all" modifier_group="cloth" material_type="Cloth" beard_cover_type="type3" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="all" modifier_group="cloth" material_type="Cloth" beard_cover_type="type3" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
@@ -1190,79 +1190,79 @@
   </Item>
   <Item id="crpg_imperial_cloth_coif" name="{=g5BPd0Oc}Cloth Coif" subtype="head_armor" mesh="empire_helmet_e" culture="Culture.empire" weight="0.02567407" difficulty="0" appearance="0.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="2" has_gender_variations="false" hair_cover_type="all" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="all" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_leather_cap" name="{=uLpnmNkZ}Leather Cap" subtype="head_armor" mesh="leather_cap_a" culture="Culture.empire" weight="0.2053926" difficulty="0" appearance="1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="8" has_gender_variations="false" hair_cover_type="type3" beard_cover_type="type2" modifier_group="leather" material_type="Leather" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="type3" beard_cover_type="type2" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_pilgrim_hood" name="{=VXFwEF3M}Pilgrim Hood" mesh="sneak_costume_head" culture="Culture.empire" weight="0.04716628" difficulty="0" appearance="0.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="3" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="true" />
   </Item>
   <Item id="crpg_tall_helmet" name="{=9FgxK9se}Tall Helmet" subtype="head_armor" mesh="roman_helmet_c" culture="Culture.empire" weight="2.126303" difficulty="0" appearance="2.6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="38" has_gender_variations="false" hair_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_imperial_mail_coif" name="{=77RIGK7B}Mail Coif" subtype="head_armor" mesh="empire_helmet_a" culture="Culture.empire" weight="0.7517617" difficulty="0" appearance="1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="19" has_gender_variations="false" hair_cover_type="all" modifier_group="chain" material_type="Chainmail" beard_cover_type="type2" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="chain" material_type="Chainmail" beard_cover_type="type2" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_imperial_nasal_helm" name="{=rSEXAMUx}Legionary Helm" subtype="head_armor" mesh="empire_helmet_h" culture="Culture.empire" weight="1.960666" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="36" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_leatherlame_nasalhelm_over_imperial_leather" name="{=AQIH729X}Iron Nasalhelm over Leather" subtype="head_armor" mesh="empire_helmet_h_da" culture="Culture.empire" weight="2.559484" difficulty="0" appearance="2.6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="43" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_leatherlame_feathered_spangenhelm_over_leather" name="{=xTH3z9Sr}Spangenhelm over Leather" mesh="empire_helmet_i_da" culture="Culture.empire" weight="2.296359" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_leatherlame_roundkettle" name="{=BUlmMbgH}Roundkettle Helmet" subtype="head_armor" mesh="empire_helmet_j__a" culture="Culture.empire" weight="1.960666" difficulty="0" appearance="1.5" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="36" has_gender_variations="false" hair_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_roundkettle_over_imperial_padding" name="{=uu9rXeYz}Roundkettle over Padding" subtype="head_armor" mesh="empire_helmet_j_b" culture="Culture.empire" weight="1.566723" difficulty="0" appearance="1.5" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="31" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type3" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type3" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_roundkettle_over_laced_cloth" name="{=9BENgwRK}Roundkettle over Laced Cloth" subtype="head_armor" mesh="empire_helmet_j_c" culture="Culture.empire" weight="1.203399" difficulty="0" appearance="1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="26" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_roundkettle_over_imperial_leather" name="{=CHaYjWDb}Light Roundkettle over Leather" subtype="head_armor" mesh="empire_helmet_j_d" culture="Culture.empire" weight="0.936664" difficulty="0" appearance="1.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="22" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_leatherlame_roundkettle_over_imperial_leather" name="{=aOwcs7Un}Roundkettle over Leather" mesh="empire_helmet_j_da" culture="Culture.empire" weight="1.491529" appearance="1.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="30" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
@@ -1274,36 +1274,36 @@
   </Item>
   <Item id="crpg_spiked_kettle_over_imperial_padding" name="{=9UJfJrZR}Spiked Kettle over Padding" mesh="empire_helmet_k_b" culture="Culture.empire" weight="2.210786" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="39" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_mail_coif" name="{=Qywm0F8B}Mail Coif with Helmet Padding" subtype="head_armor" mesh="vlandia_helmet_a" culture="Culture.empire" weight="0.6932" difficulty="0" appearance="1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="18" has_gender_variations="false" hair_cover_type="all" modifier_group="chain" material_type="Chainmail" beard_cover_type="type4" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="chain" material_type="Chainmail" beard_cover_type="type4" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_open_mail_coif" name="{=OpYdqPWs}Open Mail Coif" subtype="head_armor" mesh="vlandia_helmet_v" culture="Culture.empire" weight="0.6932" difficulty="0" appearance="1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="18" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="chain" material_type="Chainmail" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_roundkettle_over_imperial_leather" name="{=nUarDXVH}Iron Roundkettle over Leather" mesh="empire_helmet_j_db" culture="Culture.empire" weight="1.491529" appearance="1.35" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="30" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_crown" name="{=udQSdRXR}Jeweled Crown" mesh="empire_crown" culture="Culture.empire" is_merchandise="false" weight="1.799568" appearance="6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="34" has_gender_variations="false" hair_cover_type="type2" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="type2" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
   </Item>
   <Item id="crpg_empire_crown_north" name="{=WF14UrdR}Golden Laurel Crown" mesh="empire_crown_north" culture="Culture.empire" is_merchandise="false" weight="0.1014857" appearance="7" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="5" has_gender_variations="false" hair_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="false" />
   </Item>
@@ -1315,169 +1315,169 @@
   </Item>
   <Item id="crpg_vlandia_crown" name="{=1b6T0M72}Austere Crown" mesh="vlandia_crown" culture="Culture.empire" is_merchandise="false" weight="0.07261725" appearance="6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="4" has_gender_variations="false" hair_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="6" has_gender_variations="false" hair_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags Civilian="true" UseTeamColor="false" />
   </Item>
   <Item id="crpg_imperial_goggled_helmet" name="{=xJTfOqD6}Goggled Cataphract Helmet" mesh="imperial_helmet" culture="Culture.empire" weight="3.403728" appearance="2.6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="all" modifier_group="chain" material_type="Chainmail" />
+      <Armor head_armor="64" has_gender_variations="false" hair_cover_type="all" beard_cover_type="all" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_heavy_nasalhelm_over_imperial_mail" name="{=ISQ0cdOc}Heavy Nasalhelm over Mail" subtype="head_armor" mesh="empire_helmet_g_f" culture="Culture.empire" weight="3.306017" difficulty="0" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="51" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_nasalhelm_over_imperial_coif" name="{=Cg7vqdPQ}Iron Nasalhelm over Coif" mesh="empire_helmet_h_ab" culture="Culture.empire" weight="3.018642" appearance="2.8" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="48" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_leatherlame_nasalhelm_over_imperial_mail" name="{=XCnUaINR}Bronze Nasalhelm over Mail" mesh="empire_helmet_h_fa" culture="Culture.empire" weight="2.126303" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="38" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_nasalhelm_over_imperial_mail" name="{=DbavaIis}Iron Nasalhelm over Mail" subtype="head_armor" mesh="empire_helmet_h_fb" culture="Culture.empire" weight="3.018642" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="48" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_feathered_spangenhelm" name="{=ePdiHF5D}Feathered Spangenhelm" subtype="head_armor" mesh="empire_helmet_i" culture="Culture.empire" weight="1.203399" difficulty="0" appearance="2.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="26" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_feathered_spangenhelm_over_imperial_coif" name="{=YFg8x5QC}Feathered Spangenhelm over Coif" subtype="head_armor" mesh="empire_helmet_i_a" culture="Culture.empire" weight="2.470721" difficulty="0" appearance="1.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="42" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type2" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type2" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_leatherlame_feathered_spangenhelm_over_mail" name="{=aoPbMKwB}Feathered Spangenhelm over Mail" subtype="head_armor" mesh="empire_helmet_i_aa" culture="Culture.empire" weight="2.470721" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="42" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type2" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type2" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_feathered_spangenhelm_over_mail" name="{=qojh0tsC}Spangenhelm over Mail" subtype="head_armor" mesh="empire_helmet_i_fb" culture="Culture.empire" weight="2.470721" difficulty="0" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="42" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_roundkettle_over_imperial_mail" name="{=b7TdIRac}Roundkettle over Mail" subtype="head_armor" mesh="empire_helmet_j_f" culture="Culture.empire" weight="1.799568" appearance="1.65" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="34" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_helmet_with_faceguard" name="{=UoHZGyZa}Helmet with Faceguard" subtype="head_armor" mesh="roman_helmet_b" culture="Culture.empire" weight="1.134645" difficulty="0" appearance="1.6" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="25" has_gender_variations="false" hair_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_heavy_nasalhelm_over_imperial_padding" name="{=ac9xJt2X}Heavy Nasalhelm over Padding" subtype="head_armor" mesh="empire_helmet_g_b" culture="Culture.empire" weight="3.018642" difficulty="0" appearance="2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="48" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_heavy_nasalhelm_over_laced_cloth" name="{=z6eTba5h}Heavy Nasalhelm over Laced Cloth" mesh="empire_helmet_g_c" culture="Culture.empire" weight="2.831956" appearance="2.1" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="46" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_heavy_nasalhelm_over_imperial_leather" name="{=vimhFdZp}Heavy Nasalhelm over Leather" mesh="empire_helmet_g_d" culture="Culture.empire" weight="3.018642" appearance="3.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="48" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="none" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_feathered_spangenhelm_over_leather" name="{=e3nslzlA}Feathered Spangenhelm over Leather" mesh="empire_helmet_i_db" culture="Culture.empire" weight="1.960666" appearance="2.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="36" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="28" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_roundkettle_over_imperial_mail" name="{=XuwQvSDo}Iron Roundkettle over Mail" subtype="head_armor" mesh="empire_helmet_j_fb" culture="Culture.empire" weight="1.960666" difficulty="0" appearance="1.65" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="36" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_spiked_kettle_over_imperial_mail" name="{=DeawBxbx}Spiked Kettle over Mail" mesh="empire_helmet_k_f" culture="Culture.empire" weight="1.27349" appearance="1.2" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="27" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_spiked_kettle_over_mail" name="{=IX3kafcb}Iron Spiked Kettle over Mail" subtype="head_armor" mesh="empire_helmet_k_fb" culture="Culture.empire" weight="1.720762" difficulty="0" appearance="1.9" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="33" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_lord_helmet" name="{=V5qbVfWF}Palatine Guard Helmet" mesh="empire_lord_helmet_a" culture="Culture.empire" subtype="head_armor" weight="2.831956" difficulty="0" appearance="5" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="46" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type4" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type4" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_guarded_lord_helmet" name="{=4vB2SPZa}Royal Cataphract Helmet" mesh="empire_lord_helmet_b" culture="Culture.empire" subtype="head_armor" weight="3.306017" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="51" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_jewelled_helmet" name="{=BD07fj39}Imperial Jeweled Helmet" mesh="empire_lord_helmet_c" culture="Culture.empire" subtype="head_armor" weight="2.924803" difficulty="0" appearance="5" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="47" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_helmet_with_metal_strips" name="{=vaVvDVu4}Lord Helmet with Metal Strips" mesh="empire_lord_helmet_c_2" culture="Culture.empire" subtype="head_armor" weight="2.924803" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="47" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type4" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type4" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_nasalhelm_over_imperial_padding" name="{=cQ6IsHSL}Iron Nasalhelm over Padding" subtype="head_armor" mesh="empire_helmet_h_bb" culture="Culture.empire" weight="2.831956" difficulty="0" appearance="2.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="46" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type3" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" modifier_group="plate" material_type="Plate" beard_cover_type="type3" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_ironlame_nasalhelm_over_imperial_cloth" name="{=twbUeZph}Iron Legionary Helm over Cloth" mesh="empire_helmet_h_eb" culture="Culture.empire" weight="2.831956" appearance="2.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="46" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type1" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type1" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_plumed_helmet" name="{=sJ1R62Tn}Plumed Helmet" subtype="head_armor" mesh="roman_helmet_d" culture="Culture.empire" weight="2.924803" difficulty="0" appearance="3.3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="47" has_gender_variations="false" hair_cover_type="type3" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="type3" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_battle_crown_west" name="{=EOplBvKz}Imperial Plumed Helmet" subtype="head_armor" mesh="empire_battle_crown_west" culture="Culture.empire" is_merchandise="false" weight="3.018642" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="48" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_battle_crown_north" name="{=AK0lNDmN}Jeweled Plumed Battle Crown" subtype="head_armor" mesh="empire_battle_crown_north" culture="Culture.empire" is_merchandise="false" weight="2.740113" difficulty="0" appearance="3" Type="HeadArmor">
     <ItemComponent>
-      <Armor head_armor="45" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
+      <Armor head_armor="40" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type2" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>

--- a/items/leg_armors.xml
+++ b/items/leg_armors.xml
@@ -164,43 +164,43 @@
   </Item>
   <Item id="crpg_fine_town_boots" name="{=uUGAMReu}Fine Town Boots" mesh="casual_02_boots" culture="Culture.empire" weight="0.1254426" appearance="2" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="4" covers_legs="true" modifier_group="leather" material_type="Leather" />
+      <Armor leg_armor="3" covers_legs="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_folded_town_boots" name="{=oH8iFEv7}Folded Town Boots" mesh="casual_01_boots" culture="Culture.empire" weight="0.1254426" appearance="1" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="4" covers_legs="true" modifier_group="leather" material_type="Leather" />
+      <Armor leg_armor="3" covers_legs="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_empire_horseman_boots" name="{=uvSXUgT8}Horseman Boots" mesh="empire_horseman_boots" culture="Culture.empire" weight="0.1753114" difficulty="0" appearance="1.3" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="5" covers_legs="true" modifier_group="leather" material_type="Leather" />
+      <Armor leg_armor="3" covers_legs="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_strapped_leather_boots" name="{=tMwsE9IR}Strapped Leather Boots" mesh="boot_g" culture="Culture.empire" weight="0.1753114" difficulty="0" appearance="1" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="5" covers_legs="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
+      <Armor leg_armor="3" covers_legs="true" modifier_group="cloth_unarmoured" material_type="Cloth" />
     </ItemComponent>
     <Flags Civilian="true" />
   </Item>
   <Item id="crpg_plated_strip_boots" name="{=Fb7PrJuc}Splint Boots" mesh="empire_plated_boots" culture="Culture.empire" weight="1.61804" appearance="2" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="22" covers_legs="true" modifier_group="plate" material_type="Plate" />
+      <Armor leg_armor="18" covers_legs="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_decorated_imperial_boots" name="{=XXGZLTN6}Decorated Plate Boots" mesh="empire_plate_armor_boots" culture="Culture.empire" weight="1.402491" appearance="3" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="20" covers_legs="true" modifier_group="plate" material_type="Plate" />
+      <Armor leg_armor="24" covers_legs="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_lamellar_plate_boots" name="{=9cHyHQ7a}Lamellar Plate Boots" mesh="imperial_boots" culture="Culture.empire" weight="1.29863" difficulty="0" appearance="3" Type="LegArmor">
     <ItemComponent>
-      <Armor leg_armor="19" covers_legs="true" modifier_group="plate" material_type="Plate" />
+      <Armor leg_armor="30" covers_legs="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>

--- a/items/shoulder_armors.xml
+++ b/items/shoulder_armors.xml
@@ -354,103 +354,103 @@
   </Item>
   <Item id="crpg_pauldron_cape_a" name="{=pGmYxauO}Legionary Cape" mesh="pauldron_cape_a" culture="Culture.empire" weight="2.198272" appearance="4" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="16" arm_armor="4" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="13" arm_armor="7" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_a_pauldron_cape_b" name="{=URZVE5aK}Bronze Pauldrons with Neck Guard" mesh="pauldron_cape_b" culture="Culture.empire" weight="2.167811" appearance="4" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="13" arm_armor="6" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="13" arm_armor="7" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_a_pauldron_cape_c" name="{=jQKVnVNR}Bronze Pauldrons " mesh="pauldron_cape_c" culture="Culture.empire" weight="0.5331134" appearance="4" Type="Cape">
     <ItemComponent>
-      <Armor arm_armor="6" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="8" arm_armor="5" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_empire_warrior_padded_armor_shoulder" name="{=WDNKhjca}Legionary Padded Straps" mesh="empire_warrior_padded_armor_shoulder" culture="Culture.empire" weight="1.221603" appearance="1" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="9" arm_armor="4" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="13" arm_armor="7" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_woven_leather_shoulders" name="{=c7UNJSNi}Woven Leather Shoulders" mesh="vlandia_leather_stripes_shoulders" culture="Culture.empire" weight="0.8651426" appearance="1" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="6" arm_armor="4" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="8" arm_armor="5" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_imperial_studded_strip_shoulders" name="{=s7siCSsh}Legionary Reinforced Studded Harness" mesh="empire_plated_shoulder" culture="Culture.empire" weight="1.323371" appearance="1" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="7" arm_armor="6" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="13" arm_armor="7" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_a_empire_plated_shoulder_a" name="{=TS7NjgyH}Legionary Studded Harness" mesh="empire_plated_shoulder_a" culture="Culture.empire" weight="0.9793919" appearance="1" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="7" arm_armor="4" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="17" arm_armor="4" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_a_empire_plated_shoulder_b" name="{=gA8mOXrC}Plate Pauldrons" mesh="empire_plated_shoulder_b" culture="Culture.empire" weight="0.8207818" appearance="1" Type="Cape">
     <ItemComponent>
-      <Armor arm_armor="8" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="8" arm_armor="5" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_varangian_bra_basic" name="{=564PHXk3}Decorated Leather Harness" mesh="varangian_bra_basic" culture="Culture.empire" weight="1.122585" appearance="4" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="4" arm_armor="7" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="17" arm_armor="4" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_varangian_bra_royal" name="{=RXDyumYz}Caped Leather Harness" mesh="varangian_bra_royal" culture="Culture.empire" weight="1.24679" appearance="7" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="5" arm_armor="7" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="17" arm_armor="4" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_varangian_bra_padded" name="{=qaKGuHSt}Decorated Leather Harness with Padding" mesh="varangian_bra_padded" culture="Culture.empire" weight="2.137492" appearance="3" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="10" arm_armor="8" modifier_group="leather" material_type="Leather" />
+      <Armor body_armor="22" arm_armor="6" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
   <Item id="crpg_imperial_lamellar_shoulders" name="{=Ie0EazLn}Heavy Lamellar Pauldrons" mesh="imperial_shoulders" culture="Culture.empire" weight="3.526454" appearance="3" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="17" arm_armor="9" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="18" arm_armor="9" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_studded_imperial_neckguard" name="{=kjzCaoMK}Neckguard with Bronze Plate Pauldrons" mesh="empire_plate_armor_shoulder" culture="Culture.empire" weight="2.54253" appearance="2" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="14" arm_armor="7" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="18" arm_armor="9" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_plate_armor_shoulder_a" name="{=P96J2c61}Bronze Plate Pauldrons" mesh="empire_plate_armor_shoulder_a" culture="Culture.empire" weight="0.6717997" appearance="2" Type="Cape">
     <ItemComponent>
-      <Armor arm_armor="7" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="8" arm_armor="5" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_empire_plate_armor_shoulder_b" name="{=27GO9o9K}Iron Plate Pauldrons" mesh="empire_plate_armor_shoulder_b" culture="Culture.empire" weight="0.8207818" appearance="2" Type="Cape">
     <ItemComponent>
-      <Armor arm_armor="8" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="8" arm_armor="5" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_varangian_bra_mail" name="{=P0FmQHgF}Decorated Leather Harness over Mail" mesh="varangian_bra_mail" culture="Culture.empire" weight="3.598177" appearance="4" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="16" arm_armor="10" modifier_group="chain" material_type="Chainmail" />
+      <Armor body_armor="22" arm_armor="6" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
     <Flags />
   </Item>
   <Item id="crpg_varangian_bra_scale" name="{=eN1eFdhF}Decorated Leather Harness over Scale" mesh="varangian_bra_scale" culture="Culture.empire" weight="4.690566" appearance="6" Type="Cape">
     <ItemComponent>
-      <Armor body_armor="19" arm_armor="12" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="25" arm_armor="9" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags />
   </Item>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -410,7 +410,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_long_bardiche" name="{=}Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_long_bardiche_head" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_long_bardiche_head" Type="Blade" scale_factor="87" />
       <Piece id="crpg_long_bardiche_handle" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
@@ -2386,7 +2386,7 @@
 	</CraftedItem>
   <CraftedItem id="crpg_long_hafted_spiked_mace" name="{=}Long Hafted Spiked Mace" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_long_hafted_spiked_mace_head" Type="Blade" scale_factor="160" />
+      <Piece id="crpg_long_hafted_spiked_mace_head" Type="Blade" scale_factor="162" />
       <Piece id="crpg_long_hafted_spiked_mace_handle" Type="Handle" scale_factor="290" />
     </Pieces>
   </CraftedItem>
@@ -2592,7 +2592,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_bec_de_corbin" name="{=}Bec De Corbin" crafting_template="crpg_TwoHandedPolearm">
 		<Pieces>
-			<Piece id="crpg_bec_de_corbin_blade" Type="Blade" scale_factor="100"/>
+			<Piece id="crpg_bec_de_corbin_blade" Type="Blade" scale_factor="83"/>
 			<Piece id="crpg_bec_de_corbin_handle" Type="Handle" scale_factor="100"/>
 		</Pieces>
   </CraftedItem>
@@ -2616,7 +2616,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_french_voulge" name="{=}French Voulge" crafting_template="crpg_TwoHandedPolearm">
 		<Pieces>
-			<Piece id="crpg_french_voulge_blade" Type="Blade" scale_factor="100"/>
+			<Piece id="crpg_french_voulge_blade" Type="Blade" scale_factor="99"/>
 			<Piece id="crpg_french_voulge_handle" Type="Handle" scale_factor="100"/>
 		</Pieces>
   </CraftedItem>


### PR DESCRIPTION
Rework a few polearm and entered first stats for 6 new polearms.

Long Bardiche:
swing damage 49 --> 48
swing speed 76 --> 75
thrust damage 23 --> 24
Weight 1.65 --> 1.7
Reach 161 --> 158
handling 67 --> 65

Voulge:
swing damage 47 --> 44
swing speed 82 --> 81
thrust damage 21 --> 22
Weight 1.45 --> 1.47

Menavlion:
swing damage 38 --> 41
swing speed 83 --> 80
thrust damage 23 --> 22
Weight 1.72 --> 1.84
handling 72 --> 69

Long Glaive:
swing speed 76 --> 73
thrust damage 24 --> 25
thrust speed 96 --> 95
Weight 1.35 --> 1.44
handling 65 --> 63

Billhook:
swing damage 48 --> 45

Glaive:
swing speed 84 --> 83
thrust speed 95 --> 94
Weight 1.63 --> 1.68
handling 72 --> 71

Long Hafted Spiked Mace:
swing damage 27 --> 25
thrust damage 16 --> 17
Weight 1.83 --> 1.87
Reach 154 --> 155

War Scythe:
swing damage 43 --> 44
swing speed 82 --> 79
Weight 1.68 --> 1.78
handling 70 --> 68

Rhomphaia:
swing damage 47 --> 45
swing speed 78 --> 77
Weight 1.35 --> 1.41
handling 67 --> 66

Warrazor:
swing damage 50 --> 47
swing speed 77 --> 75
thrust damage 17 --> 21
thrust speed 98 --> 97
Weight 1.13 --> 1.2
handling 64 --> 63

Polesword:
swing damage 50 --> 47

Burgundian Poleaxe:
swing damage 42
swing speed 82
thrust damage 25
thrust speed 91
Weight 2.27
Reach 128
handling 72

Simple Poleaxe:
swing damage 44
swing speed 78
thrust damage 24
thrust speed 91
Weight 2.2
Reach 145
handling 69

Bec De Corbin:
swing damage 30
swing speed 84
thrust damage 25
thrust speed 93
Weight 1.91
Reach 124
handling 70

Spiked Polehammer:
swing damage 30
swing speed 76
thrust damage 21
thrust speed 92
Weight 2
Reach 148
handling 67

Burgundian Glaive:
swing damage 44
swing speed 76
thrust damage 22
thrust speed 93
Weight 1.78
Reach 189
handling 65

French Voulge:
swing damage 37
swing speed 88
thrust damage 23
thrust speed 93
Weight 1.99
Reach 133
handling 75
