### PR TITLE
Polearms changes update

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1487,10 +1487,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.43">
+  <CraftingPiece id="crpg_khuzait_polearm_2_t5_blade" name="{=bjQ8J71a}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.40">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -1505,7 +1505,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.60">
+  <CraftingPiece id="crpg_empire_polearm_2_t5_blade" name="{=qSV6C2tp}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="4.8" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1258,7 +1258,7 @@
   <CraftingPiece id="crpg_easter_polesword_t4_blade" name="{=3ged5Ozt}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.5">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -1366,7 +1366,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="0.8" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_peasant_polearm_1_t1_blade" name="{=iMbT3L4I}Scythe Blade" tier="1" piece_type="Blade" mesh="spear_blade_31" length="7" weight="0.89" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Pierce" damage_factor="3" />
     </BladeData>
@@ -1436,7 +1436,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_empire_polearm_1_t4_blade" name="{=dXRt8jY4}Menavlion Head" tier="4" piece_type="Blade" mesh="spear_blade_7" length="52.924" weight="0.5">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
@@ -1496,10 +1496,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.6">
+  <CraftingPiece id="crpg_khuzait_polearm_1_t4_blade" name="{=OBeOZ27b}Glaive Head" tier="4" piece_type="Blade" mesh="spear_blade_19" length="37.4" weight="0.63">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Thrust damage_type="Cut" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -1514,10 +1514,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.45">
+  <CraftingPiece id="crpg_vlandia_polearm_1_t5_blade" name="{=LNDbMUK0}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.48">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
@@ -1617,7 +1617,7 @@
   <CraftingPiece id="crpg_northern_spear_2_t3_blade" name="{=NAHHwS3G}Broad Leaf Shaped Spear Tip" tier="3" piece_type="Blade" mesh="spear_blade_40" length="42" weight="0.3828">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
       </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1835,9 +1835,9 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_polearm_t2_blade" name="{=R62maL2H}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -2336,11 +2336,11 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.75">
+  <CraftingPiece id="crpg_long_bardiche_head" name="{=}Long Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.69">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Cut" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Cut" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6156,7 +6156,7 @@
 <Material id="Iron3" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.2" full_scale="true">
+<CraftingPiece id="crpg_long_hafted_spiked_mace_head" name="{=}Long Hafted Spiked Mace" tier="5" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.21" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Blunt" damage_factor="1.7" />
       <Swing damage_type="Blunt" damage_factor="2.5" />
@@ -6435,10 +6435,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.7">
+  <CraftingPiece id="crpg_french_voulge_blade" name="French Voulge Blade" tier="3" piece_type="Blade" mesh="french_voulge_head" culture="Culture.vlandia" length="58.6" weight="0.86">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3"/>
-      <Swing damage_type="Cut" damage_factor="3.7"/>
+      <Thrust damage_type="Pierce" damage_factor="2.4"/>
+      <Swing damage_type="Cut" damage_factor="4.1"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6455,8 +6455,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_burgundian_glaive_blade" name="Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2"/>
-      <Swing damage_type="Cut" damage_factor="4.4"/>
+      <Thrust damage_type="Pierce" damage_factor="2.1"/>
+      <Swing damage_type="Cut" damage_factor="4.5"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6471,13 +6471,14 @@
       <Material id="Wood" count="1"/>
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.77">
+  <CraftingPiece id="crpg_burgundian_axe_blade" name="Burgundian Axe Blade" tier="3" piece_type="Blade" mesh="burgundian_poleaxe_head" culture="Culture.vlandia" length="37.8" weight="0.83">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5"/>
-      <Swing damage_type="Cut" damage_factor="4.2"/>
+      <Swing damage_type="Cut" damage_factor="4.3"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2"/>
@@ -6491,11 +6492,12 @@
     </CraftingPiece>
   <CraftingPiece id="crpg_simple_poleaxe_blade" name="Simple Poleaxe Blade" tier="3" piece_type="Blade" mesh="simple_poleaxe_head" culture="Culture.vlandia" length="46.6" weight="0.7">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4"/>
-      <Swing damage_type="Cut" damage_factor="4.4"/>
+      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Swing damage_type="Cut" damage_factor="4.3"/>
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="2"/>
@@ -6509,7 +6511,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.50">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5"/>
+      <Thrust damage_type="Pierce" damage_factor="2.3"/>
       <Swing damage_type="Pierce" damage_factor="3.0"/>
     </BladeData>
     <Flags>
@@ -6527,7 +6529,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_spiked_polehammer_blade" name="Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.5">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1"/>
+      <Thrust damage_type="Pierce" damage_factor="2.2"/>
       <Swing damage_type="Blunt" damage_factor="3.0"/>
     </BladeData>
     <Flags>

--- a/items.json
+++ b/items.json
@@ -11334,9 +11334,9 @@
     "name": "Fine Steel Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 10375,
-    "weight": 1.29,
-    "tier": 7.79638147,
+    "price": 13185,
+    "weight": 1.26,
+    "tier": 8.924269,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11347,8 +11347,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 201,
-        "balance": 0.06,
-        "handling": 62,
+        "balance": 0.09,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -11361,7 +11361,7 @@
         "thrustSpeed": 96,
         "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 71
+        "swingSpeed": 72
       }
     ]
   },
@@ -16986,9 +16986,9 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 13317,
-    "weight": 1.44,
-    "tier": 8.974446,
+    "price": 13834,
+    "weight": 1.41,
+    "tier": 9.167392,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16999,7 +16999,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.12,
+        "balance": 0.15,
         "handling": 63,
         "bodyArmor": 0,
         "flags": [
@@ -17010,10 +17010,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 95,
-        "swingDamage": 47,
+        "thrustSpeed": 96,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 73
+        "swingSpeed": 74
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -5797,9 +5797,9 @@
     "name": "Bec De Corbin",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 17671,
+    "price": 15896,
     "weight": 1.91,
-    "tier": 10.5012026,
+    "tier": 9.904106,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5821,7 +5821,7 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
         "swingDamage": 30,
@@ -5879,9 +5879,9 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 15998,
-    "weight": 1.91,
-    "tier": 9.939254,
+    "price": 15012,
+    "weight": 1.95,
+    "tier": 9.594488,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5892,8 +5892,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 141,
-        "balance": 0.42,
-        "handling": 69,
+        "balance": 0.39,
+        "handling": 68,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5905,9 +5905,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 93,
-        "swingDamage": 45,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 81
       }
     ]
   },
@@ -7120,9 +7120,9 @@
     "name": "Burgundian Glaive",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 13917,
+    "price": 15192,
     "weight": 1.78,
-    "tier": 9.197954,
+    "tier": 9.658267,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -7144,10 +7144,10 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
-        "swingDamage": 44,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }
@@ -7158,9 +7158,9 @@
     "name": "Burgundian Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12513,
-    "weight": 2.27,
-    "tier": 8.666276,
+    "price": 16174,
+    "weight": 2.33,
+    "tier": 9.999937,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -7173,21 +7173,22 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.41,
-        "handling": 72,
+        "balance": 0.37,
+        "handling": 71,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
+          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 91,
-        "swingDamage": 42,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 81
       }
     ]
   },
@@ -9343,9 +9344,9 @@
     "name": "Polesword",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 5728,
+    "price": 6545,
     "weight": 1.75,
-    "tier": 5.526349,
+    "tier": 5.97756147,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -9368,7 +9369,7 @@
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
-        "swingDamage": 47,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
         "swingSpeed": 65
       }
@@ -11297,9 +11298,9 @@
     "name": "Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 13906,
+    "price": 14950,
     "weight": 1.84,
-    "tier": 9.193977,
+    "tier": 9.572582,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -11319,7 +11320,7 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
         "swingDamage": 41,
@@ -12213,9 +12214,9 @@
     "name": "French Voulge",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 15489,
-    "weight": 1.99,
-    "tier": 9.762769,
+    "price": 15527,
+    "weight": 2.15,
+    "tier": 9.775999,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -12228,8 +12229,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 133,
-        "balance": 0.61,
-        "handling": 75,
+        "balance": 0.48,
+        "handling": 72,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -12237,12 +12238,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 37,
+        "thrustSpeed": 92,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 84
       }
     ]
   },
@@ -16949,9 +16950,9 @@
     "name": "Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 14751,
-    "weight": 1.68,
-    "tier": 9.501213,
+    "price": 16190,
+    "weight": 1.71,
+    "tier": 10.0052967,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16962,8 +16963,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 147,
-        "balance": 0.44,
-        "handling": 71,
+        "balance": 0.41,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16971,12 +16972,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 24,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 41,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 82
       }
     ]
   },
@@ -18464,9 +18465,9 @@
     "name": "Long Bardiche",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 13995,
-    "weight": 1.7,
-    "tier": 9.226804,
+    "price": 15580,
+    "weight": 1.73,
+    "tier": 9.794569,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18478,8 +18479,8 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 158,
-        "balance": 0.17,
+        "length": 161,
+        "balance": 0.13,
         "handling": 65,
         "bodyArmor": 0,
         "flags": [
@@ -18489,12 +18490,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 26,
         "thrustDamageType": "Cut",
         "thrustSpeed": 94,
-        "swingDamage": 48,
+        "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 74
       }
     ]
   },
@@ -18624,9 +18625,9 @@
     "name": "Long Hafted Spiked Mace",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 17575,
-    "weight": 1.87,
-    "tier": 10.4698267,
+    "price": 13711,
+    "weight": 1.91,
+    "tier": 9.121935,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18639,8 +18640,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 155,
-        "balance": 0.17,
-        "handling": 67,
+        "balance": 0.14,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -18651,10 +18652,10 @@
         ],
         "thrustDamage": 17,
         "thrustDamageType": "Blunt",
-        "thrustSpeed": 93,
+        "thrustSpeed": 92,
         "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 75
+        "swingSpeed": 74
       }
     ]
   },
@@ -23455,9 +23456,9 @@
     "name": "Broad Leaf Shaped Spear",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 3827,
+    "price": 12389,
     "weight": 1.5,
-    "tier": 4.334009,
+    "tier": 8.617993,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23478,7 +23479,7 @@
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 21,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
         "swingSpeed": 42
       },
@@ -23501,7 +23502,7 @@
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 95,
-        "swingDamage": 21,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       },
@@ -23524,7 +23525,7 @@
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 95,
-        "swingDamage": 21,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
         "swingSpeed": 82
       }
@@ -24966,9 +24967,9 @@
     "name": "Scythe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12385,
-    "weight": 2.25,
-    "tier": 8.616375,
+    "price": 8430,
+    "weight": 2.34,
+    "tier": 6.92394543,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -24981,8 +24982,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.58,
-        "handling": 72,
+        "balance": 0.52,
+        "handling": 71,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24996,7 +24997,7 @@
         "thrustSpeed": 91,
         "swingDamage": 30,
         "swingDamageType": "Pierce",
-        "swingSpeed": 87
+        "swingSpeed": 85
       }
     ]
   },
@@ -27717,9 +27718,9 @@
     "name": "Simple Poleaxe",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 10749,
+    "price": 13353,
     "weight": 2.2,
-    "tier": 7.9545083,
+    "tier": 8.987777,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -27739,12 +27740,13 @@
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
+          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 91,
-        "swingDamage": 44,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
         "swingSpeed": 78
       }
@@ -28842,9 +28844,9 @@
     "name": "Spiked Polehammer",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 15290,
+    "price": 16012,
     "weight": 2.0,
-    "tier": 9.693021,
+    "tier": 9.944254,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -28866,7 +28868,7 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
         "swingDamage": 30,
@@ -34028,9 +34030,9 @@
     "name": "Voulge",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 17802,
-    "weight": 1.47,
-    "tier": 10.5442076,
+    "price": 15815,
+    "weight": 1.5,
+    "tier": 9.876115,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -34043,8 +34045,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.38,
-        "handling": 66,
+        "balance": 0.36,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -34053,12 +34055,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
+        "thrustSpeed": 95,
         "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 80
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -410,7 +410,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_long_bardiche" name="{=}Long Bardiche" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_long_bardiche_head" Type="Blade" scale_factor="87" />
+      <Piece id="crpg_long_bardiche_head" Type="Blade" scale_factor="99" />
       <Piece id="crpg_long_bardiche_handle" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>


### PR DESCRIPTION
Follow with the newest thrust patch fix
Bec De Corbin
Thrust damage 25–>23

Billhook
Weight 1.91–>1.95
Handling 69–>68
Swing damage 45–>46
Swing speed 82–>81

Burgundian Glaive
Thrust damage 22–>21
Swing damage 44–>45

Burgundian Poleaxe
Weight 2.27–>2.33
Handling 72–>71
Swing damage 42–>43
Swing speed 82–>81
BvS flag added

Polesword
Swing damage 47–>48

Menavlion
Thrust damage 22–>23

French Voulge
Weight 1.99–>2.15
Handling 75–>72
Thrust damage 23–>24
Thrust speed 93–>92
Swing damage 37–>41
Swing speed 88–>84

Glaive
Weight 1.68–>1.71
Handling 71–>70
Thrust damage 25–>24
Swing damage 41–>43
Swing speed 83–>82

Long Bardiche
Weight 1.7–>1.73
Length 158–>161
Thrust damage 24–>26
Swing damage 48–>49
Swing speed 75–>74

Long Hafted Spiked Mace
Weight 1.87–>1.91
Handling 67–>66
Thrust speed 93–>92
Swing speed 75–>74

Broad Leaf Shaped Spear
Swing damage 21–>40

Scythe
Weight 2.25–>2.34
Handling 72–>71
Swing speed 87–>85

Simple Poleaxe
Thrust damage 24–>25
Swing damage 44–>43
BvS flag added

Spiked Polehammer
Thrust damage 21–>22

Voulge
Weight 1.47–>1.5
Handling 66–>65
Thrust damage 22–>24
Thrust speed 96–>95
Swing speed 81–>80
