### PR TITLE
Armor Revamp - Missing Armors - AngryMob

### DIFF
--- a/items.json
+++ b/items.json
@@ -95,6 +95,25 @@
     "weapons": []
   },
   {
+    "id": "crpg_a_aserai_scale_b_shoulder_e",
+    "name": "Long Sleeved Bronze Scale Shoulder Guards",
+    "culture": "Aserai",
+    "type": "ShoulderArmor",
+    "price": 7867,
+    "weight": 6.8,
+    "tier": 9.187858,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 25,
+      "armArmor": 9,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_a_battania_cloak_a",
     "name": "Simple Cape",
     "culture": "Battania",
@@ -1807,7 +1826,7 @@
   },
   {
     "id": "crpg_aserai_scale_shoulder_b",
-    "name": "Long Sleeved Bronze Scale Shoulder Guards",
+    "name": "Long Sleeved Decorated Scale Shoulder Guards",
     "culture": "Aserai",
     "type": "ShoulderArmor",
     "price": 10710,
@@ -9003,6 +9022,25 @@
       "bodyArmor": 52,
       "armArmor": 18,
       "legArmor": 23,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_desert_scale_shoulders",
+    "name": "Long Sleeved Steel Scale Shoulder Guards",
+    "culture": "Aserai",
+    "type": "ShoulderArmor",
+    "price": 9636,
+    "weight": 4.2,
+    "tier": 9.708144,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 25,
+      "armArmor": 9,
+      "legArmor": 0,
       "materialType": "Plate"
     },
     "weapons": []
@@ -16239,6 +16277,28 @@
     "weapons": []
   },
   {
+    "id": "crpg_khuzait_leather_stitched",
+    "name": "Stitched Cured Leather Vest",
+    "culture": "Empire",
+    "type": "BodyArmor",
+    "price": 6707,
+    "weight": 4.5,
+    "tier": 6.41228151,
+    "requirement": 0,
+    "flags": [
+      "UseTeamColor",
+      "Civilian"
+    ],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 38,
+      "armArmor": 8,
+      "legArmor": 8,
+      "materialType": "Leather"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_khuzait_mace_1_t2",
     "name": "Steppe Light Mace",
     "culture": "Khuzait",
@@ -18324,7 +18384,7 @@
   },
   {
     "id": "crpg_lordly_mail_mitten",
-    "name": "Heavy Mail Mittens",
+    "name": "Plated Mail Mittens",
     "culture": "Vlandia",
     "type": "HandArmor",
     "price": 3169,
@@ -18338,6 +18398,25 @@
       "armArmor": 24,
       "legArmor": 0,
       "materialType": "Chainmail"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_lordly_padded_mitten",
+    "name": "Decorated Padded Mittens",
+    "culture": "Empire",
+    "type": "HandArmor",
+    "price": 1560,
+    "weight": 1.3,
+    "tier": 6.66402149,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 0,
+      "armArmor": 18,
+      "legArmor": 0,
+      "materialType": "Cloth"
     },
     "weapons": []
   },
@@ -21533,6 +21612,25 @@
     "price": 4348,
     "weight": 3.926823,
     "tier": 7.809116,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 18,
+      "armArmor": 9,
+      "legArmor": 0,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_noble_pauldron_with_scarf",
+    "name": "Ornate Pauldrons over mail",
+    "culture": "Vlandia",
+    "type": "ShoulderArmor",
+    "price": 4661,
+    "weight": 3.2,
+    "tier": 7.96077251,
     "requirement": 0,
     "flags": [],
     "armor": {
@@ -25260,6 +25358,44 @@
     "weapons": []
   },
   {
+    "id": "crpg_reinforced_mail_mitten",
+    "name": "Metal Striped Mail Mittens",
+    "culture": "Vlandia",
+    "type": "HandArmor",
+    "price": 4203,
+    "weight": 1.6,
+    "tier": 8.78805351,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 0,
+      "armArmor": 24,
+      "legArmor": 0,
+      "materialType": "Chainmail"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_reinforced_padded_mitten",
+    "name": "Plated Padded Mittens",
+    "culture": "Empire",
+    "type": "HandArmor",
+    "price": 1648,
+    "weight": 0.9,
+    "tier": 6.7694335,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 0,
+      "bodyArmor": 0,
+      "armArmor": 18,
+      "legArmor": 0,
+      "materialType": "Cloth"
+    },
+    "weapons": []
+  },
+  {
     "id": "crpg_reinforced_suede_armor",
     "name": "Reinforced Suede Armor",
     "culture": "Khuzait",
@@ -27287,6 +27423,25 @@
       "bodyArmor": 40,
       "armArmor": 13,
       "legArmor": 18,
+      "materialType": "Plate"
+    },
+    "weapons": []
+  },
+  {
+    "id": "crpg_southern_lord_helmet",
+    "name": "Ornate Desert Helmet",
+    "culture": "Aserai",
+    "type": "HeadArmor",
+    "price": 7879,
+    "weight": 2.9,
+    "tier": 8.472483,
+    "requirement": 0,
+    "flags": [],
+    "armor": {
+      "headArmor": 52,
+      "bodyArmor": 0,
+      "armArmor": 0,
+      "legArmor": 0,
       "materialType": "Plate"
     },
     "weapons": []
@@ -30608,18 +30763,18 @@
     "name": "Heavy Lamellar Vest",
     "culture": "Sturgia",
     "type": "BodyArmor",
-    "price": 3747,
-    "weight": 10.02491,
-    "tier": 5.44496727,
+    "price": 17311,
+    "weight": 8.3,
+    "tier": 8.327196,
     "requirement": 0,
     "flags": [
       "UseTeamColor"
     ],
     "armor": {
       "headArmor": 0,
-      "bodyArmor": 35,
-      "armArmor": 2,
-      "legArmor": 18,
+      "bodyArmor": 50,
+      "armArmor": 13,
+      "legArmor": 13,
       "materialType": "Plate"
     },
     "weapons": []

--- a/items/arm_armors.xml
+++ b/items/arm_armors.xml
@@ -102,7 +102,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_lordly_mail_mitten" name="{=VDMkVMxt}Heavy Mail Mittens" mesh="mail_mitten_a" culture="Culture.vlandia" weight="4.264907" appearance="3" Type="HandArmor">
+  <Item id="crpg_lordly_mail_mitten" name="{=VDMkVMxt}Plated Mail Mittens" mesh="mail_mitten_a" culture="Culture.vlandia" weight="4.264907" appearance="3" Type="HandArmor">
     <ItemComponent>
       <Armor arm_armor="24" covers_hands="true" modifier_group="chain" material_type="Chainmail" />
     </ItemComponent>
@@ -174,4 +174,22 @@
 		</ItemComponent>
 		<Flags UseTeamColor="false"/>
 	</Item>
+  <Item id="crpg_reinforced_mail_mitten" name="{=dPQGxmJ7}Metal Striped Mail Mittens" mesh="mail_mitten_b" culture="Culture.vlandia" weight="1.6" difficulty="0" appearance="3" Type="HandArmor">
+    <ItemComponent>
+      <Armor arm_armor="24" covers_hands="true" modifier_group="chain" material_type="Chainmail" />
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_reinforced_padded_mitten" name="{=PLtQdf23}Plated Padded Mittens" mesh="padded_vambrace_a_reinforced" culture="Culture.empire" weight="0.9" difficulty="0" appearance="2" Type="HandArmor">
+    <ItemComponent>
+      <Armor arm_armor="18" covers_hands="true" modifier_group="cloth" material_type="Cloth" />
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_lordly_padded_mitten" name="{=t01v8qW7}Decorated Padded Mittens" mesh="padded_vambrace_a_lordly" culture="Culture.empire" weight="1.3" difficulty="0" appearance="0.7" Type="HandArmor">
+    <ItemComponent>
+      <Armor arm_armor="18" covers_hands="true" modifier_group="cloth" material_type="Cloth" />
+    </ItemComponent>
+    <Flags />
+  </Item>
 </Items>

--- a/items/body_armors.xml
+++ b/items/body_armors.xml
@@ -1007,9 +1007,9 @@
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
-  <Item id="crpg_sturgian_lamellar_gambeson_heavy" name="{=luoXhz19}Heavy Lamellar Vest" subtype="body_armor" mesh="sturgian_lamellar_gambeson_heavy" culture="Culture.sturgia" weight="10.02491" difficulty="0" appearance="1.8" Type="BodyArmor">
+  <Item id="crpg_sturgian_lamellar_gambeson_heavy" name="{=luoXhz19}Heavy Lamellar Vest with Skirt" subtype="body_armor" mesh="sturgian_lamellar_gambeson_heavy" culture="Culture.sturgia" weight="10.02491" difficulty="0" appearance="1.8" Type="BodyArmor">
     <ItemComponent>
-      <Armor body_armor="35" leg_armor="18" arm_armor="2" has_gender_variations="true" covers_body="true" modifier_group="plate" material_type="Plate" />
+      <Armor body_armor="52" leg_armor="23" arm_armor="18" has_gender_variations="true" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
@@ -1486,5 +1486,17 @@
       <Armor body_armor="24" leg_armor="12" arm_armor="6" covers_body="true" modifier_group="leather" material_type="Leather" />
     </ItemComponent>
     <Flags UseTeamColor="false" />
+  </Item>
+  <Item id="crpg_khuzait_leather_stitched" name="{=z7oMeRl3}Stitched Cured Leather Vest" mesh="khuzait_leather_stitch_a" culture="Culture.empire" weight="4.5" appearance="1" Type="BodyArmor">
+    <ItemComponent>
+      <Armor body_armor="38" leg_armor="8" arm_armor="8" has_gender_variations="false" covers_body="true" modifier_group="leather" material_type="Leather" />
+    </ItemComponent>
+    <Flags UseTeamColor="true" Civilian="true" />
+  </Item>
+  <Item id="crpg_sturgian_lamellar_gambeson_heavy" name="{=luoXhz19}Heavy Lamellar Vest" subtype="body_armor" mesh="sturgian_lamellar_gambeson_heavy" culture="Culture.sturgia" weight="8.3" difficulty="0" appearance="1.8" Type="BodyArmor">
+    <ItemComponent>
+      <Armor body_armor="50" leg_armor="13" arm_armor="13" has_gender_variations="true" covers_body="true" modifier_group="plate" material_type="Plate" />
+    </ItemComponent>
+    <Flags UseTeamColor="true" />
   </Item>
 </Items>

--- a/items/head_armors.xml
+++ b/items/head_armors.xml
@@ -1667,4 +1667,10 @@
 		</ItemComponent>
 		<Flags UseTeamColor="false"/>
 	</Item>
+  <Item id="crpg_southern_lord_helmet" name="{=GdM7iaV9}Ornate Desert Helmet" mesh="aserai_lord_helmet_c" culture="Culture.aserai" subtype="head_armor" weight="2.9" difficulty="0" appearance="4.2" Type="HeadArmor">
+    <ItemComponent>
+      <Armor head_armor="52" has_gender_variations="false" hair_cover_type="all" beard_cover_type="type4" modifier_group="plate" material_type="Plate" />
+    </ItemComponent>
+    <Flags />
+  </Item>
 </Items>

--- a/items/shoulder_armors.xml
+++ b/items/shoulder_armors.xml
@@ -54,7 +54,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_aserai_scale_shoulder_b" name="{=z4nryDlp}Long Sleeved Bronze Scale Shoulder Guards" mesh="aserai_scale_shoulder_b" culture="Culture.aserai" weight="3.106376" appearance="5" Type="Cape">
+  <Item id="crpg_aserai_scale_shoulder_b" name="{=z4nryDlp}Long Sleeved Decorated Scale Shoulder Guards" mesh="aserai_scale_shoulder_b" culture="Culture.aserai" weight="3.106376" appearance="5" Type="Cape">
     <ItemComponent>
       <Armor body_armor="25" arm_armor="9" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
@@ -496,4 +496,22 @@
 		</ItemComponent>
 		<Flags/>
 	</Item>
+  <Item id="crpg_a_aserai_scale_b_shoulder_e" name="{=LePDTpFD}Long Sleeved Bronze Scale Shoulder Guards" mesh="aserai_scale_b_shoulder_e" culture="Culture.aserai" weight="6.8" appearance="3" Type="Cape">
+    <ItemComponent>
+      <Armor body_armor="25" arm_armor="9" modifier_group="plate" material_type="Plate" />
+    </ItemComponent>
+    <Flags/>
+  </Item>
+  <Item id="crpg_desert_scale_shoulders" name="{=sbbNL1qF}Long Sleeved Steel Scale Shoulder Guards" mesh="aserai_scale_b_shoulder" culture="Culture.aserai" weight="4.2" appearance="3" Type="Cape">
+    <ItemComponent>
+      <Armor body_armor="25" arm_armor="9" modifier_group="plate" material_type="Plate" />
+    </ItemComponent>
+    <Flags/>
+  </Item>
+  <Item id="crpg_noble_pauldron_with_scarf" name="{=wMsbMc2T}Ornate Pauldrons over mail" mesh="noble_pauldron_with_scarf" culture="Culture.vlandia" weight="3.2" appearance="7" Type="Cape">
+    <ItemComponent>
+      <Armor body_armor="18" arm_armor="9" modifier_group="plate" material_type="Plate" />
+    </ItemComponent>
+    <Flags />
+  </Item>
 </Items>


### PR DESCRIPTION
Missing native armors added, and some existing armors renamed to fit with the new additions:
Helmets:
crpg_southern_lord_helmet - Ornate Desert Helmet

no renames

Bodies:
crpg_khuzait_leather_stitched - Stitched Cured Leather Vest
crpg_sturgian_lamellar_gambeson - Heavy Lamellar Vest

existing Heavy Lamellar Vest renamed to Heavy Lamellar Vest with Skirt and stats changed to cavalry type to reflect skirt

Shoulders:
crpg_noble_pauldron_with_scarf - Ornate Pauldrons over mail
crpg_desert_scale_shoulders - Long Sleeved Steel Scale Shoulder Guards
crpg_a_aserai_scale_b_shoulder_e - Long Sleeved Bronze Scale Shoulder Guards

existing Long Sleeved Bronze Scale Shoulder Guards renamed to Long Sleeved Decorated Scale Shoulder Guards

Arms:
crpg_lordly_padded_mitten - Decorated Padded Mittens
crpg_reinforced_padded_mitten - Plated Padded Mittens
crpg_reinforced_mail_mitten - Metal Striped Mail Mittens

existing Heavy Mail Mittens renamed to Plated Mail Mittens