### PR TITLE
PolearmChanges

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1407,7 +1407,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_southern_spear_3_t4_blade" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3096">
+  <CraftingPiece id="crpg_southern_spear_3_t4_blade" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3496">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Blunt" damage_factor="1.4" />
@@ -1896,7 +1896,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_western_spear_3_t3_blade" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.56">
+  <CraftingPiece id="crpg_western_spear_3_t3_blade" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.62">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Blunt" damage_factor="1.7" />
@@ -6658,7 +6658,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_bec_de_corbin_blade" name="Bec De Corbin Blade" tier="3" piece_type="Blade" mesh="bec_head" culture="Culture.vlandia" length="104" weight="0.4">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.7"/>
+      <Thrust damage_type="Pierce" damage_factor="2.6"/>
       <Swing damage_type="Pierce" damage_factor="2.9"/>
     </BladeData>
     <Flags>

--- a/items.json
+++ b/items.json
@@ -5862,9 +5862,9 @@
     "name": "Bec De Corbin",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 14251,
+    "price": 13144,
     "weight": 2.11,
-    "tier": 10.099164,
+    "tier": 9.65598,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5886,7 +5886,7 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 27,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
         "swingDamage": 29,
@@ -28257,9 +28257,9 @@
     "name": "Long Thamaskene Tipped Spear",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 15562,
-    "weight": 2.03,
-    "tier": 10.6024494,
+    "price": 13342,
+    "weight": 2.07,
+    "tier": 9.736737,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -28271,7 +28271,7 @@
         "stackAmount": 0,
         "length": 195,
         "balance": 0.0,
-        "handling": 63,
+        "handling": 62,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28282,7 +28282,7 @@
         "thrustSpeed": 82,
         "swingDamage": 14,
         "swingDamageType": "Blunt",
-        "swingSpeed": 21
+        "swingSpeed": 18
       },
       {
         "class": "TwoHandedPolearm",
@@ -28292,7 +28292,7 @@
         "stackAmount": 0,
         "length": 195,
         "balance": 0.0,
-        "handling": 59,
+        "handling": 58,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28302,10 +28302,10 @@
         ],
         "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 90,
         "swingDamage": 14,
         "swingDamageType": "Blunt",
-        "swingSpeed": 70
+        "swingSpeed": 68
       },
       {
         "class": "TwoHandedPolearm",
@@ -28315,7 +28315,7 @@
         "stackAmount": 0,
         "length": 195,
         "balance": 0.0,
-        "handling": 59,
+        "handling": 58,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -28325,10 +28325,10 @@
         ],
         "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 90,
         "swingDamage": 14,
         "swingDamageType": "Blunt",
-        "swingSpeed": 70
+        "swingSpeed": 68
       }
     ]
   },
@@ -35484,9 +35484,9 @@
     "name": "Tall Tipped War Spear",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 14914,
-    "weight": 1.4,
-    "tier": 10.35623,
+    "price": 13861,
+    "weight": 1.46,
+    "tier": 9.944908,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -35498,7 +35498,7 @@
         "stackAmount": 0,
         "length": 184,
         "balance": 0.0,
-        "handling": 63,
+        "handling": 62,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -35509,7 +35509,7 @@
         "thrustSpeed": 87,
         "swingDamage": 17,
         "swingDamageType": "Blunt",
-        "swingSpeed": 25
+        "swingSpeed": 21
       },
       {
         "class": "TwoHandedPolearm",
@@ -35518,8 +35518,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 184,
-        "balance": 0.07,
-        "handling": 59,
+        "balance": 0.02,
+        "handling": 58,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -35532,7 +35532,7 @@
         "thrustSpeed": 94,
         "swingDamage": 17,
         "swingDamageType": "Blunt",
-        "swingSpeed": 71
+        "swingSpeed": 70
       },
       {
         "class": "TwoHandedPolearm",
@@ -35541,8 +35541,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 184,
-        "balance": 0.07,
-        "handling": 59,
+        "balance": 0.02,
+        "handling": 58,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -35555,7 +35555,7 @@
         "thrustSpeed": 94,
         "swingDamage": 17,
         "swingDamageType": "Blunt",
-        "swingSpeed": 71
+        "swingSpeed": 70
       }
     ]
   },


### PR DESCRIPTION
3 polearms change:
Bec De Corbin
- new tier: 9.65598 
- thrust damage from 27 to 26

Tall Tipped War Spear
- new tier: 9.944908
- swing speed from 71 to 70
- weight from 1.4 to 1.46
- handling from 59 to 58

Long Thamaskene Tipped Spear
- new tier: 9.736737
- swing speed from 70 to 68
- thrust speed from 91 to 90
- weight from 2.03 to 2.07
- handling from 59 to 58