### PR TITLE
1H Swords - Sturgia Rework - AngryMob

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2962,12 +2962,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_pommel" name="{=LDRnfLRh}Decorated Northern Pommel" tier="4" piece_type="Pommel" mesh="sturgian_noble_pommel_2" culture="Culture.sturgia" length="4.7" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_pommel" name="{=LDRnfLRh}Decorated Northern Pommel" tier="4" piece_type="Pommel" mesh="sturgian_noble_pommel_2" culture="Culture.sturgia" length="4.7" weight="0.6">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.2">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.6">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3025,12 +3025,12 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_pommel" name="{=usVYZYYD}Northern Lordly Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_4" culture="Culture.sturgia" length="5.4" weight="0.2">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_pommel" name="{=usVYZYYD}Northern Lordly Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_4" culture="Culture.sturgia" length="5.4" weight="0.15">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.70">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3251,38 +3251,38 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.4">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.48">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.4">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_3_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.13">
+  <CraftingPiece id="crpg_sturgia_sword_3_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.65">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.13">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.6">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bastard_sword_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.3">
+  <CraftingPiece id="crpg_bastard_sword_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.65">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.50">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_pommel" name="{=sHwhgRzK}Crescent Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_7" culture="Culture.khuzait" length="1.711" weight="0.8">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3600,13 +3600,13 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_handle" name="{=9T2KA9sk}Gold Bound Decorated Steel Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_4" culture="Culture.sturgia" length="15.7" weight="0.3">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_handle" name="{=9T2KA9sk}Gold Bound Decorated Steel Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_4" culture="Culture.sturgia" length="15.7" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_handle" name="{=ueCf3sde}Leather Wrapped Thin One Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_noble_grip_3" culture="Culture.sturgia" length="15" weight="0.95">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_handle" name="{=ueCf3sde}Leather Wrapped Thin One Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_noble_grip_3" culture="Culture.sturgia" length="15" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3618,7 +3618,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bastard_sword_t2_handle" name="{=Gewh8Bzr}Bound Fur Two Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_33" culture="Culture.sturgia" length="25" weight="0.35">
+  <CraftingPiece id="crpg_bastard_sword_t2_handle" name="{=Gewh8Bzr}Bound Fur Two Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_33" culture="Culture.sturgia" length="25" weight="0.10">
     <BuildData piece_offset="-6.7" previous_piece_offset="0.3" next_piece_offset="0.35" />
     <Materials>
       <Material id="Iron2" count="2" />
@@ -3715,7 +3715,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.7">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_handle" name="{=Nk924YlG}Decorated Fine Steel One Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_2" culture="Culture.sturgia" length="15" weight="0.3">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3727,7 +3727,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_handle" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_handle" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3968,7 +3968,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_handle" name="{=ZKsIpbg6}Half Leather Covered Wire Bound Two Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_grip_36" culture="Culture.sturgia" length="19.8" weight="0.45">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_handle" name="{=ZKsIpbg6}Half Leather Covered Wire Bound Two Handed Grip" tier="5" piece_type="Handle" mesh="sturgian_grip_36" culture="Culture.sturgia" length="19.8" weight="0.35">
     <BuildData piece_offset="0" previous_piece_offset="-0.2" next_piece_offset="0.6" />
     <Materials>
       <Material id="Iron5" count="3" />
@@ -3986,7 +3986,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_handle" name="{=LEdJzFrZ}Bevelled Angular One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_7" culture="Culture.sturgia" length="15" weight="0.45">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_handle" name="{=LEdJzFrZ}Bevelled Angular One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_7" culture="Culture.sturgia" length="15" weight="0.35">
     <BuildData piece_offset="0" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -4010,7 +4010,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_handle" name="{=qbYoAvs6}Bound Hide One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_13" length="15.2" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_handle" name="{=qbYoAvs6}Bound Hide One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_13" length="15.2" weight="0.1">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -4227,14 +4227,14 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_guard" name="{=4z3U5ubo}Golden Warsword Guard" tier="5" piece_type="Guard" mesh="sturgian_noble_guard_4" culture="Culture.sturgia" length="3.4" weight="0.20">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_guard" name="{=4z3U5ubo}Golden Warsword Guard" tier="5" piece_type="Guard" mesh="sturgian_noble_guard_4" culture="Culture.sturgia" length="3.4" weight="0.10">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0" />
     <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_guard" name="{=3uUaFQ9Y}Hammer Shaped Guard With Engravings" tier="3" piece_type="Guard" mesh="sturgian_noble_guard_3" culture="Culture.sturgia" length="3.8" weight="0.3">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_guard" name="{=3uUaFQ9Y}Hammer Shaped Guard With Engravings" tier="3" piece_type="Guard" mesh="sturgian_noble_guard_3" culture="Culture.sturgia" length="3.8" weight="0.1">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0.3" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4311,7 +4311,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_guard" name="{=eapPaDKi}Thick Silvered Warsword Guard " tier="5" piece_type="Guard" mesh="sturgian_noble_guard_2" culture="Culture.sturgia" length="3.5" weight="0.35">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_guard" name="{=eapPaDKi}Thick Silvered Warsword Guard " tier="5" piece_type="Guard" mesh="sturgian_noble_guard_2" culture="Culture.sturgia" length="3.5" weight="0.08">
     <BuildData next_piece_offset="0.5" previous_piece_offset="0.3" />
     <StatContributions armor_bonus="0" />
     <Materials>
@@ -4570,7 +4570,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_guard" name="{=RB3oxhaV}Long-Armed Guard" tier="5" piece_type="Guard" mesh="sturgian_guard_4" culture="Culture.sturgia" length="1" weight="0.35">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_guard" name="{=RB3oxhaV}Long-Armed Guard" tier="5" piece_type="Guard" mesh="sturgian_guard_4" culture="Culture.sturgia" length="1" weight="0.12">
     <BuildData next_piece_offset="0.4" />
     <StatContributions armor_bonus="0" />
     <Materials>
@@ -4584,14 +4584,14 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.35">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.2">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.1">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="0" />
     <Materials>
@@ -4605,7 +4605,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_guard" name="{=89QyC7eD}Narrow Northern Guard" tier="1" piece_type="Guard" mesh="sturgian_guard_1" culture="Culture.sturgia" length="1.7" weight="0.2">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_guard" name="{=89QyC7eD}Narrow Northern Guard" tier="1" piece_type="Guard" mesh="sturgian_guard_1" culture="Culture.sturgia" length="1.7" weight="0.1">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="1" />
     <Materials>
@@ -4836,7 +4836,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bastard_sword_t2_guard" name="{=XI5QgznO}Tapered Cleaver Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_2" culture="Culture.aserai" length="1.289" weight="0.25">
+  <CraftingPiece id="crpg_bastard_sword_t2_guard" name="{=XI5QgznO}Tapered Cleaver Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_2" culture="Culture.aserai" length="1.289" weight="0.05">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4938,10 +4938,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.12">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4950,10 +4950,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_blade" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.87">
+  <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_blade" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5082,10 +5082,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_blade" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="0.95">
+  <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_blade" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5094,10 +5094,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.9">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.02">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5521,10 +5521,10 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_blade" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.91">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_blade" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5533,10 +5533,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_3_t3_blade" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.10">
+  <CraftingPiece id="crpg_sturgia_sword_3_t3_blade" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5545,10 +5545,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.95">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5557,10 +5557,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="1.3">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.85">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5569,10 +5569,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_4_t4_blade" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.95">
+  <CraftingPiece id="crpg_sturgia_sword_4_t4_blade" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="1.07">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5581,10 +5581,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.97">
+  <CraftingPiece id="crpg_sturgia_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5593,10 +5593,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.20">
+  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5825,11 +5825,11 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bastard_sword_t2_blade" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.1">
+  <CraftingPiece id="crpg_bastard_sword_t2_blade" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.0">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.4" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -3073,13 +3073,13 @@
     "weapons": []
   },
   {
-    "id": "crpg_bastard_sword_t2",
-    "name": "Simple Warsword",
+    "id": "crpg_bastard_sword_t2_v2",
+    "name": "Simple Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1745,
-    "weight": 2.0,
-    "tier": 4.2576437,
+    "price": 2817,
+    "weight": 1.65,
+    "tier": 5.70136261,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3091,19 +3091,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 98,
-        "balance": 0.51,
-        "handling": 83,
+        "length": 84,
+        "balance": 0.63,
+        "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 14,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -29879,13 +29879,13 @@
     "weapons": []
   },
   {
-    "id": "crpg_sturgia_noble_sword_1_t5",
-    "name": "Thamaskene Steel Warsword",
+    "id": "crpg_sturgia_noble_sword_1_t5_v2",
+    "name": "Thamaskene Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4154,
-    "weight": 2.15,
-    "tier": 7.15892553,
+    "price": 5966,
+    "weight": 2.1,
+    "tier": 8.798293,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29897,30 +29897,65 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 103,
-        "balance": 0.43,
-        "handling": 90,
+        "length": 82,
+        "balance": 0.61,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 32,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_noble_sword_2_t5_v2",
+    "name": "Decorated Long Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 6757,
+    "weight": 2.08,
+    "tier": 9.435332,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 104,
+        "balance": 0.42,
+        "handling": 89,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 86,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }
     ]
   },
   {
-    "id": "crpg_sturgia_noble_sword_2_t5",
-    "name": "Decorated Long Warsword",
+    "id": "crpg_sturgia_noble_sword_3_t5_v2",
+    "name": "Decorated Northern Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4664,
-    "weight": 2.42,
-    "tier": 7.650725,
+    "price": 6303,
+    "weight": 1.83,
+    "tier": 9.075044,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -29932,65 +29967,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 110,
-        "balance": 0.35,
-        "handling": 88,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 33,
-        "swingDamageType": "Cut",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_noble_sword_3_t5",
-    "name": "Decorated Fullered Sword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 3768,
-    "weight": 2.7,
-    "tier": 6.765382,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 96,
-        "balance": 0.48,
-        "handling": 92,
+        "length": 88,
+        "balance": 0.72,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 82,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 91
       }
     ]
   },
   {
-    "id": "crpg_sturgia_noble_sword_4_t5",
+    "id": "crpg_sturgia_noble_sword_4_t5_v2",
     "name": "Gold Bound Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3791,
-    "weight": 1.82,
-    "tier": 6.79004049,
+    "price": 7416,
+    "weight": 2.05,
+    "tier": 9.937938,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30003,18 +30003,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.75,
-        "handling": 95,
+        "balance": 0.6,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 28,
+        "thrustSpeed": 86,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 87
       }
     ]
   },
@@ -30154,13 +30154,13 @@
     ]
   },
   {
-    "id": "crpg_sturgia_sword_1_t2",
-    "name": "Tapered Blade",
+    "id": "crpg_sturgia_sword_1_t2_v2",
+    "name": "Iron Thegn Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1609,
-    "weight": 1.97,
-    "tier": 4.04659271,
+    "price": 3372,
+    "weight": 2.0,
+    "tier": 6.340542,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30172,30 +30172,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 90,
-        "balance": 0.63,
-        "handling": 89,
+        "length": 83,
+        "balance": 0.64,
+        "handling": 85,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 27,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 89
       }
     ]
   },
   {
-    "id": "crpg_sturgia_sword_2_t3",
-    "name": "Backsword",
+    "id": "crpg_sturgia_sword_2_t3_v2",
+    "name": "Northern Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1744,
-    "weight": 2.01,
-    "tier": 4.256398,
+    "price": 5285,
+    "weight": 1.78,
+    "tier": 8.216066,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30207,135 +30207,30 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 89,
-        "balance": 0.53,
-        "handling": 93,
+        "length": 87,
+        "balance": 0.74,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 28,
-        "swingDamageType": "Cut",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_3_t3",
-    "name": "Pointy Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 3287,
-    "weight": 1.66,
-    "tier": 6.24710655,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 93,
-        "balance": 0.68,
-        "handling": 94,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 24,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 23,
-        "swingDamageType": "Cut",
-        "swingSpeed": 90
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_4_t4",
-    "name": "Long Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 3426,
-    "weight": 2.05,
-    "tier": 6.40035725,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 100,
-        "balance": 0.59,
-        "handling": 90,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
-        "swingDamageType": "Cut",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_sturgia_sword_5_t4",
-    "name": "Fullered Narrow Warsword",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-    "price": 3308,
-    "weight": 1.69,
-    "tier": 6.270406,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 89,
-        "balance": 0.75,
-        "handling": 91,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 22,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 27,
+        "thrustSpeed": 88,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 92
       }
     ]
   },
   {
-    "id": "crpg_sturgia_sword_5_t5",
-    "name": "Fullered Long Warsword",
+    "id": "crpg_sturgia_sword_3_t3_v2",
+    "name": "Pointed Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4389,
-    "weight": 1.96,
-    "tier": 7.38899469,
+    "price": 3955,
+    "weight": 2.0,
+    "tier": 6.9582696,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30347,19 +30242,124 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 97,
-        "balance": 0.63,
-        "handling": 90,
+        "length": 88,
+        "balance": 0.61,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 30,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_4_t4_v2",
+    "name": "Iron Long Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 3774,
+    "weight": 2.11,
+    "tier": 6.772046,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 103,
+        "balance": 0.44,
+        "handling": 84,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 85,
+        "swingDamage": 33,
+        "swingDamageType": "Cut",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_5_t4_v2",
+    "name": "Thamaskene Pointed Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 5057,
+    "weight": 1.82,
+    "tier": 8.01221752,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 85,
+        "balance": 0.7,
+        "handling": 84,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 27,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 29,
+        "swingDamageType": "Cut",
+        "swingSpeed": 90
+      }
+    ]
+  },
+  {
+    "id": "crpg_sturgia_sword_5_t5_v2",
+    "name": "Steel Long Warsword",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 4722,
+    "weight": 1.97,
+    "tier": 7.70494461,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 105,
+        "balance": 0.44,
+        "handling": 83,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 34,
+        "swingDamageType": "Cut",
+        "swingSpeed": 83
       }
     ]
   },
@@ -30989,13 +30989,13 @@
     ]
   },
   {
-    "id": "crpg_thegn_sword_1_t2",
-    "name": "Thegn Sword",
+    "id": "crpg_thegn_sword_1_t2_v2",
+    "name": "Engraved Thegn Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 7104,
-    "weight": 1.89,
-    "tier": 9.702907,
+    "price": 7453,
+    "weight": 1.9,
+    "tier": 9.965522,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31007,19 +31007,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 92,
-        "balance": 0.61,
-        "handling": 94,
+        "length": 86,
+        "balance": 0.67,
+        "handling": 87,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 31,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -844,17 +844,17 @@
       <Piece id="crpg_khuzait_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_1_t2" name="{=Ag6dujzl}Tapered Blade" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_1_t2_v2" name="{=Ag6dujzl}Iron Thegn Blade" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_1_t2_blade" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_sturgia_sword_1_t2_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_1_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_1_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_thegn_sword_1_t2" name="{=Ag6dujzl}Thegn Sword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_thegn_sword_1_t2_v2" name="{=Ag6dujzl}Engraved Thegn Blade" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_thegn_sword_1_t2_blade" Type="Blade" scale_factor="113" />
+      <Piece id="crpg_thegn_sword_1_t2_blade" Type="Blade" scale_factor="105" />
       <Piece id="crpg_sturgia_sword_1_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_1_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -956,17 +956,17 @@
       <Piece id="crpg_khuzait_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_2_t3" name="{=FQHaFsyQ}Backsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_2_t3_v2" name="{=FQHaFsyQ}Northern Backsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_2_t3_blade" Type="Blade" scale_factor="118" />
+      <Piece id="crpg_sturgia_sword_2_t3_blade" Type="Blade" scale_factor="115" />
       <Piece id="crpg_sturgia_sword_2_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_2_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_2_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_3_t3" name="{=MRIdGqhA}Pointy Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_3_t3_v2" name="{=MRIdGqhA}Pointed Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_3_t3_blade" Type="Blade" scale_factor="112" />
+      <Piece id="crpg_sturgia_sword_3_t3_blade" Type="Blade" scale_factor="105" />
       <Piece id="crpg_sturgia_sword_3_t3_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_3_t3_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_3_t3_pommel" Type="Pommel" scale_factor="100" />
@@ -1108,17 +1108,17 @@
       <Piece id="crpg_khuzait_sword_5_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_4_t4" name="{=EadnjRjs}Long Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_4_t4_v2" name="{=EadnjRjs}Iron Long Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_4_t4_blade" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_sturgia_sword_4_t4_blade" Type="Blade" scale_factor="108" />
       <Piece id="crpg_sturgia_sword_4_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_4_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_4_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_5_t4" name="{=SGdY9jmK}Fullered Narrow Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_5_t4_v2" name="{=SGdY9jmK}Thamaskene Pointed Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_5_t4_blade" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_sturgia_sword_5_t4_blade" Type="Blade" scale_factor="105" />
       <Piece id="crpg_sturgia_sword_5_t4_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_5_t4_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_5_t4_pommel" Type="Pommel" scale_factor="100" />
@@ -1188,9 +1188,9 @@
       <Piece id="crpg_aserai_sword_7_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_5_t5" name="{=jfWzICId}Fullered Long Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_5_t5_v2" name="{=jfWzICId}Steel Long Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_sword_5_t5_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_sturgia_sword_5_t5_blade" Type="Blade" scale_factor="110" />
       <Piece id="crpg_sturgia_sword_5_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_5_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_5_t5_pommel" Type="Pommel" scale_factor="100" />
@@ -1332,31 +1332,31 @@
       <Piece id="crpg_khuzait_noble_sword_3_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_noble_sword_1_t5" name="{=lXwaLAYP}Thamaskene Steel Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_noble_sword_1_t5_v2" name="{=lXwaLAYP}Thamaskene Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_noble_sword_1_t5_blade" Type="Blade" scale_factor="150" />
+      <Piece id="crpg_sturgia_noble_sword_1_t5_blade" Type="Blade" scale_factor="115" />
       <Piece id="crpg_sturgia_noble_sword_1_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_1_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_1_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_noble_sword_2_t5" name="{=4wQRk3f5}Decorated Long Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_noble_sword_2_t5_v2" name="{=4wQRk3f5}Decorated Long Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_noble_sword_2_t5_blade" Type="Blade" scale_factor="139" />
+      <Piece id="crpg_sturgia_noble_sword_2_t5_blade" Type="Blade" scale_factor="130" />
       <Piece id="crpg_sturgia_noble_sword_2_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_2_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_2_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_noble_sword_3_t5" name="{=QA5zGCKf}Decorated Fullered Sword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_noble_sword_3_t5_v2" name="{=QA5zGCKf}Decorated Northern Backsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_sturgia_noble_sword_3_t5_blade" Type="Blade" scale_factor="138" />
+      <Piece id="crpg_sturgia_noble_sword_3_t5_blade" Type="Blade" scale_factor="125" />
       <Piece id="crpg_sturgia_noble_sword_3_t5_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_3_t5_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_3_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_noble_sword_4_t5" name="{=06Qoh8AO}Gold Bound Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_noble_sword_4_t5_v2" name="{=06Qoh8AO}Gold Bound Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_sturgia_noble_sword_4_t5_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_sturgia_noble_sword_4_t5_guard" Type="Guard" scale_factor="100" />
@@ -1396,9 +1396,9 @@
       <Piece id="crpg_battania_2hsword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bastard_sword_t2" name="{=arBdK7st}Simple Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_bastard_sword_t2_v2" name="{=arBdK7st}Simple Short Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_bastard_sword_t2_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_bastard_sword_t2_blade" Type="Blade" scale_factor="85" />
       <Piece id="crpg_bastard_sword_t2_guard" Type="Guard" scale_factor="100" />
       <Piece id="crpg_bastard_sword_t2_handle" Type="Handle" scale_factor="100" />
       <Piece id="crpg_bastard_sword_t2_pommel" Type="Pommel" scale_factor="100" />


### PR DESCRIPTION
Complete rework of all Sturgian 1H swords. refund included for all swords. The "handling focus" was an unsuccessful subclass. The new focus is on various shortswords, with 1 group of normal swords as well,

new groups and names as follows:

"Choppers"
Decorated Long Warsword		 ---> Decorated Long Warsword
Fullered Long Warsword			 ---> Steel Long Warsword
Long Warsword				 ---> Iron Long Warsword

"Short Balanced"
Thegn Sword					 ---> Engraved Thegn Blade
Tapered Blade					 ---> Iron Thegn Blade

"Short Choppers"
Gold Bound Short Warsword		 ---> Gold Bound Short Warsword
Thamaskene Steel Warsword		 ---> Thamaskene Short Warsword
Simple Warsword				 ---> Simple Short Warsword

"Short Slashers"
Decorated Fullered Sword		 ---> Decorated Northern Backsword
Backsword					 ---> Northern Backsword

"Short Thrusters"
Fullered Narrow Warsword		 ---> Thamaskene Pointed Warsword
Pointy Warsword				 ---> Pointed Warsword