### PR TITLE
PolearmsChangeUpdate (follow by the second nerf on Handling)

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1434,10 +1434,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.5">
+  <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.53">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1467,9 +1467,9 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_polearm_1_t5_blade" name="{=PmPxx2gK}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.60" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_battania_polearm_1_t5_blade" name="{=PmPxx2gK}Bent Razor Head" tier="4" piece_type="Blade" mesh="spear_blade_44" length="80" weight="0.63" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -1478,10 +1478,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_polearm_1_t5_blade" name="{=wait0O6m}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.57" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_sturgia_polearm_1_t5_blade" name="{=wait0O6m}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.61" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1490,7 +1490,7 @@
   <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.43">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -1498,14 +1498,14 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.6">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Thrust damage_type="Cut" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.60">
+  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.6">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="4.8" />
@@ -1837,7 +1837,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -2339,8 +2339,8 @@
   <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Cut" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6046,7 +6046,7 @@
 <Material id="Wood" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_war_scythe_blade" name="{=}War Scythe Blade" tier="2" piece_type="Blade" mesh="warscythe_head" length="120" weight="0.72" excluded_item_usage_features="shield:thrust">
+<CraftingPiece id="crpg_war_scythe_blade" name="{=}War Scythe Blade" tier="2" piece_type="Blade" mesh="warscythe_head" length="120" weight="0.75" excluded_item_usage_features="shield:thrust">
 <BuildData piece_offset="-20"/>
 <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
 <Swing damage_type="Cut" damage_factor="4.4"/>
@@ -6156,9 +6156,9 @@
 <Material id="Iron3" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.2" full_scale="true">
+<CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.23" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Blunt" damage_factor="1.7" />
+      <Thrust damage_type="Blunt" damage_factor="1.8" />
       <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
@@ -6435,10 +6435,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.7">
+  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.86">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3"/>
-      <Swing damage_type="Cut" damage_factor="3.7"/>
+      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Swing damage_type="Cut" damage_factor="4.2"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6453,10 +6453,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade" name="Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
+  <CraftingPiece id="crpg_burgundian_glaive_blade" name="Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.37">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2"/>
-      <Swing damage_type="Cut" damage_factor="4.4"/>
+      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Swing damage_type="Cut" damage_factor="4.8"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6471,10 +6471,10 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.77">
+  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.74">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5"/>
-      <Swing damage_type="Cut" damage_factor="4.2"/>
+      <Swing damage_type="Cut" damage_factor="4.3"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6491,8 +6491,8 @@
     </CraftingPiece>
   <CraftingPiece id="crpg_simple_poleaxe_blade" name="Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.7">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4"/>
-      <Swing damage_type="Cut" damage_factor="4.4"/>
+      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Swing damage_type="Cut" damage_factor="4.5"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6507,7 +6507,7 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.50">
+  <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.47">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5"/>
       <Swing damage_type="Pierce" damage_factor="3.0"/>

--- a/items.json
+++ b/items.json
@@ -4830,9 +4830,9 @@
     "name": "Rhomphaia",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 17117,
-    "weight": 1.41,
-    "tier": 10.3182831,
+    "price": 12400,
+    "weight": 1.44,
+    "tier": 8.622346,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -4843,7 +4843,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 184,
-        "balance": 0.23,
+        "balance": 0.21,
         "handling": 66,
         "bodyArmor": 0,
         "flags": [
@@ -4856,9 +4856,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 96,
-        "swingDamage": 45,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 76
       }
     ]
   },
@@ -5797,9 +5797,9 @@
     "name": "Bec De Corbin",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12413,
-    "weight": 1.91,
-    "tier": 8.62737,
+    "price": 15107,
+    "weight": 1.89,
+    "tier": 9.628217,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5812,8 +5812,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 124,
-        "balance": 0.47,
-        "handling": 70,
+        "balance": 0.5,
+        "handling": 71,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5823,10 +5823,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
+        "thrustSpeed": 94,
         "swingDamage": 30,
         "swingDamageType": "Pierce",
-        "swingSpeed": 84
+        "swingSpeed": 85
       }
     ]
   },
@@ -5879,9 +5879,9 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 17783,
+    "price": 14815,
     "weight": 1.91,
-    "tier": 10.5378418,
+    "tier": 9.524284,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5905,7 +5905,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 93,
-        "swingDamage": 45,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }
@@ -7120,9 +7120,9 @@
     "name": "Burgundian Glaive",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 14260,
-    "weight": 1.78,
-    "tier": 9.323732,
+    "price": 15756,
+    "weight": 1.87,
+    "tier": 9.855761,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -7135,8 +7135,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.21,
-        "handling": 65,
+        "balance": 0.12,
+        "handling": 62,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -7144,12 +7144,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 44,
+        "thrustSpeed": 92,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 73
       }
     ]
   },
@@ -7158,9 +7158,9 @@
     "name": "Burgundian Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 10910,
-    "weight": 2.27,
-    "tier": 8.021976,
+    "price": 15898,
+    "weight": 2.24,
+    "tier": 9.904951,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -7173,8 +7173,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.41,
-        "handling": 72,
+        "balance": 0.43,
+        "handling": 73,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -7185,9 +7185,9 @@
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 91,
-        "swingDamage": 42,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 83
       }
     ]
   },
@@ -11297,9 +11297,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 12816,
-    "weight": 1.84,
-    "tier": 8.783545,
+    "price": 15857,
+    "weight": 1.87,
+    "tier": 9.890608,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11310,8 +11310,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 169,
-        "balance": 0.33,
-        "handling": 69,
+        "balance": 0.3,
+        "handling": 68,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -11319,12 +11319,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 41,
+        "thrustSpeed": 93,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 79
       }
     ]
   },
@@ -12213,9 +12213,9 @@
     "name": "French Voulge",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 11198,
-    "weight": 1.99,
-    "tier": 8.140728,
+    "price": 15710,
+    "weight": 2.15,
+    "tier": 9.839896,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -12228,8 +12228,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 133,
-        "balance": 0.61,
-        "handling": 75,
+        "balance": 0.48,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -12237,12 +12237,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 37,
+        "thrustSpeed": 92,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 84
       }
     ]
   },
@@ -16949,9 +16949,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 13484,
+    "price": 16137,
     "weight": 1.68,
-    "tier": 9.037146,
+    "tier": 9.98715,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16971,10 +16971,10 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 24,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 41,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
         "swingSpeed": 83
       }
@@ -16985,9 +16985,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 16137,
+    "price": 13629,
     "weight": 1.44,
-    "tier": 9.987215,
+    "tier": 9.0912,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -17010,7 +17010,7 @@
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
         "thrustSpeed": 95,
-        "swingDamage": 47,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
         "swingSpeed": 73
       }
@@ -18464,9 +18464,9 @@
     "name": "Long Bardiche",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 18030,
+    "price": 15841,
     "weight": 1.7,
-    "tier": 10.6182117,
+    "tier": 9.885214,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18489,10 +18489,10 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 27,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 48,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
         "swingSpeed": 75
       }
@@ -18624,9 +18624,9 @@
     "name": "Long Hafted Spiked Mace",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 15698,
-    "weight": 1.87,
-    "tier": 9.835544,
+    "price": 7139,
+    "weight": 1.99,
+    "tier": 6.288904,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18639,8 +18639,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 155,
-        "balance": 0.17,
-        "handling": 67,
+        "balance": 0.07,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -18649,12 +18649,12 @@
           "TwoHandIdleOnMount",
           "MultiplePenetration"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 18,
         "thrustDamageType": "Blunt",
-        "thrustSpeed": 93,
+        "thrustSpeed": 91,
         "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 75
+        "swingSpeed": 71
       }
     ]
   },
@@ -27717,9 +27717,9 @@
     "name": "Simple Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 10759,
+    "price": 13093,
     "weight": 2.2,
-    "tier": 7.95875454,
+    "tier": 8.889323,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -27741,10 +27741,10 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 91,
-        "swingDamage": 44,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
         "swingSpeed": 78
       }
@@ -28842,9 +28842,9 @@
     "name": "Spiked Polehammer",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 16352,
+    "price": 16006,
     "weight": 2.0,
-    "tier": 10.060667,
+    "tier": 9.942302,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28856,7 +28856,7 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 148,
+        "length": 147,
         "balance": 0.23,
         "handling": 67,
         "bodyArmor": 0,
@@ -31051,9 +31051,9 @@
     "name": "Warrazor",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 14210,
-    "weight": 1.2,
-    "tier": 9.305796,
+    "price": 12840,
+    "weight": 1.24,
+    "tier": 8.792853,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31064,8 +31064,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.19,
-        "handling": 63,
+        "balance": 0.16,
+        "handling": 62,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -31073,12 +31073,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 96,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 74
       },
       {
         "class": "TwoHandedPolearm",
@@ -31087,8 +31087,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.19,
-        "handling": 63,
+        "balance": 0.16,
+        "handling": 62,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -31096,12 +31096,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 96,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 74
       }
     ]
   },
@@ -34438,9 +34438,9 @@
     "name": "War Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 16362,
-    "weight": 1.78,
-    "tier": 10.0639811,
+    "price": 13238,
+    "weight": 1.8,
+    "tier": 8.944567,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -34451,8 +34451,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 169,
-        "balance": 0.31,
-        "handling": 68,
+        "balance": 0.29,
+        "handling": 67,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -34465,7 +34465,7 @@
         "thrustSpeed": 94,
         "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 78
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2586,7 +2586,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_spiked_polehammer" name="{=}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
 		<Pieces>
-			<Piece id="crpg_spiked_polehammer_blade" Type="Blade" scale_factor="100"/>
+			<Piece id="crpg_spiked_polehammer_blade" Type="Blade" scale_factor="99"/>
 			<Piece id="crpg_spiked_polehammer_handle" Type="Handle" scale_factor="100"/>
 		</Pieces>
   </CraftedItem>


### PR DESCRIPTION
Listing down of all changes (the "original stats" before changes are the result stats from the previous "Polearm Change" branch):


Long Bardiche:
swing damage 48--> 47
thrust damage 24--> 27

Menavlion:
swing damage 41--> 43
swing speed 80--> 79
thrust damage 22--> 24
thrust speed 94--> 93
Weight 1.84--> 1.87
handling 69--> 68

Long Glaive:
swing damage 47--> 46

Billhook:
swing damage 45--> 44

Glaive:
swing damage 41--> 42

Long Hafted Spiked Mace:
swing speed 75--> 79
thrust damage 17--> 18
thrust speed 93--> 91
Weight 1.87--> 1.99
handling 67--> 64

War Scythe:
swing speed 79--> 78

Rhomphaia:
swing damage 45--> 44
swing speed 77--> 76
Weight 1.41--> 1.44

Warrazor:
swing damage 47--> 48
swing speed 75--> 74
thrust damage 21--> 18
thrust speed 97--> 96
Weight 1.2--> 1.24
handling 63--> 62

Burgundian Poleaxe:
swing damage 42--> 43
swing speed 82--> 81
thrust speed 91--> 90
Weight 2.27--> 2.24
handling 72--> 73

Simple Poleaxe:
swing damage 44--> 45
thrust damage 24--> 25

Bec De Corbin:
swing speed 84--> 85
thrust speed 93--> 94
Weight 1.91--> 1.89
handling 70--> 71

Spiked Polehammer:
Reach 148--> 147

Burgundian Glaive:
swing damage 44--> 48
swing speed 76--> 73
thrust damage 22--> 23
thrust speed 93--> 92
Weight 1.78--> 1.87
handling 65--> 62

French Voulge:
swing damage 37--> 42
swing speed 88--> 84
thrust damage 23--> 25
thrust speed 93--> 92
Weight 1.99--> 2.15
handling 75--> 72
