### PR TITLE
Throwingmaul tweaks

### DIFF
--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -1486,6 +1486,8 @@
     <WeaponDescriptions>
       <WeaponDescription id="crpg_ThrowingAxe" />
       <WeaponDescription id="crpg_OneHandedAxe" />
+      <WeaponDescription id="crpg_ThrowingHammer" />
+      <WeaponDescription id="crpg_OneHandedMace" />
     </WeaponDescriptions>
     <StatsData weapon_description="crpg_ThrowingAxe">
       <StatData stat_type="Weight" max_value="7.0" />

--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -1487,7 +1487,7 @@
       <WeaponDescription id="crpg_ThrowingAxe" />
       <WeaponDescription id="crpg_OneHandedAxe" />
       <WeaponDescription id="crpg_ThrowingHammer" />
-      <WeaponDescription id="crpg_OneHandedMace" />
+      <WeaponDescription id="crpg_Mace" />
     </WeaponDescriptions>
     <StatsData weapon_description="crpg_ThrowingAxe">
       <StatData stat_type="Weight" max_value="7.0" />

--- a/items.json
+++ b/items.json
@@ -31908,6 +31908,26 @@
         "swingDamage": 0,
         "swingDamageType": "Blunt",
         "swingSpeed": 104
+      },
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 41,
+        "balance": 1.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 94,
+        "swingDamage": 10,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 104
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2075,7 +2075,7 @@
       <Piece id="crpg_highland_throwing_axe_1_t2_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_throwing_maul" name="{=GrfnpDxu}Throwing Hammers" crafting_template="crpg_ThrowingHammer" culture="Culture.battania">
+  <CraftedItem id="crpg_throwing_maul" name="{=GrfnpDxu}Throwing Hammers" crafting_template="crpg_ThrowingAxe" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_throwing_maul_blade" Type="Blade" scale_factor="75" />
       <Piece id="crpg_throwing_maul_handle" Type="Handle" scale_factor="50" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2075,7 +2075,7 @@
       <Piece id="crpg_highland_throwing_axe_1_t2_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_throwing_maul" name="{=GrfnpDxu}Throwing Hammers" crafting_template="crpg_ThrowingAxe" culture="Culture.battania">
+  <CraftedItem id="crpg_throwing_maul" name="{=GrfnpDxu}Throwing Hammers" crafting_template="crpg_ThrowingHammer" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_throwing_maul_blade" Type="Blade" scale_factor="75" />
       <Piece id="crpg_throwing_maul_handle" Type="Handle" scale_factor="50" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -1841,8 +1841,6 @@
       <WeaponFlag value="UnloadWhenSheathed" />
     </WeaponFlags>
     <AvailablePieces>
-      <AvailablePiece id="crpg_throwing_maul_handle" />
-      <AvailablePiece id="crpg_throwing_maul_blade" />
       <AvailablePiece id="crpg_southern_throwing_axe_1_t4_handle" />
       <AvailablePiece id="crpg_highland_throwing_axe_1_t2_handle" />
       <AvailablePiece id="crpg_western_throwing_axe_1_t1_handle" />
@@ -1851,6 +1849,19 @@
       <AvailablePiece id="crpg_western_throwing_axe_1_t1_blade" />
       <AvailablePiece id="crpg_southern_throwing_axe_1_t4_blade" />
       <AvailablePiece id="crpg_highland_throwing_axe_1_t2_blade" />
+    </AvailablePieces>
+  </WeaponDescription>
+  <WeaponDescription id="crpg_ThrowingHammer" weapon_class="ThrowingAxe" item_usage_features="throwing:axe">
+    <WeaponFlags>
+      <WeaponFlag value="RangedWeapon" />
+      <WeaponFlag value="Consumable" />
+      <WeaponFlag value="UseHandAsThrowBase" />
+      <WeaponFlag value="AutoReload" />
+      <WeaponFlag value="UnloadWhenSheathed" />
+    </WeaponFlags>
+    <AvailablePieces>
+      <AvailablePiece id="crpg_throwing_maul_handle" />
+      <AvailablePiece id="crpg_throwing_maul_blade" />
     </AvailablePieces>
   </WeaponDescription>
   <WeaponDescription id="crpg_OneHandedPolearm" weapon_class="OneHandedPolearm" item_usage_features="onehanded_polearm:block:long:rshield:thrust">
@@ -3085,6 +3096,8 @@
       <WeaponFlag value="MeleeWeapon" />
     </WeaponFlags>
     <AvailablePieces>
+      <AvailablePiece id="crpg_throwing_maul_handle" />
+      <AvailablePiece id="crpg_throwing_maul_blade" />
       <AvailablePiece id="crpg_blacksmith_war_hammer_mace_t3_handle" />
       <AvailablePiece id="crpg_blacksmith_war_hammer_1_t1_blade" />
       <AvailablePiece id="crpg_medium_goedendag_head"/>


### PR DESCRIPTION
Added a weapon_description crpg_ThrowingHammer that sets the throwing weapons in it to not get stuck in the target.
Also included crpg_Mace and crpg_ThrowingHammer in the crpg_ThrowingAxe crafting_template.
This way throwing blunt weapons and pieces can be put into the crpg_ThrowingAxe crafting_template and then into the crpg_Mace and crpg_ThrowingHammer weapon_description to get the correct flags.
This was already done for the Throwing Maul.