### PR TITLE
removed pike CT from 2H lance heads

### DIFF
--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -1544,6 +1544,14 @@
       <StatData stat_type="Handling" max_value="200" />
     </StatsData>
     <UsablePieces>
+      <UsablePiece piece_id="crpg_empire_lance_3_t5_blade" />
+      <UsablePiece piece_id="crpg_empire_lance_3_t5_handle" />
+      <UsablePiece piece_id="crpg_empire_lance_2_t4_blade" />
+      <UsablePiece piece_id="crpg_empire_lance_2_t4_handle" />
+      <UsablePiece piece_id="crpg_sturgia_lance_2_t5_blade" />
+      <UsablePiece piece_id="crpg_sturgia_lance_2_t5_handle" />
+      <UsablePiece piece_id="crpg_vlandia_lance_3_t5_blade" />
+      <UsablePiece piece_id="crpg_vlandia_lance_3_t5_handle" />
       <UsablePiece piece_id="crpg_war_scythe_blade" />
       <UsablePiece piece_id="crpg_war_scythe_handle" />
       <UsablePiece piece_id="crpg_awlpike_blade" />
@@ -1608,10 +1616,6 @@
       <UsablePiece piece_id="crpg_eastern_throwing_spear_2_t4_pommel" />
       <UsablePiece piece_id="crpg_empire_lance_2_t3_blade" />
       <UsablePiece piece_id="crpg_empire_lance_2_t3_handle" />
-      <UsablePiece piece_id="crpg_empire_lance_2_t4_blade" />
-      <UsablePiece piece_id="crpg_empire_lance_2_t4_handle" />
-      <UsablePiece piece_id="crpg_empire_lance_3_t5_blade" />
-      <UsablePiece piece_id="crpg_empire_lance_3_t5_handle" />
       <UsablePiece piece_id="crpg_empire_mace_3_t4_pommel" />
       <UsablePiece piece_id="crpg_empire_polearm_1_t4_blade" />
       <UsablePiece piece_id="crpg_empire_polearm_1_t4_guard" />
@@ -1710,8 +1714,6 @@
       <UsablePiece piece_id="crpg_southern_spear_4_t3_handle" />
       <UsablePiece piece_id="crpg_sturgia_lance_2_t4_blade" />
       <UsablePiece piece_id="crpg_sturgia_lance_2_t4_handle" />
-      <UsablePiece piece_id="crpg_sturgia_lance_2_t5_blade" />
-      <UsablePiece piece_id="crpg_sturgia_lance_2_t5_handle" />
       <UsablePiece piece_id="crpg_sturgia_polearm_1_t5_blade" />
       <UsablePiece piece_id="crpg_sturgia_polearm_1_t5_guard" />
       <UsablePiece piece_id="crpg_sturgia_polearm_1_t5_handle" />
@@ -1730,8 +1732,6 @@
       <UsablePiece piece_id="crpg_vlandia_lance_3_t3_handle" />
       <UsablePiece piece_id="crpg_vlandia_lance_3_t4_blade" />
       <UsablePiece piece_id="crpg_vlandia_lance_3_t4_handle" />
-      <UsablePiece piece_id="crpg_vlandia_lance_3_t5_blade" />
-      <UsablePiece piece_id="crpg_vlandia_lance_3_t5_handle" />
       <UsablePiece piece_id="crpg_vlandia_mace_2_t4_pommel" />
       <UsablePiece piece_id="crpg_vlandia_mace_3_t5_pommel" />
       <UsablePiece piece_id="crpg_vlandia_pike_1_t5_blade" />
@@ -1899,8 +1899,6 @@
       <UsablePiece piece_id="crpg_eastern_throwing_spear_1_t3_guard" />
       <UsablePiece piece_id="crpg_eastern_throwing_spear_2_t4_blade" />
       <UsablePiece piece_id="crpg_eastern_throwing_spear_2_t4_guard" />
-      <UsablePiece piece_id="crpg_empire_lance_2_t4_blade" />
-      <UsablePiece piece_id="crpg_empire_lance_3_t5_blade" />
       <UsablePiece piece_id="crpg_empire_polearm_1_t4_blade" />
       <UsablePiece piece_id="crpg_empire_polearm_1_t4_pommel" />
       <UsablePiece piece_id="crpg_empire_polearm_2_t5_blade" />
@@ -1947,14 +1945,12 @@
       <UsablePiece piece_id="crpg_southern_spear_3_t4_pommel" />
       <UsablePiece piece_id="crpg_southern_spear_4_t3_blade" />
       <UsablePiece piece_id="crpg_southern_spear_4_t3_guard" />
-      <UsablePiece piece_id="crpg_sturgia_lance_2_t5_blade" />
       <UsablePiece piece_id="crpg_sturgia_polearm_1_t5_guard" />
       <UsablePiece piece_id="crpg_sturgia_polearm_1_t5_pommel" />
       <UsablePiece piece_id="crpg_thamaskene_pike_t4_blade" />
       <UsablePiece piece_id="crpg_thamaskene_pike_t4_handle" />
       <UsablePiece piece_id="crpg_triangluar_spear_t3_blade" />
       <UsablePiece piece_id="crpg_triangluar_spear_t3_handle" />
-      <UsablePiece piece_id="crpg_vlandia_lance_3_t5_blade" />
       <UsablePiece piece_id="crpg_vlandia_pike_1_t5_blade" />
       <UsablePiece piece_id="crpg_vlandia_pike_1_t5_handle" />
       <UsablePiece piece_id="crpg_vlandia_polearm_1_t5_guard" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -2614,17 +2614,6 @@
       <WeaponFlag value="TwoHandIdleOnMount" />
     </WeaponFlags>
     <AvailablePieces>
-      <AvailablePiece id="crpg_western_spear_3_t3_blade" />
-      <AvailablePiece id="crpg_western_spear_3_t3_guard" />
-      <AvailablePiece id="crpg_western_spear_3_t3_handle" />
-      <AvailablePiece id="crpg_triangluar_spear_t3_blade" />
-      <AvailablePiece id="crpg_triangluar_spear_t3_handle" />
-      <AvailablePiece id="crpg_eastern_spear_2_t3_blade" />
-      <AvailablePiece id="crpg_eastern_spear_2_t3_handle" />
-      <AvailablePiece id="crpg_southern_spear_3_t4_blade" />
-      <AvailablePiece id="crpg_southern_spear_3_t4_guard" />
-      <AvailablePiece id="crpg_southern_spear_3_t4_handle" />
-      <AvailablePiece id="crpg_southern_spear_3_t4_pommel" />
       <AvailablePiece id="crpg_eastern_javelin_2_t3_pommel" />
       <AvailablePiece id="crpg_northern_javelin_2_t3_pommel" />
       <AvailablePiece id="crpg_generic_javelin_1_t3_pommel" />


### PR DESCRIPTION
moved the 2h lance pieces (handles & blades) all together at the top of 2h polearm CT, for ease with working on the current issues. removed 2h lance blades / heads from the crpg_pike CT. 

N/B I've noticed the lances are still in the shop under 'show additional items'.

Also removed the four 4d spears from the 2h polearm pike WD as it cannot affect them.