### PR TITLE
1H Swords - AngryMob

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2893,7 +2893,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_pommel" name="{=Oz6xANFb}Highland Ornamental Pommel" tier="4" piece_type="Pommel" mesh="battania_noble_pommel_1" culture="Culture.battania" length="4.1" weight="0.45">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_pommel" name="{=Oz6xANFb}Highland Ornamental Pommel" tier="4" piece_type="Pommel" mesh="battania_noble_pommel_1" culture="Culture.battania" length="4.1" weight="0.49">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -2941,13 +2941,13 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_pommel" name="{=zoQhOBku}Round Spiked Pommel" tier="4" piece_type="Pommel" mesh="khuzait_noble_pommel_3" culture="Culture.khuzait" length="5.6" weight="0.27">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_pommel" name="{=zoQhOBku}Round Spiked Pommel" tier="4" piece_type="Pommel" mesh="khuzait_noble_pommel_3" culture="Culture.khuzait" length="5.6" weight="0.05">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.49">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_pommel" name="{=BQ3hMy9D}Horsehead Pommel" tier="5" piece_type="Pommel" mesh="khuzait_pommel_5" culture="Culture.khuzait" length="7.268" weight="0.7">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -2957,7 +2957,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.31">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_pommel" name="{=faZasq1G}Eastern Ring Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_1" culture="Culture.khuzait" length="6.588" weight="0.55">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -2967,12 +2967,12 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.6">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.58">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_pommel" name="{=HmsEarnz}Teardrop Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_9" culture="Culture.sturgia" length="4.744" weight="0.01">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_pommel" name="{=HmsEarnz}Teardrop Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_9" culture="Culture.sturgia" length="4.744" weight="0.7">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3019,7 +3019,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_pommel" name="{=OW7w3Mth}Fian's Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_5" culture="Culture.battania" length="10" weight="0.25">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_pommel" name="{=OW7w3Mth}Fian's Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_5" culture="Culture.battania" length="10" weight="0.31">
     <BuildData next_piece_offset="0.2" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3030,12 +3030,12 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.70">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_pommel" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.85">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_pommel" name="{=26KZ6S7F}Eastern Decorated Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_2" culture="Culture.khuzait" length="4.3" weight="0.42">
+  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_pommel" name="{=26KZ6S7F}Eastern Decorated Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_2" culture="Culture.khuzait" length="4.3" weight="0.35">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3047,7 +3047,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_pommel" name="{=W5tvNbjY}Eastern Ornamented Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_1" culture="Culture.khuzait" length="3.6" weight="0.18">
+  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_pommel" name="{=W5tvNbjY}Eastern Ornamented Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_1" culture="Culture.khuzait" length="3.6" weight="0.03">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3090,7 +3090,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_pommel" name="{=gTMThdRJ}Lordly Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_4" culture="Culture.vlandia" length="6" weight="0.59">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_pommel" name="{=gTMThdRJ}Lordly Pommel" tier="5" piece_type="Pommel" mesh="vlandian_noble_pommel_4" culture="Culture.vlandia" length="6" weight="0.55">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3111,7 +3111,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.09">
+  <CraftingPiece id="crpg_cleaver_sword_t3_pommel" name="{=aGtEhibt}Northern Round Pommel" tier="3" piece_type="Pommel" mesh="sturgian_pommel_1" culture="Culture.sturgia" length="3.539" weight="0.84">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3182,7 +3182,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_cleaver_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.55">
+  <CraftingPiece id="crpg_military_cleaver_t2_pommel" name="{=5NeanDJM}Ring Pommel" tier="1" piece_type="Pommel" mesh="vlandian_pommel_10" culture="Culture.vlandia" length="5.5" weight="0.82">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3216,12 +3216,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.18">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.46">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.36">
+  <CraftingPiece id="crpg_battania_sword_5_t5_pommel" name="{=BKHKQ15N}Turqouise Pommel" tier="5" piece_type="Pommel" mesh="battania_pommel_8" culture="Culture.battania" length="2.5" weight="0.42">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -3241,7 +3241,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.66">
+  <CraftingPiece id="crpg_battania_sword_2_t3_pommel" name="{=dTkiV4i6}Fishing Boat Pommel" tier="3" piece_type="Pommel" mesh="battania_pommel_3" culture="Culture.battania" length="3.1" weight="0.8">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3251,12 +3251,12 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.4">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_pommel" name="{=fHKHwvsW}Bronze Banded Pommel" tier="5" piece_type="Pommel" mesh="sturgian_pommel_12" culture="Culture.sturgia" length="5.1" weight="0.28">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.48">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_pommel" name="{=1ajbJdao}Bar Pommel" tier="4" piece_type="Pommel" mesh="sturgian_pommel_8" culture="Culture.sturgia" length="1.864" weight="0.47">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3271,7 +3271,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.6">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_pommel" name="{=9qaanOpL}Simple Northern Pommel" tier="1" piece_type="Pommel" mesh="sturgian_pommel_3" culture="Culture.sturgia" length="3.587" weight="0.75">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3293,17 +3293,17 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_5_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.29">
+  <CraftingPiece id="crpg_khuzait_sword_5_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.34">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_4_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.28">
+  <CraftingPiece id="crpg_khuzait_sword_4_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.31">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_pommel" name="{=1pvLe1Mh}Simple Ild Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_3" culture="Culture.khuzait" length="1.741" weight="0.1">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_pommel" name="{=1pvLe1Mh}Simple Ild Pommel" tier="1" piece_type="Pommel" mesh="khuzait_pommel_3" culture="Culture.khuzait" length="1.741" weight="0.03">
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
@@ -3457,12 +3457,12 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.1">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.03">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.11">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_pommel" name="{=ugQrq53t}Fan Pommel" tier="5" piece_type="Pommel" mesh="vlandian_pommel_9" culture="Culture.vlandia" length="5.275" weight="0.75">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -3485,7 +3485,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.09">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_pommel" name="{=wvLoXrFV}Western Great Pommel" tier="4" piece_type="Pommel" mesh="vlandian_pommel_7" culture="Culture.vlandia" length="5.231" weight="0.03">
     <BuildData next_piece_offset="-0.2" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -3570,7 +3570,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.5">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_handle" name="{=g60SQjOR}Leather Wrapped Horn Longsword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_24" culture="Culture.vlandia" length="17.1" weight="0.6">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3588,13 +3588,13 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_handle" name="{=Ft5A2Eb4}Eastern Leather Covered Reinforced Two Handed Grip" tier="4" piece_type="Handle" mesh="khuzait_noble_grip_1" culture="Culture.khuzait" length="25.2" weight="0.35">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_handle" name="{=Ft5A2Eb4}Eastern Leather Covered Reinforced Two Handed Grip" tier="4" piece_type="Handle" mesh="khuzait_noble_grip_1" culture="Culture.khuzait" length="25.2" weight="0.20">
     <BuildData piece_offset="0" previous_piece_offset="0.35" next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.3">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_handle" name="{=Aw7Veoaa}Iron Bound Rough Leater Angular Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_6" culture="Culture.khuzait" length="19.4" weight="0.2">
     <BuildData piece_offset="-1.98" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3739,7 +3739,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_handle" name="{=bPUXlfs8}Decorated Eastern Ild Grip" tier="5" piece_type="Handle" mesh="khuzait_noble_grip_2" culture="Culture.khuzait" length="15" weight="0.46">
+  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_handle" name="{=bPUXlfs8}Decorated Eastern Ild Grip" tier="5" piece_type="Handle" mesh="khuzait_noble_grip_2" culture="Culture.khuzait" length="15" weight="0.45">
     <BuildData piece_offset="0" previous_piece_offset="0.35" next_piece_offset="0.5" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3775,7 +3775,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.15">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_handle" name="{=TKQl9boE}Golden Decorated Fine Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_4" culture="Culture.vlandia" length="15" weight="0.05">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3787,7 +3787,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_handle" name="{=3VoW9qZs}Gold Bound Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_3" culture="Culture.vlandia" length="17.5" weight="0.25">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_handle" name="{=3VoW9qZs}Gold Bound Arming Sword Grip" tier="5" piece_type="Handle" mesh="vlandian_noble_grip_3" culture="Culture.vlandia" length="17.5" weight="0.15">
     <BuildData piece_offset="0" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3817,7 +3817,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.45">
+  <CraftingPiece id="crpg_cleaver_sword_t3_handle" name="{=lYEaqL9y}Bound Fur One Handed Grip" tier="1" piece_type="Handle" mesh="sturgian_grip_14" culture="Culture.sturgia" length="15.3" weight="0.25">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3835,7 +3835,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.15">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_handle" name="{=nVrg9Uda}Leather Wrapped Horn Arming Sword Grip" tier="3" piece_type="Handle" mesh="vlandian_grip_23" culture="Culture.vlandia" length="15.9" weight="0.05">
     <BuildData piece_offset="-1" previous_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3859,7 +3859,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.8">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_handle" name="{=Ldq6AOrb}Iron Ring Bound Rough Leather Two Handed Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_14" culture="Culture.khuzait" length="25" weight="0.3">
     <BuildData piece_offset="-0.09" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3889,7 +3889,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_cleaver_t2_handle" name="{=BL96pnde}Rough Leather One Handed Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_5" culture="Culture.aserai" length="15.857" weight="0.70">
+  <CraftingPiece id="crpg_military_cleaver_t2_handle" name="{=BL96pnde}Rough Leather One Handed Cleaver Grip" tier="2" piece_type="Handle" mesh="cleaver_grip_5" culture="Culture.aserai" length="15.857" weight="0.6">
     <BuildData piece_offset="-0.39" previous_piece_offset="0" next_piece_offset="-0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -3926,7 +3926,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.4" item_holster_pos_shift="0,0,-0.03">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_handle" name="{=eBxzZ1SW}Jewelled Reinforced One Handed Grip" tier="5" piece_type="Handle" mesh="battania_grip_4" culture="Culture.battania" length="19.17" weight="0.5" item_holster_pos_shift="0,0,-0.03">
     <BuildData piece_offset="-1.88" previous_piece_offset="0.1" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -3938,7 +3938,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.4">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_handle" name="{=SqR5K74b}Fine Highland Grip" tier="4" piece_type="Handle" mesh="battania_grip_1" culture="Culture.battania" length="15.5" weight="0.2">
     <BuildData piece_offset="-0.22" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron4" count="2" />
@@ -3956,7 +3956,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_handle" name="{=62biJ5O5}Highland Fine Leather One Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_3" culture="Culture.battania" length="15" weight="0.62">
+  <CraftingPiece id="crpg_battania_sword_2_t3_handle" name="{=62biJ5O5}Highland Fine Leather One Handed Grip" tier="3" piece_type="Handle" mesh="battania_grip_3" culture="Culture.battania" length="15" weight="0.35">
     <BuildData piece_offset="0" previous_piece_offset="0.3" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -3980,7 +3980,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_handle" name="{=8olqutaL}Northern Split Two Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_grip_25" culture="Culture.sturgia" length="25" weight="0.25">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_handle" name="{=8olqutaL}Northern Split Two Handed Grip" tier="3" piece_type="Handle" mesh="sturgian_grip_25" culture="Culture.sturgia" length="25" weight="0.2">
     <BuildData piece_offset="-7.04" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -4040,7 +4040,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_handle" name="{=OlUuoUBe}Eastern Iron Bound Fine Leather Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_2" culture="Culture.khuzait" length="15.1" weight="0.58">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_handle" name="{=OlUuoUBe}Eastern Iron Bound Fine Leather Grip" tier="3" piece_type="Handle" mesh="khuzait_grip_2" culture="Culture.khuzait" length="15.1" weight="0.5">
     <BuildData piece_offset="-0.04" previous_piece_offset="0.2" next_piece_offset="0.1" />
     <Materials>
       <Material id="Iron3" count="2" />
@@ -4148,19 +4148,19 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_handle" name="{=tq5XGebt}Bronze Bound Fine Leather Covered Two Handed Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_20" culture="Culture.vlandia" length="19.8" weight="0.25">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_handle" name="{=tq5XGebt}Bronze Bound Fine Leather Covered Two Handed Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_20" culture="Culture.vlandia" length="19.8" weight="0.2">
     <BuildData piece_offset="-4.5" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_handle" name="{=2MNfdGZQ}Fine Leather Covered Reinforced Horn Longsword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_10" culture="Culture.vlandia" length="25.2" weight="0.12" item_holster_pos_shift="0,0,-0.02">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_handle" name="{=2MNfdGZQ}Fine Leather Covered Reinforced Horn Longsword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_10" culture="Culture.vlandia" length="25.2" weight="0.05" item_holster_pos_shift="0,0,-0.02">
     <BuildData piece_offset="-4.59" previous_piece_offset="0.358" />
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_handle" name="{=3wXjMEwI}Segmented Leather Covered Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_4" culture="Culture.vlandia" length="15.2" weight="0.18">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_handle" name="{=3wXjMEwI}Segmented Leather Covered Arming Sword Grip" tier="4" piece_type="Handle" mesh="vlandian_grip_4" culture="Culture.vlandia" length="15.2" weight="0.1">
     <BuildData piece_offset="-0.09" previous_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -4220,7 +4220,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_guard" name="{=wXUjru6o}Knobbed Wide Saber Guard" tier="5" piece_type="Guard" mesh="khuzait_noble_guard_3" culture="Culture.khuzait" length="2.9" weight="0.27">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_guard" name="{=wXUjru6o}Knobbed Wide Saber Guard" tier="5" piece_type="Guard" mesh="khuzait_noble_guard_3" culture="Culture.khuzait" length="2.9" weight="0.3">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4276,14 +4276,14 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.6">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_guard" name="{=PsKP5j6A}Knobbed Guard" tier="3" piece_type="Guard" mesh="vlandian_guard_1" culture="Culture.vlandia" length="3.5" weight="0.25">
     <BuildData next_piece_offset="1.9" previous_piece_offset="-0.4" />
     <StatContributions armor_bonus="4" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.3">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_guard" name="{=DLvSnz8U}Etched Highland Guard" tier="5" piece_type="Guard" mesh="battania_guard_5" culture="Culture.battania" length="5.7" weight="0.1">
     <BuildData next_piece_offset="1.8" previous_piece_offset="-0.3" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4297,7 +4297,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.27">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_guard" name="{=OlnvawN6}Bronze Great Sword Guard" tier="5" piece_type="Guard" mesh="battania_noble_guard_1" culture="Culture.battania" length="7.1" weight="0.3">
     <BuildData next_piece_offset="0.6" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4325,7 +4325,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_guard" name="{=azjW7lAg}Engraved Ild Guard" tier="5" piece_type="Guard" mesh="khuzait_noble_guard_1" culture="Culture.khuzait" length="1.8" weight="0.34">
+  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_guard" name="{=azjW7lAg}Engraved Ild Guard" tier="5" piece_type="Guard" mesh="khuzait_noble_guard_1" culture="Culture.khuzait" length="1.8" weight="0.3">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4381,14 +4381,14 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.1">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.05">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.12">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.1">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4416,7 +4416,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.32">
+  <CraftingPiece id="crpg_cleaver_sword_t3_guard" name="{=Hj151a5b}Tapered Crescent Guard" tier="1" piece_type="Guard" mesh="cleaver_guard_1" length="0.523" weight="0.15">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4479,7 +4479,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_cleaver_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.33">
+  <CraftingPiece id="crpg_military_cleaver_t2_guard" name="{=aFxc3ZVL}Concave Disc Guard" tier="2" piece_type="Guard" mesh="khuzait_guard_2" culture="Culture.khuzait" length="1.663" weight="0.2">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4535,7 +4535,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_guard" name="{=AkfEFzkk}Bowl Guard" tier="2" piece_type="Guard" mesh="battania_guard_6" culture="Culture.battania" length="5.7" weight="0.3">
+  <CraftingPiece id="crpg_battania_sword_2_t3_guard" name="{=AkfEFzkk}Bowl Guard" tier="2" piece_type="Guard" mesh="battania_guard_6" culture="Culture.battania" length="5.7" weight="0.2">
     <BuildData next_piece_offset="1.8" />
     <StatContributions armor_bonus="2" />
     <Materials>
@@ -4598,7 +4598,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.2">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_guard" name="{=b1KGhVwD}Concave Northern Guard" tier="4" piece_type="Guard" mesh="sturgian_guard_2" culture="Culture.sturgia" length="2.4" weight="0.05">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4647,7 +4647,7 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_guard" name="{=nKb9goqQ}Thin Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_5" length="1.846" weight="0.2">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_guard" name="{=nKb9goqQ}Thin Guard" tier="1" piece_type="Guard" mesh="khuzait_guard_5" length="1.846" weight="0.35">
     <BuildData next_piece_offset="0.3" />
     <StatContributions armor_bonus="3" />
     <Materials>
@@ -4696,7 +4696,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.65">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_guard" name="{=ittUjlRb}Diamond Guard" tier="3" piece_type="Guard" mesh="aserai_guard_7" culture="Culture.aserai" length="2.865" weight="0.15">
     <BuildData next_piece_offset="0.4" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4773,7 +4773,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_5_t5_guard" name="{=az6t2tOm}Ridged Western Guard" tier="5" piece_type="Guard" mesh="vlandian_guard_8" culture="Culture.vlandia" length="1.42" weight="0.11">
+  <CraftingPiece id="crpg_vlandia_sword_5_t5_guard" name="{=az6t2tOm}Ridged Western Guard" tier="5" piece_type="Guard" mesh="vlandian_guard_8" culture="Culture.vlandia" length="1.42" weight="0.3">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4815,7 +4815,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_guard" name="{=xoSaQWhX}Western Crescent Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_5" culture="Culture.vlandia" length="0.9" weight="0.11">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_guard" name="{=xoSaQWhX}Western Crescent Guard" tier="4" piece_type="Guard" mesh="vlandian_guard_5" culture="Culture.vlandia" length="0.9" weight="0.05">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -4878,9 +4878,9 @@
       <Material id="Iron1" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_3_t5_blade" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.27">
+  <CraftingPiece id="crpg_battania_noble_sword_3_t5_blade" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.28">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
@@ -4916,8 +4916,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_vlandia_noble_sword_4_t5_blade" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.82">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4926,9 +4926,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.23">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
@@ -4940,7 +4940,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.26">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -4952,8 +4952,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_noble_sword_3_t5_blade" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.81">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -4991,7 +4991,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_broad_falchion_sword_t3_blade" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.01">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
@@ -5058,10 +5058,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="1.06">
+  <CraftingPiece id="crpg_battania_noble_sword_2_t5_blade" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.99">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5070,9 +5070,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_noble_sword_1_t5_blade" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="1.06">
+  <CraftingPiece id="crpg_battania_noble_sword_1_t5_blade" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -5084,7 +5084,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_noble_sword_2_t5_blade" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -5094,9 +5094,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.02">
+  <CraftingPiece id="crpg_sturgia_noble_sword_1_t5_blade" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.93">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -5106,31 +5106,31 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_blade" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.90">
+  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_blade" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.91">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.99">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.15">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.85">
+  <CraftingPiece id="crpg_khuzait_noble_sword_1_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.96">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
@@ -5180,8 +5180,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_vlandia_noble_sword_2_t5_blade" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.74">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5190,10 +5190,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_blade" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.89">
+  <CraftingPiece id="crpg_vlandia_noble_sword_1_t5_blade" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5222,8 +5222,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_broad_arming_sword_t4_blade" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.69">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -5249,10 +5249,10 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.98">
+  <CraftingPiece id="crpg_winds_fury_sword_t3_blade" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.66">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
@@ -5261,16 +5261,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_pointed_falchion_sword_t4_blade" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.08" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cleaver_sword_t3_blade" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="1.6">
+  <CraftingPiece id="crpg_cleaver_sword_t3_blade" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.97" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -5278,8 +5277,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_short_sword_t3_blade" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.83">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_9_scabbard_9">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5307,9 +5306,9 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_cleaver_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.91" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_military_cleaver_t3_blade" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.7" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
@@ -5328,7 +5327,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.84">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.88">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="1.7" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -5340,10 +5339,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.70">
+  <CraftingPiece id="crpg_falchion_sword_t2_blade" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5383,10 +5382,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.99">
+  <CraftingPiece id="crpg_dawnbreaker_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.75">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5395,10 +5394,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="1.12">
+  <CraftingPiece id="crpg_tyrhung_sword_t3_blade" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.74">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5455,9 +5454,9 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_5_t5_blade" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.98">
+  <CraftingPiece id="crpg_battania_sword_5_t5_blade" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.93">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -5467,10 +5466,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_sword_2_t3_blade" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.75">
+  <CraftingPiece id="crpg_battania_sword_2_t3_blade" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.79">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5505,7 +5504,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_battania_sword_4_t4_blade" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.19">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
@@ -5521,10 +5520,10 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t5_blade" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.0">
+  <CraftingPiece id="crpg_sturgia_sword_5_t5_blade" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.12">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5535,7 +5534,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_3_t3_blade" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -5545,10 +5544,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.9">
+  <CraftingPiece id="crpg_sturgia_sword_5_t4_blade" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5557,10 +5556,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.85">
+  <CraftingPiece id="crpg_sturgia_sword_2_t3_blade" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.69">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5571,8 +5570,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_sturgia_sword_4_t4_blade" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="1.07">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5584,6 +5583,18 @@
   <CraftingPiece id="crpg_sturgia_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -5593,22 +5604,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.03">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_simple_back_sword_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.66" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_simple_back_sword_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.73" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5632,7 +5631,7 @@
   <CraftingPiece id="crpg_broad_ild_sword_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.77">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5641,9 +5640,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_3_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.3">
+  <CraftingPiece id="crpg_khuzait_sword_3_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -5655,7 +5654,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_2_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.45">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -5665,9 +5664,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_5_t4_blade" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.92">
+  <CraftingPiece id="crpg_khuzait_sword_5_t4_blade" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.93">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -5677,7 +5676,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_4_t4_blade" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.91">
+  <CraftingPiece id="crpg_khuzait_sword_4_t4_blade" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.94">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -5747,9 +5746,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.80">
+  <CraftingPiece id="crpg_the_scalpel_sword_t3_blade" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.88">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
@@ -5825,11 +5824,11 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bastard_sword_t2_blade" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.0">
+  <CraftingPiece id="crpg_bastard_sword_t2_blade" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.09">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5874,10 +5873,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_3_t4_blade" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.29">
+  <CraftingPiece id="crpg_vlandia_sword_3_t4_blade" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5898,9 +5897,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_sword_4_t4_blade" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.40">
+  <CraftingPiece id="crpg_vlandia_sword_4_t4_blade" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.46">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
@@ -5909,8 +5908,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_vlandia_sword_2_t3_blade" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5939,8 +5938,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_vlandia_sword_5_t5_blade" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.35">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
@@ -5949,7 +5948,7 @@
   <CraftingPiece id="crpg_vlandia_sword_1_t2_blade" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2919,7 +2919,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_pommel" name="{=Udo97SZC}Western Decorated Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_3" culture="Culture.vlandia" length="5" weight="0.05">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_pommel" name="{=Udo97SZC}Western Decorated Pommel" tier="4" piece_type="Pommel" mesh="vlandian_noble_pommel_3" culture="Culture.vlandia" length="5" weight="0.26">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -2941,7 +2941,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_pommel" name="{=zoQhOBku}Round Spiked Pommel" tier="4" piece_type="Pommel" mesh="khuzait_noble_pommel_3" culture="Culture.khuzait" length="5.6" weight="0.05">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_pommel" name="{=zoQhOBku}Round Spiked Pommel" tier="4" piece_type="Pommel" mesh="khuzait_noble_pommel_3" culture="Culture.khuzait" length="5.6" weight="0.09">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron4" count="1" />
@@ -2967,7 +2967,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.58">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_pommel" name="{=Ao7c1VrC}Northern Triangular Pommel" tier="3" piece_type="Pommel" mesh="sturgian_noble_pommel_1" culture="Culture.sturgia" length="4.3" weight="0.65">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -3035,7 +3035,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_pommel" name="{=26KZ6S7F}Eastern Decorated Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_2" culture="Culture.khuzait" length="4.3" weight="0.35">
+  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_pommel" name="{=26KZ6S7F}Eastern Decorated Pommel" tier="5" piece_type="Pommel" mesh="khuzait_noble_pommel_2" culture="Culture.khuzait" length="4.3" weight="0.38">
     <BuildData next_piece_offset="0" />
     <Materials>
       <Material id="Iron5" count="1" />
@@ -3298,7 +3298,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_4_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.31">
+  <CraftingPiece id="crpg_khuzait_sword_4_t4_pommel" name="{=lv9oJyKJ}Eastern Flat Pommel" tier="3" piece_type="Pommel" mesh="khuzait_pommel_4" culture="Culture.khuzait" length="1.508" weight="0.22">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -4381,7 +4381,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.05">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_guard" name="{=OPfm5y7W}Golden Knightly Lionheads Guard" tier="5" piece_type="Guard" mesh="vlandian_noble_guard_3" culture="Culture.vlandia" length="2.4" weight="0.09">
     <BuildData next_piece_offset="0.2" />
     <StatContributions armor_bonus="4" />
     <Materials>
@@ -4926,7 +4926,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.25">
+  <CraftingPiece id="crpg_vlandia_noble_sword_3_t5_blade" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.16">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -4938,7 +4938,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.26">
+  <CraftingPiece id="crpg_sturgia_noble_sword_4_t5_blade" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.23">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -5106,7 +5106,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_blade" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.91">
+  <CraftingPiece id="crpg_khuzait_noble_sword_2_t5_blade" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.9">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
@@ -5116,7 +5116,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.15">
+  <CraftingPiece id="crpg_khuzait_noble_sword_3_t5_blade" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.14">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
@@ -5327,9 +5327,9 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.88">
+  <CraftingPiece id="crpg_simple_sabre_sword_t2_blade" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -5592,7 +5592,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_thegn_sword_1_t2_blade" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.03">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -5618,8 +5618,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_1_t2_blade" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.82">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5642,7 +5642,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_khuzait_sword_3_t3_blade" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -5676,10 +5676,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_khuzait_sword_4_t4_blade" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.94">
+  <CraftingPiece id="crpg_khuzait_sword_4_t4_blade" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="1.03">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -5828,7 +5828,7 @@
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -3166,7 +3166,7 @@
     "weapons": []
   },
   {
-    "id": "crpg_bastard_sword_t2_v2",
+    "id": "crpg_bastard_sword_t2",
     "name": "Simple Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
@@ -3185,18 +3185,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.63,
+        "balance": 0.6,
         "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 35,
+        "thrustSpeed": 88,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -4740,15 +4740,15 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.44,
-        "handling": 83,
+        "balance": 0.46,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 86,
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 83
@@ -4776,15 +4776,15 @@
         "stackAmount": 0,
         "length": 103,
         "balance": 0.48,
-        "handling": 89,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 30,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -4810,13 +4810,13 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.32,
-        "handling": 82,
+        "balance": 0.3,
+        "handling": 81,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 39,
@@ -4997,16 +4997,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.6,
-        "handling": 85,
+        "balance": 0.58,
+        "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 35,
+        "thrustSpeed": 85,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
@@ -5071,7 +5071,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 84,
         "swingDamage": 38,
@@ -5100,13 +5100,13 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.35,
-        "handling": 82,
+        "balance": 0.36,
+        "handling": 81,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 36,
@@ -6913,10 +6913,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 29,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 30,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -7012,7 +7012,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 31,
@@ -7050,7 +7050,7 @@
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 30,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 92
       }
@@ -7673,23 +7673,23 @@
     "weapons": [
       {
         "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "itemUsage": "onehanded_block_shield_swing",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.33,
-        "handling": 85,
+        "balance": 0.37,
+        "handling": 74,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 35,
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 85,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -8543,7 +8543,7 @@
     ]
   },
   {
-    "id": "crpg_dawnbreaker_sword_t3",
+    "id": "crpg_dawnbreaker_sword_t3_v2",
     "name": "Dawnbreaker",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
@@ -8562,18 +8562,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.51,
-        "handling": 91,
+        "balance": 0.33,
+        "handling": 74,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 83,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 80
       }
     ]
   },
@@ -11697,18 +11697,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.6,
+        "balance": 0.61,
         "handling": 86,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 30,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 88
       }
     ]
   },
@@ -16742,15 +16742,15 @@
         "stackAmount": 0,
         "length": 119,
         "balance": 0.25,
-        "handling": 85,
+        "handling": 88,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 35,
+        "thrustSpeed": 84,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
         "swingSpeed": 77
       }
@@ -16774,18 +16774,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.56,
-        "handling": 86,
+        "balance": 0.6,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 87
       }
     ]
   },
@@ -16808,15 +16808,15 @@
         "stackAmount": 0,
         "length": 87,
         "balance": 0.72,
-        "handling": 91,
+        "handling": 95,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 90,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 91
       }
@@ -16977,7 +16977,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
         "swingDamage": 29,
@@ -17006,23 +17006,23 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.21,
-        "handling": 82,
+        "balance": 0.25,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 77
       }
     ]
   },
   {
-    "id": "crpg_khuzait_sword_4_t4",
+    "id": "crpg_khuzait_sword_4_t4_v2",
     "name": "Fine Steel Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
@@ -17041,8 +17041,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.63,
-        "handling": 87,
+        "balance": 0.6,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -17052,7 +17052,7 @@
         "thrustSpeed": 87,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -17076,18 +17076,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.54,
-        "handling": 85,
+        "balance": 0.5,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 85
       }
     ]
   },
@@ -19478,16 +19478,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.45,
-        "handling": 80,
+        "balance": 0.44,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 37,
+        "thrustSpeed": 85,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
         "swingSpeed": 83
       }
@@ -19711,7 +19711,7 @@
     "type": "Mount",
     "price": 7016,
     "weight": 450.0,
-    "tier": 6.503736,
+    "tier": 8.907614,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19733,7 +19733,7 @@
     "type": "Mount",
     "price": 8384,
     "weight": 450.0,
-    "tier": 7.206992,
+    "tier": 9.376849,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19755,7 +19755,7 @@
     "type": "Mount",
     "price": 10892,
     "weight": 450.0,
-    "tier": 8.362733,
+    "tier": 10.1007595,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19777,7 +19777,7 @@
     "type": "Mount",
     "price": 12297,
     "weight": 450.0,
-    "tier": 8.952493,
+    "tier": 10.4508572,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19799,7 +19799,7 @@
     "type": "Mount",
     "price": 16026,
     "weight": 450.0,
-    "tier": 10.3731222,
+    "tier": 11.2495375,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19821,7 +19821,7 @@
     "type": "Mount",
     "price": 19400,
     "weight": 450.0,
-    "tier": 11.5219641,
+    "tier": 11.8561363,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19843,7 +19843,7 @@
     "type": "Mount",
     "price": 1507,
     "weight": 450.0,
-    "tier": 2.49147487,
+    "tier": 5.513256,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19865,7 +19865,7 @@
     "type": "Mount",
     "price": 2145,
     "weight": 450.0,
-    "tier": 3.15131736,
+    "tier": 6.20048952,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19887,7 +19887,7 @@
     "type": "Mount",
     "price": 3080,
     "weight": 450.0,
-    "tier": 3.96811247,
+    "tier": 6.95779943,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19909,7 +19909,7 @@
     "type": "Mount",
     "price": 4274,
     "weight": 450.0,
-    "tier": 4.85076427,
+    "tier": 7.69281,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19931,7 +19931,7 @@
     "type": "Mount",
     "price": 5393,
     "weight": 450.0,
-    "tier": 5.57456732,
+    "tier": 8.2468,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19953,7 +19953,7 @@
     "type": "Mount",
     "price": 6289,
     "weight": 420.0,
-    "tier": 6.10215759,
+    "tier": 8.628228,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19975,7 +19975,7 @@
     "type": "Mount",
     "price": 8154,
     "weight": 420.0,
-    "tier": 7.09293365,
+    "tier": 9.302354,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19997,7 +19997,7 @@
     "type": "Mount",
     "price": 10575,
     "weight": 420.0,
-    "tier": 8.224431,
+    "tier": 10.0168886,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20019,7 +20019,7 @@
     "type": "Mount",
     "price": 12175,
     "weight": 420.0,
-    "tier": 8.902765,
+    "tier": 10.4217911,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20041,7 +20041,7 @@
     "type": "Mount",
     "price": 14923,
     "weight": 420.0,
-    "tier": 9.97162151,
+    "tier": 11.0296774,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20063,7 +20063,7 @@
     "type": "Mount",
     "price": 17916,
     "weight": 420.0,
-    "tier": 11.0297079,
+    "tier": 11.6001053,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20085,7 +20085,7 @@
     "type": "Mount",
     "price": 579,
     "weight": 420.0,
-    "tier": 1.22718561,
+    "tier": 3.86932349,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20107,7 +20107,7 @@
     "type": "Mount",
     "price": 851,
     "weight": 420.0,
-    "tier": 1.657077,
+    "tier": 4.49625826,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20129,7 +20129,7 @@
     "type": "Mount",
     "price": 1060,
     "weight": 420.0,
-    "tier": 1.94750786,
+    "tier": 4.87438154,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20151,7 +20151,7 @@
     "type": "Mount",
     "price": 1448,
     "weight": 420.0,
-    "tier": 2.42474222,
+    "tier": 5.4389205,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20173,7 +20173,7 @@
     "type": "Mount",
     "price": 2046,
     "weight": 420.0,
-    "tier": 3.05597663,
+    "tier": 6.10597372,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20195,7 +20195,7 @@
     "type": "Mount",
     "price": 2827,
     "weight": 420.0,
-    "tier": 3.76057076,
+    "tier": 6.77340126,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20217,7 +20217,7 @@
     "type": "Mount",
     "price": 3925,
     "weight": 420.0,
-    "tier": 4.606884,
+    "tier": 7.49693155,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20239,7 +20239,7 @@
     "type": "Mount",
     "price": 5466,
     "weight": 420.0,
-    "tier": 5.619284,
+    "tier": 8.279811,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20261,7 +20261,7 @@
     "type": "Mount",
     "price": 8081,
     "weight": 430.0,
-    "tier": 7.05631447,
+    "tier": 9.27831,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20283,7 +20283,7 @@
     "type": "Mount",
     "price": 9583,
     "weight": 430.0,
-    "tier": 7.77831554,
+    "tier": 9.741429,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20305,7 +20305,7 @@
     "type": "Mount",
     "price": 12406,
     "weight": 430.0,
-    "tier": 8.997137,
+    "tier": 10.4768829,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20327,7 +20327,7 @@
     "type": "Mount",
     "price": 16846,
     "weight": 430.0,
-    "tier": 10.6623745,
+    "tier": 11.405304,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20349,7 +20349,7 @@
     "type": "Mount",
     "price": 20272,
     "weight": 430.0,
-    "tier": 11.8020506,
+    "tier": 11.9993753,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20371,7 +20371,7 @@
     "type": "Mount",
     "price": 1603,
     "weight": 450.0,
-    "tier": 2.59895325,
+    "tier": 5.630917,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20393,7 +20393,7 @@
     "type": "Mount",
     "price": 2203,
     "weight": 430.0,
-    "tier": 3.20696974,
+    "tier": 6.25500059,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20415,7 +20415,7 @@
     "type": "Mount",
     "price": 3137,
     "weight": 430.0,
-    "tier": 4.01302671,
+    "tier": 6.99706554,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20437,7 +20437,7 @@
     "type": "Mount",
     "price": 4346,
     "weight": 430.0,
-    "tier": 4.90012932,
+    "tier": 7.73185444,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20459,7 +20459,7 @@
     "type": "Mount",
     "price": 6236,
     "weight": 430.0,
-    "tier": 6.071869,
+    "tier": 8.606788,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20481,7 +20481,7 @@
     "type": "Mount",
     "price": 6220,
     "weight": 520.0,
-    "tier": 6.06284046,
+    "tier": 8.600387,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20503,7 +20503,7 @@
     "type": "Mount",
     "price": 7089,
     "weight": 520.0,
-    "tier": 6.54287863,
+    "tier": 8.934379,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20525,7 +20525,7 @@
     "type": "Mount",
     "price": 7709,
     "weight": 520.0,
-    "tier": 6.86758041,
+    "tier": 9.153386,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20547,7 +20547,7 @@
     "type": "Mount",
     "price": 8836,
     "weight": 520.0,
-    "tier": 7.42690468,
+    "tier": 9.518836,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20569,7 +20569,7 @@
     "type": "Mount",
     "price": 11578,
     "weight": 520.0,
-    "tier": 8.655123,
+    "tier": 10.2758207,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20591,7 +20591,7 @@
     "type": "Mount",
     "price": 13245,
     "weight": 520.0,
-    "tier": 9.331944,
+    "tier": 10.6700382,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20613,7 +20613,7 @@
     "type": "Mount",
     "price": 15723,
     "weight": 520.0,
-    "tier": 10.26399,
+    "tier": 11.1902046,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20635,7 +20635,7 @@
     "type": "Mount",
     "price": 19520,
     "weight": 520.0,
-    "tier": 11.5606194,
+    "tier": 11.8760071,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20657,7 +20657,7 @@
     "type": "Mount",
     "price": 850,
     "weight": 520.0,
-    "tier": 1.65485942,
+    "tier": 4.493249,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20679,7 +20679,7 @@
     "type": "Mount",
     "price": 1383,
     "weight": 520.0,
-    "tier": 2.349268,
+    "tier": 5.35360336,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20701,7 +20701,7 @@
     "type": "Mount",
     "price": 1948,
     "weight": 520.0,
-    "tier": 2.958975,
+    "tier": 6.00828552,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20723,7 +20723,7 @@
     "type": "Mount",
     "price": 2753,
     "weight": 520.0,
-    "tier": 3.69804144,
+    "tier": 6.716852,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20745,7 +20745,7 @@
     "type": "Mount",
     "price": 3429,
     "weight": 520.0,
-    "tier": 4.24101257,
+    "tier": 7.19307661,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20767,7 +20767,7 @@
     "type": "Mount",
     "price": 3908,
     "weight": 520.0,
-    "tier": 4.59435368,
+    "tier": 7.486729,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20789,7 +20789,7 @@
     "type": "Mount",
     "price": 4243,
     "weight": 520.0,
-    "tier": 4.82953167,
+    "tier": 7.675955,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20811,7 +20811,7 @@
     "type": "Mount",
     "price": 4865,
     "weight": 520.0,
-    "tier": 5.24347544,
+    "tier": 7.99815,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20833,7 +20833,7 @@
     "type": "Mount",
     "price": 8368,
     "weight": 450.0,
-    "tier": 7.199217,
+    "tier": 9.37179,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20855,7 +20855,7 @@
     "type": "Mount",
     "price": 10093,
     "weight": 450.0,
-    "tier": 8.010217,
+    "tier": 9.885577,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20877,7 +20877,7 @@
     "type": "Mount",
     "price": 12992,
     "weight": 450.0,
-    "tier": 9.231891,
+    "tier": 10.6126842,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20899,7 +20899,7 @@
     "type": "Mount",
     "price": 17890,
     "weight": 450.0,
-    "tier": 11.0211592,
+    "tier": 11.5956087,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20921,7 +20921,7 @@
     "type": "Mount",
     "price": 21302,
     "weight": 450.0,
-    "tier": 12.12575,
+    "tier": 12.162818,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20943,7 +20943,7 @@
     "type": "Mount",
     "price": 1534,
     "weight": 450.0,
-    "tier": 2.52271461,
+    "tier": 5.547713,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20965,7 +20965,7 @@
     "type": "Mount",
     "price": 2179,
     "weight": 450.0,
-    "tier": 3.183634,
+    "tier": 6.23220158,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20987,7 +20987,7 @@
     "type": "Mount",
     "price": 3111,
     "weight": 450.0,
-    "tier": 3.99263859,
+    "tier": 6.97926855,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21009,7 +21009,7 @@
     "type": "Mount",
     "price": 4474,
     "weight": 450.0,
-    "tier": 4.98650551,
+    "tier": 7.799703,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21031,7 +21031,7 @@
     "type": "Mount",
     "price": 6491,
     "weight": 450.0,
-    "tier": 6.215653,
+    "tier": 8.708097,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21053,7 +21053,7 @@
     "type": "Mount",
     "price": 8210,
     "weight": 420.0,
-    "tier": 7.121054,
+    "tier": 9.320776,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21075,7 +21075,7 @@
     "type": "Mount",
     "price": 9481,
     "weight": 420.0,
-    "tier": 7.730953,
+    "tier": 9.711726,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21097,7 +21097,7 @@
     "type": "Mount",
     "price": 12238,
     "weight": 420.0,
-    "tier": 8.928414,
+    "tier": 10.4367933,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21119,7 +21119,7 @@
     "type": "Mount",
     "price": 16205,
     "weight": 420.0,
-    "tier": 10.4368391,
+    "tier": 11.2840347,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21141,7 +21141,7 @@
     "type": "Mount",
     "price": 19293,
     "weight": 420.0,
-    "tier": 11.4871006,
+    "tier": 11.8381853,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21163,7 +21163,7 @@
     "type": "Mount",
     "price": 1628,
     "weight": 420.0,
-    "tier": 2.62545538,
+    "tier": 5.65955448,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21185,7 +21185,7 @@
     "type": "Mount",
     "price": 2246,
     "weight": 420.0,
-    "tier": 3.24756622,
+    "tier": 6.2944665,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21207,7 +21207,7 @@
     "type": "Mount",
     "price": 3199,
     "weight": 420.0,
-    "tier": 4.06239,
+    "tier": 7.03996849,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21229,7 +21229,7 @@
     "type": "Mount",
     "price": 4450,
     "weight": 420.0,
-    "tier": 4.970368,
+    "tier": 7.7870717,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21251,7 +21251,7 @@
     "type": "Mount",
     "price": 6367,
     "weight": 420.0,
-    "tier": 6.14633,
+    "tier": 8.659401,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21273,7 +21273,7 @@
     "type": "Mount",
     "price": 7562,
     "weight": 300.0,
-    "tier": 6.791751,
+    "tier": 9.102712,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21295,7 +21295,7 @@
     "type": "Mount",
     "price": 8851,
     "weight": 300.0,
-    "tier": 7.43374968,
+    "tier": 9.523221,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21317,7 +21317,7 @@
     "type": "Mount",
     "price": 11515,
     "weight": 300.0,
-    "tier": 8.628556,
+    "tier": 10.2600384,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21339,7 +21339,7 @@
     "type": "Mount",
     "price": 14975,
     "weight": 300.0,
-    "tier": 9.99101,
+    "tier": 11.0403948,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21361,7 +21361,7 @@
     "type": "Mount",
     "price": 18542,
     "weight": 300.0,
-    "tier": 11.2397976,
+    "tier": 11.7100611,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21383,7 +21383,7 @@
     "type": "Mount",
     "price": 1550,
     "weight": 300.0,
-    "tier": 2.540428,
+    "tier": 5.56715536,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21405,7 +21405,7 @@
     "type": "Mount",
     "price": 2130,
     "weight": 300.0,
-    "tier": 3.13779426,
+    "tier": 6.18717146,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21427,7 +21427,7 @@
     "type": "Mount",
     "price": 2944,
     "weight": 300.0,
-    "tier": 3.857515,
+    "tier": 6.860152,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21449,7 +21449,7 @@
     "type": "Mount",
     "price": 4086,
     "weight": 300.0,
-    "tier": 4.72100544,
+    "tier": 7.58922052,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21471,7 +21471,7 @@
     "type": "Mount",
     "price": 5810,
     "weight": 300.0,
-    "tier": 5.825277,
+    "tier": 8.430206,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21600,7 +21600,7 @@
     "type": "Mount",
     "price": 327,
     "weight": 300.0,
-    "tier": 0.7438689,
+    "tier": 3.0125072,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21622,7 +21622,7 @@
     "type": "Mount",
     "price": 1405,
     "weight": 300.0,
-    "tier": 2.37520838,
+    "tier": 5.383079,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -25047,7 +25047,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 32,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
@@ -27405,10 +27405,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 30,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 90
       }
@@ -27434,18 +27434,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.66,
-        "handling": 85,
+        "balance": 0.61,
+        "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 30,
+        "thrustSpeed": 85,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 88
       }
     ]
   },
@@ -27569,7 +27569,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
+        "balance": 0.58,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
@@ -27580,7 +27580,7 @@
         "thrustSpeed": 85,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -30630,7 +30630,7 @@
     "weapons": []
   },
   {
-    "id": "crpg_sturgia_noble_sword_1_t5_v2",
+    "id": "crpg_sturgia_noble_sword_1_t5",
     "name": "Thamaskene Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
@@ -30649,18 +30649,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 82,
-        "balance": 0.61,
-        "handling": 87,
+        "balance": 0.58,
+        "handling": 83,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -30690,7 +30690,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 86,
         "swingDamage": 34,
@@ -30725,10 +30725,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
-        "swingDamage": 32,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 90
       }
@@ -30755,12 +30755,12 @@
         "stackAmount": 0,
         "length": 84,
         "balance": 0.56,
-        "handling": 86,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 36,
@@ -30905,7 +30905,7 @@
     ]
   },
   {
-    "id": "crpg_sturgia_sword_1_t2_v2",
+    "id": "crpg_sturgia_sword_1_t2",
     "name": "Iron Thegn Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
@@ -30933,7 +30933,7 @@
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 32,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 89
       }
@@ -30960,15 +30960,15 @@
         "stackAmount": 0,
         "length": 87,
         "balance": 0.74,
-        "handling": 89,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 92
       }
@@ -31000,7 +31000,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 30,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 29,
@@ -31035,10 +31035,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 33,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 83
       }
@@ -31064,18 +31064,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.7,
+        "balance": 0.66,
         "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 27,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 89
       }
     ]
   },
@@ -31099,18 +31099,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.44,
-        "handling": 83,
+        "balance": 0.42,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 34,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 82
       }
     ]
   },
@@ -31747,18 +31747,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.46,
-        "handling": 82,
+        "balance": 0.48,
+        "handling": 76,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 88,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 84
       }
     ]
   },
@@ -31782,18 +31782,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 86,
-        "balance": 0.64,
+        "balance": 0.67,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 33,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 90
       }
     ]
   },
@@ -32657,7 +32657,7 @@
     "weapons": []
   },
   {
-    "id": "crpg_tyrhung_sword_t3",
+    "id": "crpg_tyrhung_sword_t3_v2",
     "name": "Tyrhung",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
@@ -32676,16 +32676,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.53,
-        "handling": 91,
+        "balance": 0.5,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 29,
+        "thrustSpeed": 89,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 85
       }
@@ -33678,16 +33678,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.52,
-        "handling": 84,
+        "balance": 0.51,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 85
       }
@@ -33719,10 +33719,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 34,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -33749,17 +33749,17 @@
         "stackAmount": 0,
         "length": 98,
         "balance": 0.53,
-        "handling": 92,
+        "handling": 91,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -33789,10 +33789,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 34,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
         "swingSpeed": 85
       }
@@ -33927,7 +33927,7 @@
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 86,
-        "swingDamage": 34,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -33959,10 +33959,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 33,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }
@@ -33988,16 +33988,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.21,
+        "balance": 0.23,
         "handling": 83,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 35,
+        "thrustSpeed": 88,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }
@@ -34021,18 +34021,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.6,
-        "handling": 88,
+        "balance": 0.56,
+        "handling": 87,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 29,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 86
       }
     ]
   },
@@ -34055,15 +34055,15 @@
         "stackAmount": 0,
         "length": 117,
         "balance": 0.23,
-        "handling": 81,
+        "handling": 83,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 34,
+        "thrustSpeed": 86,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }
@@ -35390,18 +35390,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.56,
-        "handling": 81,
+        "balance": 0.59,
+        "handling": 76,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 87
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -3170,9 +3170,9 @@
     "name": "Simple Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 5724,
-    "weight": 1.65,
-    "tier": 8.595606,
+    "price": 2580,
+    "weight": 1.73,
+    "tier": 5.41038036,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -3194,7 +3194,7 @@
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
-        "swingDamage": 33,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
@@ -4725,9 +4725,9 @@
     "name": "Engraved Backsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 6958,
-    "weight": 1.95,
-    "tier": 9.591346,
+    "price": 7147,
+    "weight": 2.03,
+    "tier": 9.735216,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4760,9 +4760,9 @@
     "name": "Highland Pointed Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4239,
-    "weight": 2.08,
-    "tier": 7.24302673,
+    "price": 5276,
+    "weight": 1.88,
+    "tier": 8.207648,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4795,9 +4795,9 @@
     "name": "Decorated Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7125,
-    "weight": 2.22,
-    "tier": 9.719157,
+    "price": 7261,
+    "weight": 2.25,
+    "tier": 9.821654,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -4982,9 +4982,9 @@
     "name": "Fine Steel Broad Shortsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 7259,
-    "weight": 2.41,
-    "tier": 9.82012,
+    "price": 5450,
+    "weight": 2.22,
+    "tier": 8.360392,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -5052,9 +5052,9 @@
     "name": "Fine Steel Cavalry Broadsword",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4350,
+    "price": 5077,
     "weight": 2.33,
-    "tier": 7.35112238,
+    "tier": 8.030952,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -5085,9 +5085,9 @@
     "name": "Highland Broad Blade",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5884,
-    "weight": 2.11,
-    "tier": 8.730547,
+    "price": 5872,
+    "weight": 2.1,
+    "tier": 8.720549,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -6894,9 +6894,9 @@
     "name": "Iron Pointed Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 2796,
+    "price": 3200,
     "weight": 1.6,
-    "tier": 5.67679,
+    "tier": 6.14890957,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -6993,9 +6993,9 @@
     "name": "Pointed Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 4652,
+    "price": 5011,
     "weight": 1.96,
-    "tier": 7.63991642,
+    "tier": 7.971292,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -7026,9 +7026,9 @@
     "name": "Broad Ild",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 6322,
+    "price": 4911,
     "weight": 2.21,
-    "tier": 9.089968,
+    "tier": 7.87971973,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -7665,9 +7665,9 @@
     "name": "Iron Cleaver",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 2916,
-    "weight": 2.35,
-    "tier": 5.820042,
+    "price": 3745,
+    "weight": 2.14,
+    "tier": 6.741253,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -8547,9 +8547,9 @@
     "name": "Dawnbreaker",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 7015,
-    "weight": 2.25,
-    "tier": 9.63514,
+    "price": 6816,
+    "weight": 2.39,
+    "tier": 9.481055,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -11682,9 +11682,9 @@
     "name": "Iron Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 4081,
-    "weight": 2.0,
-    "tier": 7.08585358,
+    "price": 3628,
+    "weight": 1.97,
+    "tier": 6.61795664,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16728,9 +16728,9 @@
     "name": "Decorated Cavalry Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 4422,
-    "weight": 2.47,
-    "tier": 7.42080975,
+    "price": 6579,
+    "weight": 2.37,
+    "tier": 9.295779,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16761,9 +16761,9 @@
     "name": "Lion Imprinted Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 7629,
-    "weight": 2.09,
-    "tier": 10.0955391,
+    "price": 7563,
+    "weight": 2.05,
+    "tier": 10.0469894,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16775,14 +16775,14 @@
         "stackAmount": 0,
         "length": 99,
         "balance": 0.6,
-        "handling": 88,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 86,
         "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 87
@@ -16794,9 +16794,9 @@
     "name": "Tall Gripped Ild",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 8300,
-    "weight": 1.86,
-    "tier": 10.5785847,
+    "price": 7300,
+    "weight": 1.71,
+    "tier": 9.851356,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16807,15 +16807,15 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.72,
-        "handling": 95,
+        "balance": 0.71,
+        "handling": 94,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 89,
         "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 91
@@ -16921,9 +16921,9 @@
     "name": "Iron Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 5232,
+    "price": 3538,
     "weight": 2.12,
-    "tier": 8.168667,
+    "tier": 6.522214,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16942,10 +16942,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 31,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
@@ -16956,9 +16956,9 @@
     "name": "Straight Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3717,
+    "price": 4162,
     "weight": 1.41,
-    "tier": 6.71195459,
+    "tier": 7.166879,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16991,9 +16991,9 @@
     "name": "Fine Steel Cavalry Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3806,
-    "weight": 2.28,
-    "tier": 6.80514669,
+    "price": 5212,
+    "weight": 2.23,
+    "tier": 8.151487,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17012,7 +17012,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 36,
@@ -17026,9 +17026,9 @@
     "name": "Fine Steel Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 7980,
-    "weight": 1.91,
-    "tier": 10.3506193,
+    "price": 5696,
+    "weight": 1.97,
+    "tier": 8.57179,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17042,15 +17042,15 @@
         "stackAmount": 0,
         "length": 97,
         "balance": 0.6,
-        "handling": 86,
+        "handling": 87,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 32,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
@@ -17061,9 +17061,9 @@
     "name": "Heavy Saber",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 6412,
-    "weight": 2.14,
-    "tier": 9.16231,
+    "price": 5351,
+    "weight": 2.2,
+    "tier": 8.274235,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19465,9 +19465,9 @@
     "name": "Soldier's Cleaver",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 7479,
-    "weight": 2.37,
-    "tier": 9.985142,
+    "price": 7288,
+    "weight": 2.2,
+    "tier": 9.842348,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19711,7 +19711,7 @@
     "type": "Mount",
     "price": 7016,
     "weight": 450.0,
-    "tier": 8.907614,
+    "tier": 6.503736,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19733,7 +19733,7 @@
     "type": "Mount",
     "price": 8384,
     "weight": 450.0,
-    "tier": 9.376849,
+    "tier": 7.206992,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19755,7 +19755,7 @@
     "type": "Mount",
     "price": 10892,
     "weight": 450.0,
-    "tier": 10.1007595,
+    "tier": 8.362733,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19777,7 +19777,7 @@
     "type": "Mount",
     "price": 12297,
     "weight": 450.0,
-    "tier": 10.4508572,
+    "tier": 8.952493,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19799,7 +19799,7 @@
     "type": "Mount",
     "price": 16026,
     "weight": 450.0,
-    "tier": 11.2495375,
+    "tier": 10.3731222,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19821,7 +19821,7 @@
     "type": "Mount",
     "price": 19400,
     "weight": 450.0,
-    "tier": 11.8561363,
+    "tier": 11.5219641,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19843,7 +19843,7 @@
     "type": "Mount",
     "price": 1507,
     "weight": 450.0,
-    "tier": 5.513256,
+    "tier": 2.49147487,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19865,7 +19865,7 @@
     "type": "Mount",
     "price": 2145,
     "weight": 450.0,
-    "tier": 6.20048952,
+    "tier": 3.15131736,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19887,7 +19887,7 @@
     "type": "Mount",
     "price": 3080,
     "weight": 450.0,
-    "tier": 6.95779943,
+    "tier": 3.96811247,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19909,7 +19909,7 @@
     "type": "Mount",
     "price": 4274,
     "weight": 450.0,
-    "tier": 7.69281,
+    "tier": 4.85076427,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19931,7 +19931,7 @@
     "type": "Mount",
     "price": 5393,
     "weight": 450.0,
-    "tier": 8.2468,
+    "tier": 5.57456732,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19953,7 +19953,7 @@
     "type": "Mount",
     "price": 6289,
     "weight": 420.0,
-    "tier": 8.628228,
+    "tier": 6.10215759,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19975,7 +19975,7 @@
     "type": "Mount",
     "price": 8154,
     "weight": 420.0,
-    "tier": 9.302354,
+    "tier": 7.09293365,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19997,7 +19997,7 @@
     "type": "Mount",
     "price": 10575,
     "weight": 420.0,
-    "tier": 10.0168886,
+    "tier": 8.224431,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20019,7 +20019,7 @@
     "type": "Mount",
     "price": 12175,
     "weight": 420.0,
-    "tier": 10.4217911,
+    "tier": 8.902765,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20041,7 +20041,7 @@
     "type": "Mount",
     "price": 14923,
     "weight": 420.0,
-    "tier": 11.0296774,
+    "tier": 9.97162151,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20063,7 +20063,7 @@
     "type": "Mount",
     "price": 17916,
     "weight": 420.0,
-    "tier": 11.6001053,
+    "tier": 11.0297079,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20085,7 +20085,7 @@
     "type": "Mount",
     "price": 579,
     "weight": 420.0,
-    "tier": 3.86932349,
+    "tier": 1.22718561,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20107,7 +20107,7 @@
     "type": "Mount",
     "price": 851,
     "weight": 420.0,
-    "tier": 4.49625826,
+    "tier": 1.657077,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20129,7 +20129,7 @@
     "type": "Mount",
     "price": 1060,
     "weight": 420.0,
-    "tier": 4.87438154,
+    "tier": 1.94750786,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20151,7 +20151,7 @@
     "type": "Mount",
     "price": 1448,
     "weight": 420.0,
-    "tier": 5.4389205,
+    "tier": 2.42474222,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20173,7 +20173,7 @@
     "type": "Mount",
     "price": 2046,
     "weight": 420.0,
-    "tier": 6.10597372,
+    "tier": 3.05597663,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20195,7 +20195,7 @@
     "type": "Mount",
     "price": 2827,
     "weight": 420.0,
-    "tier": 6.77340126,
+    "tier": 3.76057076,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20217,7 +20217,7 @@
     "type": "Mount",
     "price": 3925,
     "weight": 420.0,
-    "tier": 7.49693155,
+    "tier": 4.606884,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20239,7 +20239,7 @@
     "type": "Mount",
     "price": 5466,
     "weight": 420.0,
-    "tier": 8.279811,
+    "tier": 5.619284,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20261,7 +20261,7 @@
     "type": "Mount",
     "price": 8081,
     "weight": 430.0,
-    "tier": 9.27831,
+    "tier": 7.05631447,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20283,7 +20283,7 @@
     "type": "Mount",
     "price": 9583,
     "weight": 430.0,
-    "tier": 9.741429,
+    "tier": 7.77831554,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20305,7 +20305,7 @@
     "type": "Mount",
     "price": 12406,
     "weight": 430.0,
-    "tier": 10.4768829,
+    "tier": 8.997137,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20327,7 +20327,7 @@
     "type": "Mount",
     "price": 16846,
     "weight": 430.0,
-    "tier": 11.405304,
+    "tier": 10.6623745,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20349,7 +20349,7 @@
     "type": "Mount",
     "price": 20272,
     "weight": 430.0,
-    "tier": 11.9993753,
+    "tier": 11.8020506,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20371,7 +20371,7 @@
     "type": "Mount",
     "price": 1603,
     "weight": 450.0,
-    "tier": 5.630917,
+    "tier": 2.59895325,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20393,7 +20393,7 @@
     "type": "Mount",
     "price": 2203,
     "weight": 430.0,
-    "tier": 6.25500059,
+    "tier": 3.20696974,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20415,7 +20415,7 @@
     "type": "Mount",
     "price": 3137,
     "weight": 430.0,
-    "tier": 6.99706554,
+    "tier": 4.01302671,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20437,7 +20437,7 @@
     "type": "Mount",
     "price": 4346,
     "weight": 430.0,
-    "tier": 7.73185444,
+    "tier": 4.90012932,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20459,7 +20459,7 @@
     "type": "Mount",
     "price": 6236,
     "weight": 430.0,
-    "tier": 8.606788,
+    "tier": 6.071869,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20481,7 +20481,7 @@
     "type": "Mount",
     "price": 6220,
     "weight": 520.0,
-    "tier": 8.600387,
+    "tier": 6.06284046,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20503,7 +20503,7 @@
     "type": "Mount",
     "price": 7089,
     "weight": 520.0,
-    "tier": 8.934379,
+    "tier": 6.54287863,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20525,7 +20525,7 @@
     "type": "Mount",
     "price": 7709,
     "weight": 520.0,
-    "tier": 9.153386,
+    "tier": 6.86758041,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20547,7 +20547,7 @@
     "type": "Mount",
     "price": 8836,
     "weight": 520.0,
-    "tier": 9.518836,
+    "tier": 7.42690468,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20569,7 +20569,7 @@
     "type": "Mount",
     "price": 11578,
     "weight": 520.0,
-    "tier": 10.2758207,
+    "tier": 8.655123,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20591,7 +20591,7 @@
     "type": "Mount",
     "price": 13245,
     "weight": 520.0,
-    "tier": 10.6700382,
+    "tier": 9.331944,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20613,7 +20613,7 @@
     "type": "Mount",
     "price": 15723,
     "weight": 520.0,
-    "tier": 11.1902046,
+    "tier": 10.26399,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20635,7 +20635,7 @@
     "type": "Mount",
     "price": 19520,
     "weight": 520.0,
-    "tier": 11.8760071,
+    "tier": 11.5606194,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20657,7 +20657,7 @@
     "type": "Mount",
     "price": 850,
     "weight": 520.0,
-    "tier": 4.493249,
+    "tier": 1.65485942,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20679,7 +20679,7 @@
     "type": "Mount",
     "price": 1383,
     "weight": 520.0,
-    "tier": 5.35360336,
+    "tier": 2.349268,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20701,7 +20701,7 @@
     "type": "Mount",
     "price": 1948,
     "weight": 520.0,
-    "tier": 6.00828552,
+    "tier": 2.958975,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20723,7 +20723,7 @@
     "type": "Mount",
     "price": 2753,
     "weight": 520.0,
-    "tier": 6.716852,
+    "tier": 3.69804144,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20745,7 +20745,7 @@
     "type": "Mount",
     "price": 3429,
     "weight": 520.0,
-    "tier": 7.19307661,
+    "tier": 4.24101257,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20767,7 +20767,7 @@
     "type": "Mount",
     "price": 3908,
     "weight": 520.0,
-    "tier": 7.486729,
+    "tier": 4.59435368,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20789,7 +20789,7 @@
     "type": "Mount",
     "price": 4243,
     "weight": 520.0,
-    "tier": 7.675955,
+    "tier": 4.82953167,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20811,7 +20811,7 @@
     "type": "Mount",
     "price": 4865,
     "weight": 520.0,
-    "tier": 7.99815,
+    "tier": 5.24347544,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20833,7 +20833,7 @@
     "type": "Mount",
     "price": 8368,
     "weight": 450.0,
-    "tier": 9.37179,
+    "tier": 7.199217,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20855,7 +20855,7 @@
     "type": "Mount",
     "price": 10093,
     "weight": 450.0,
-    "tier": 9.885577,
+    "tier": 8.010217,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20877,7 +20877,7 @@
     "type": "Mount",
     "price": 12992,
     "weight": 450.0,
-    "tier": 10.6126842,
+    "tier": 9.231891,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20899,7 +20899,7 @@
     "type": "Mount",
     "price": 17890,
     "weight": 450.0,
-    "tier": 11.5956087,
+    "tier": 11.0211592,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20921,7 +20921,7 @@
     "type": "Mount",
     "price": 21302,
     "weight": 450.0,
-    "tier": 12.162818,
+    "tier": 12.12575,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20943,7 +20943,7 @@
     "type": "Mount",
     "price": 1534,
     "weight": 450.0,
-    "tier": 5.547713,
+    "tier": 2.52271461,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20965,7 +20965,7 @@
     "type": "Mount",
     "price": 2179,
     "weight": 450.0,
-    "tier": 6.23220158,
+    "tier": 3.183634,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -20987,7 +20987,7 @@
     "type": "Mount",
     "price": 3111,
     "weight": 450.0,
-    "tier": 6.97926855,
+    "tier": 3.99263859,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21009,7 +21009,7 @@
     "type": "Mount",
     "price": 4474,
     "weight": 450.0,
-    "tier": 7.799703,
+    "tier": 4.98650551,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21031,7 +21031,7 @@
     "type": "Mount",
     "price": 6491,
     "weight": 450.0,
-    "tier": 8.708097,
+    "tier": 6.215653,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21053,7 +21053,7 @@
     "type": "Mount",
     "price": 8210,
     "weight": 420.0,
-    "tier": 9.320776,
+    "tier": 7.121054,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21075,7 +21075,7 @@
     "type": "Mount",
     "price": 9481,
     "weight": 420.0,
-    "tier": 9.711726,
+    "tier": 7.730953,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21097,7 +21097,7 @@
     "type": "Mount",
     "price": 12238,
     "weight": 420.0,
-    "tier": 10.4367933,
+    "tier": 8.928414,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21119,7 +21119,7 @@
     "type": "Mount",
     "price": 16205,
     "weight": 420.0,
-    "tier": 11.2840347,
+    "tier": 10.4368391,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21141,7 +21141,7 @@
     "type": "Mount",
     "price": 19293,
     "weight": 420.0,
-    "tier": 11.8381853,
+    "tier": 11.4871006,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21163,7 +21163,7 @@
     "type": "Mount",
     "price": 1628,
     "weight": 420.0,
-    "tier": 5.65955448,
+    "tier": 2.62545538,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21185,7 +21185,7 @@
     "type": "Mount",
     "price": 2246,
     "weight": 420.0,
-    "tier": 6.2944665,
+    "tier": 3.24756622,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21207,7 +21207,7 @@
     "type": "Mount",
     "price": 3199,
     "weight": 420.0,
-    "tier": 7.03996849,
+    "tier": 4.06239,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21229,7 +21229,7 @@
     "type": "Mount",
     "price": 4450,
     "weight": 420.0,
-    "tier": 7.7870717,
+    "tier": 4.970368,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21251,7 +21251,7 @@
     "type": "Mount",
     "price": 6367,
     "weight": 420.0,
-    "tier": 8.659401,
+    "tier": 6.14633,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21273,7 +21273,7 @@
     "type": "Mount",
     "price": 7562,
     "weight": 300.0,
-    "tier": 9.102712,
+    "tier": 6.791751,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21295,7 +21295,7 @@
     "type": "Mount",
     "price": 8851,
     "weight": 300.0,
-    "tier": 9.523221,
+    "tier": 7.43374968,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21317,7 +21317,7 @@
     "type": "Mount",
     "price": 11515,
     "weight": 300.0,
-    "tier": 10.2600384,
+    "tier": 8.628556,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21339,7 +21339,7 @@
     "type": "Mount",
     "price": 14975,
     "weight": 300.0,
-    "tier": 11.0403948,
+    "tier": 9.99101,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21361,7 +21361,7 @@
     "type": "Mount",
     "price": 18542,
     "weight": 300.0,
-    "tier": 11.7100611,
+    "tier": 11.2397976,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21383,7 +21383,7 @@
     "type": "Mount",
     "price": 1550,
     "weight": 300.0,
-    "tier": 5.56715536,
+    "tier": 2.540428,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21405,7 +21405,7 @@
     "type": "Mount",
     "price": 2130,
     "weight": 300.0,
-    "tier": 6.18717146,
+    "tier": 3.13779426,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21427,7 +21427,7 @@
     "type": "Mount",
     "price": 2944,
     "weight": 300.0,
-    "tier": 6.860152,
+    "tier": 3.857515,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21449,7 +21449,7 @@
     "type": "Mount",
     "price": 4086,
     "weight": 300.0,
-    "tier": 7.58922052,
+    "tier": 4.72100544,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21471,7 +21471,7 @@
     "type": "Mount",
     "price": 5810,
     "weight": 300.0,
-    "tier": 8.430206,
+    "tier": 5.825277,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21600,7 +21600,7 @@
     "type": "Mount",
     "price": 327,
     "weight": 300.0,
-    "tier": 3.0125072,
+    "tier": 0.7438689,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -21622,7 +21622,7 @@
     "type": "Mount",
     "price": 1405,
     "weight": 300.0,
-    "tier": 5.383079,
+    "tier": 2.37520838,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -25025,9 +25025,9 @@
     "name": "Broad Falchion",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 6255,
+    "price": 4914,
     "weight": 1.99,
-    "tier": 9.036183,
+    "tier": 7.883069,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27384,9 +27384,9 @@
     "name": "Short Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5472,
+    "price": 4453,
     "weight": 1.97,
-    "tier": 8.379848,
+    "tier": 7.45072556,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27419,9 +27419,9 @@
     "name": "Simple Scimitar",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 4561,
-    "weight": 2.05,
-    "tier": 7.553933,
+    "price": 2876,
+    "weight": 2.12,
+    "tier": 5.77296734,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27554,9 +27554,9 @@
     "name": "Simple Saber ",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3704,
-    "weight": 2.11,
-    "tier": 6.698494,
+    "price": 2743,
+    "weight": 2.17,
+    "tier": 5.6122756,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27569,18 +27569,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.58,
+        "balance": 0.56,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 86
       }
     ]
   },
@@ -30634,9 +30634,9 @@
     "name": "Thamaskene Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 8083,
-    "weight": 2.1,
-    "tier": 10.4247856,
+    "price": 5942,
+    "weight": 2.15,
+    "tier": 8.779101,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30669,9 +30669,9 @@
     "name": "Decorated Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 5870,
+    "price": 6840,
     "weight": 2.08,
-    "tier": 8.718924,
+    "tier": 9.499657,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30704,9 +30704,9 @@
     "name": "Decorated Northern Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 8111,
+    "price": 7286,
     "weight": 1.86,
-    "tier": 10.4446068,
+    "tier": 9.840315,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30739,9 +30739,9 @@
     "name": "Gold Bound Short Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 7412,
-    "weight": 2.11,
-    "tier": 9.934813,
+    "price": 7311,
+    "weight": 2.13,
+    "tier": 9.859158,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30754,8 +30754,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.55,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -30909,9 +30909,9 @@
     "name": "Iron Thegn Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4925,
+    "price": 3908,
     "weight": 2.0,
-    "tier": 7.89281464,
+    "tier": 6.90989065,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30944,9 +30944,9 @@
     "name": "Northern Backsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 8531,
-    "weight": 1.78,
-    "tier": 10.7397738,
+    "price": 5821,
+    "weight": 1.74,
+    "tier": 8.677846,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30979,9 +30979,9 @@
     "name": "Pointed Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3301,
+    "price": 4291,
     "weight": 2.0,
-    "tier": 6.26207066,
+    "tier": 7.293616,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31014,9 +31014,9 @@
     "name": "Iron Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4376,
+    "price": 3863,
     "weight": 2.11,
-    "tier": 7.37696934,
+    "tier": 6.864206,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31049,9 +31049,9 @@
     "name": "Thamaskene Pointed Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3871,
-    "weight": 1.82,
-    "tier": 6.872162,
+    "price": 5827,
+    "weight": 1.87,
+    "tier": 8.682667,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31084,9 +31084,9 @@
     "name": "Steel Long Warsword",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 5671,
-    "weight": 1.97,
-    "tier": 8.550276,
+    "price": 4719,
+    "weight": 1.98,
+    "tier": 7.70292759,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31734,9 +31734,9 @@
     "name": "Scalpel",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 6883,
-    "weight": 2.4,
-    "tier": 9.533632,
+    "price": 7191,
+    "weight": 1.74,
+    "tier": 9.769094,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31767,9 +31767,9 @@
     "name": "Engraved Thegn Blade",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 8218,
+    "price": 7008,
     "weight": 1.93,
-    "tier": 10.5205622,
+    "tier": 9.629238,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31782,7 +31782,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 86,
-        "balance": 0.67,
+        "balance": 0.64,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
@@ -31793,7 +31793,7 @@
         "thrustSpeed": 87,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 89
       }
     ]
   },
@@ -32661,9 +32661,9 @@
     "name": "Tyrhung",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 4875,
-    "weight": 1.63,
-    "tier": 7.846766,
+    "price": 6868,
+    "weight": 1.64,
+    "tier": 9.521554,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33663,9 +33663,9 @@
     "name": "Decorated Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 7885,
-    "weight": 2.07,
-    "tier": 10.28221,
+    "price": 7207,
+    "weight": 2.03,
+    "tier": 9.781045,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33698,9 +33698,9 @@
     "name": "Fine Steel Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 7265,
+    "price": 6143,
     "weight": 2.11,
-    "tier": 9.82453,
+    "tier": 8.944765,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33733,9 +33733,9 @@
     "name": "Engraved Pointed Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 4705,
-    "weight": 1.75,
-    "tier": 7.68917,
+    "price": 7321,
+    "weight": 1.77,
+    "tier": 9.866533,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33748,15 +33748,15 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.53,
-        "handling": 91,
+        "balance": 0.55,
+        "handling": 90,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 89,
         "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 86
@@ -33768,9 +33768,9 @@
     "name": "Crescent Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5835,
+    "price": 4922,
     "weight": 2.2,
-    "tier": 8.689218,
+    "tier": 7.88991547,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33903,9 +33903,9 @@
     "name": "Iron Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 4942,
+    "price": 3985,
     "weight": 2.02,
-    "tier": 7.90841675,
+    "tier": 6.988547,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33938,9 +33938,9 @@
     "name": "Iron Cavalry Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 2245,
+    "price": 2877,
     "weight": 2.16,
-    "tier": 4.973294,
+    "tier": 5.774267,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33973,9 +33973,9 @@
     "name": "Knightly Cavalry Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 4039,
-    "weight": 1.97,
-    "tier": 7.043087,
+    "price": 7246,
+    "weight": 1.78,
+    "tier": 9.810214,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -34008,9 +34008,9 @@
     "name": "Narrow Arming Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 4281,
-    "weight": 1.43,
-    "tier": 7.283811,
+    "price": 4992,
+    "weight": 1.41,
+    "tier": 7.953537,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -34041,9 +34041,9 @@
     "name": "Fine Steel Cavalry Sword",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 3074,
-    "weight": 1.97,
-    "tier": 6.004901,
+    "price": 5157,
+    "weight": 2.04,
+    "tier": 8.102137,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -35377,9 +35377,9 @@
     "name": "Winds Fury",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 7311,
-    "weight": 1.87,
-    "tier": 9.85964,
+    "price": 7158,
+    "weight": 1.69,
+    "tier": 9.743742,
     "requirement": 0,
     "flags": [],
     "weapons": [

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -137,7 +137,7 @@
       <Piece id="crpg_winds_fury_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tyrhung_sword_t3" name="{=TbFLTHHm}Tyrhung" crafting_template="crpg_OneHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_tyrhung_sword_t3_v2" name="{=TbFLTHHm}Tyrhung" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_tyrhung_sword_t3_blade" Type="Blade" scale_factor="113" />
       <Piece id="crpg_tyrhung_sword_t3_guard" Type="Guard" scale_factor="100" />
@@ -153,7 +153,7 @@
       <Piece id="crpg_the_scalpel_sword_t3_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_dawnbreaker_sword_t3" name="{=J3erdO1b}Dawnbreaker" crafting_template="crpg_OneHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_dawnbreaker_sword_t3_v2" name="{=J3erdO1b}Dawnbreaker" crafting_template="crpg_OneHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_dawnbreaker_sword_t3_blade" Type="Blade" scale_factor="105" />
       <Piece id="crpg_dawnbreaker_sword_t3_guard" Type="Guard" scale_factor="100" />
@@ -827,7 +827,7 @@
       <Piece id="crpg_khuzait_sword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_sword_1_t2_v2" name="{=Ag6dujzl}Iron Thegn Blade" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_sword_1_t2" name="{=Ag6dujzl}Iron Thegn Blade" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_sturgia_sword_1_t2_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_sturgia_sword_1_t2_guard" Type="Guard" scale_factor="100" />
@@ -1075,7 +1075,7 @@
       <Piece id="crpg_aserai_sword_6_t4_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_khuzait_sword_4_t4" name="{=gadEbFyj}Fine Steel Saber" crafting_template="crpg_OneHandedSword" culture="Culture.khuzait" modifier_group="sword">
+  <CraftedItem id="crpg_khuzait_sword_4_t4_v2" name="{=gadEbFyj}Fine Steel Saber" crafting_template="crpg_OneHandedSword" culture="Culture.khuzait" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_khuzait_sword_4_t4_blade" Type="Blade" scale_factor="94" />
       <Piece id="crpg_khuzait_sword_4_t4_guard" Type="Guard" scale_factor="100" />
@@ -1315,7 +1315,7 @@
       <Piece id="crpg_khuzait_noble_sword_3_t5_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_noble_sword_1_t5_v2" name="{=lXwaLAYP}Thamaskene Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_sturgia_noble_sword_1_t5" name="{=lXwaLAYP}Thamaskene Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_sturgia_noble_sword_1_t5_blade" Type="Blade" scale_factor="115" />
       <Piece id="crpg_sturgia_noble_sword_1_t5_guard" Type="Guard" scale_factor="100" />
@@ -1379,7 +1379,7 @@
       <Piece id="crpg_battania_2hsword_1_t2_pommel" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bastard_sword_t2_v2" name="{=arBdK7st}Simple Short Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_bastard_sword_t2" name="{=arBdK7st}Simple Short Warsword" crafting_template="crpg_OneHandedSword" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_bastard_sword_t2_blade" Type="Blade" scale_factor="85" />
       <Piece id="crpg_bastard_sword_t2_guard" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Updated all battania, khuzait, sturgia, vlandia, and neutral 1h swords:
-exporter version 21
-large thrust damage increases where possible - especially on thrust specialty swords. others try to get around 20 minimum for viability. traded a bit of other stats to accomplish where required.
-fixed tiers that were off from planned tiers - including the last minute >t10 adjustments from last patch

-substantial nerfs due to tier adjustments were given refunds:
crpg_sturgia_noble_sword_1_t5_v2
crpg_khuzait_sword_4_t4
crpg_bastard_sword_t2_v2
crpg_sturgia_sword_1_t2_v2

-substantial rebalance to make these more unique were given refunds:
crpg_tyrhung_sword_t3
crpg_dawnbreaker_sword_t3