### PR TITLE
Marengo (simple Grey to White)

### DIFF
--- a/items/horses_and_others.xml
+++ b/items/horses_and_others.xml
@@ -991,7 +991,7 @@
           <Mesh name="horse_mane" affected_by_cover="true" />
         </AdditionalMeshes>
         <Materials>
-          <Material name="horse_grey_mat">
+          <Material name="horse_white_mat">
             <MeshMultipliers>
               <MeshMultiplier mesh_multiplier="FF08080B" percentage="1.0" />
               <MeshMultiplier mesh_multiplier="FF909090" percentage="0.25" />


### PR DESCRIPTION
Although I did check this way back using the mesh viewer tool, I didn't anticipate it would be this close to black. 

White has dappling/grey tones which would be much more suitable for Marengo.

