### PR TITLE
2 haxe.may2023.update

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2394,7 +2394,7 @@
   <CraftingPiece id="crpg_battania_2haxe_1_t2_blade" name="{=ALO9gw69}Square Bit Two Handed Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_14_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.9" weight="0.9">
     <BuildData piece_offset="-5.8" />
     <BladeData stack_amount="2" blade_length="13.923" blade_width="21.94" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2353,10 +2353,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_black_heart_2haxe_t3_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.75">
+  <CraftingPiece id="crpg_black_heart_2haxe_t3_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.55">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="20.281" blade_width="19.8" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2366,10 +2366,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bearded_axe_t3_blade" name="{=gSdybwMN}Large Drilled Norse Bearded Head" tier="3" piece_type="Blade" mesh="axe_craft_3_head" distance_to_next_piece="13.057" distance_to_previous_piece="2.314" weight="0.725">
+  <CraftingPiece id="crpg_bearded_axe_t3_blade" name="{=gSdybwMN}Large Drilled Norse Bearded Head" tier="3" piece_type="Blade" mesh="axe_craft_3_head" distance_to_next_piece="13.057" distance_to_previous_piece="2.314" weight="0.7">
     <BuildData piece_offset="-4.628" />
     <BladeData stack_amount="2" blade_length="23.005" blade_width="22.407" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2340,10 +2340,10 @@
       <Flag name="BonusAgainstShield" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hooked_axe_t4_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.575">
+  <CraftingPiece id="crpg_hooked_axe_t4_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.65">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="20.281" blade_width="19.8" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2353,10 +2353,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_black_heart_2haxe_t3_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.6">
+  <CraftingPiece id="crpg_black_heart_2haxe_t3_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.75">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="20.281" blade_width="19.8" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2366,10 +2366,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bearded_axe_t3_blade" name="{=gSdybwMN}Large Drilled Norse Bearded Head" tier="3" piece_type="Blade" mesh="axe_craft_3_head" distance_to_next_piece="13.057" distance_to_previous_piece="2.314" weight="0.575">
+  <CraftingPiece id="crpg_bearded_axe_t3_blade" name="{=gSdybwMN}Large Drilled Norse Bearded Head" tier="3" piece_type="Blade" mesh="axe_craft_3_head" distance_to_next_piece="13.057" distance_to_previous_piece="2.314" weight="0.725">
     <BuildData piece_offset="-4.628" />
     <BladeData stack_amount="2" blade_length="23.005" blade_width="22.407" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2379,10 +2379,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_sparth_axe_t2_blade" name="{=orwoyDlX}Great Sparth Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_5_head" distance_to_next_piece="3.414" distance_to_previous_piece="2.617" weight="0.7">
+  <CraftingPiece id="crpg_simple_sparth_axe_t2_blade" name="{=orwoyDlX}Great Sparth Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_5_head" distance_to_next_piece="3.414" distance_to_previous_piece="2.617" weight="1.0">
     <BuildData piece_offset="-5.234" />
     <BladeData stack_amount="2" blade_length="13.105" blade_width="27.618" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2391,10 +2391,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_battania_2haxe_1_t2_blade" name="{=ALO9gw69}Square Bit Two Handed Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_14_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.9" weight="0.735">
+  <CraftingPiece id="crpg_battania_2haxe_1_t2_blade" name="{=ALO9gw69}Square Bit Two Handed Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_14_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.9" weight="0.9">
     <BuildData piece_offset="-5.8" />
     <BladeData stack_amount="2" blade_length="13.923" blade_width="21.94" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2403,10 +2403,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_2haxe_2_t5_blade" name="{=IxCaIvUk}Large Northern Broad Head With Decorated Neck" tier="5" piece_type="Blade" mesh="axe_craft_22_head" distance_to_next_piece="9.3" distance_to_previous_piece="2" weight="0.6">
+  <CraftingPiece id="crpg_sturgia_2haxe_2_t5_blade" name="{=IxCaIvUk}Large Northern Broad Head With Decorated Neck" tier="5" piece_type="Blade" mesh="axe_craft_22_head" distance_to_next_piece="9.3" distance_to_previous_piece="2" weight="0.66">
     <BuildData piece_offset="-4" />
     <BladeData stack_amount="2" blade_length="20.781" blade_width="30.384" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2416,10 +2416,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_2haxe_1_t4_blade" name="{=NfPgejKk}Drilled Sparth Blade" tier="4" piece_type="Blade" mesh="axe_craft_1_head" distance_to_next_piece="5.402" distance_to_previous_piece="2.747" weight="0.55">
+  <CraftingPiece id="crpg_sturgia_2haxe_1_t4_blade" name="{=NfPgejKk}Drilled Sparth Blade" tier="4" piece_type="Blade" mesh="axe_craft_1_head" distance_to_next_piece="5.402" distance_to_previous_piece="2.747" weight="0.825">
     <BuildData piece_offset="-8.241" />
     <BladeData stack_amount="2" blade_length="16.651" blade_width="26.744" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2432,6 +2432,7 @@
   <CraftingPiece id="crpg_aserai_2haxe_3_t5_blade" name="{=SEsx3kZz}Heavy Bardiche Head" tier="5" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.735">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="4.6" />
       <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
@@ -2454,10 +2455,10 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_1_t3_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.25">
+  <CraftingPiece id="crpg_aserai_2haxe_1_t3_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.425">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2480,10 +2481,10 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_2haxe_1_t4_blade" name="{=R62maL2H}Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.7">
+  <CraftingPiece id="crpg_vlandia_2haxe_1_t4_blade" name="{=R62maL2H}Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.52">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2493,10 +2494,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_northern_axe_t3_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.5">
+  <CraftingPiece id="crpg_northern_axe_t3_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.875">
     <BuildData piece_offset="-5.424" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2506,10 +2507,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_avalanche_2haxe_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.5">
+  <CraftingPiece id="crpg_avalanche_2haxe_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.6">
     <BuildData piece_offset="-5.424" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -2522,7 +2523,7 @@
   <CraftingPiece id="crpg_peasant_2haxe_1_t1_blade" name="{=LSrJljDL}Adze Head" tier="1" piece_type="Blade" mesh="axe_craft_15_head" distance_to_next_piece="4.1" distance_to_previous_piece="3.2" weight="0.7" is_default="true">
     <BuildData piece_offset="-6.4" />
     <BladeData stack_amount="2" blade_length="4.552" blade_width="25.764" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6132,7 +6133,7 @@
 <CraftingPiece id="crpg_greataxe_blade" name="{=}Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.65">
 <BuildData piece_offset="-14.0"/>
 <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-<Swing damage_type="Cut" damage_factor="4.3"/>
+<Swing damage_type="Cut" damage_factor="4.4"/>
 </BladeData>
 <Flags>
 <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>
@@ -6149,7 +6150,7 @@
 <Material id="Iron5" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_long_greataxe_blade" name="{=}Long Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.475">
+<CraftingPiece id="crpg_long_greataxe_blade" name="{=}Long Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.45">
 <BuildData piece_offset="-14.0"/>
 <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
 <Swing damage_type="Cut" damage_factor="4.1"/>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2179,7 +2179,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_1_t3_handle" name="{=XxhFx0yw}Short Leather Wrapped Great Axe Handle" tier="3" piece_type="Handle" mesh="axe_craft_8_handle" length="116" weight="2.1" excluded_item_usage_features="widegrip">
+  <CraftingPiece id="crpg_aserai_2haxe_1_t3_handle" name="{=XxhFx0yw}Short Leather Wrapped Great Axe Handle" tier="3" piece_type="Handle" mesh="axe_craft_8_handle" length="116" weight="3.0" excluded_item_usage_features="widegrip">
     <BuildData piece_offset="23.86" next_piece_offset="1" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -2454,10 +2454,10 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_1_t3_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.425">
+  <CraftingPiece id="crpg_aserai_2haxe_1_t3_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.15">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2165,7 +2165,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_2_t4_handle" name="{=l13RibeF}Steel Reinforced Great Axe Handle" tier="4" piece_type="Handle" mesh="axe_craft_10_handle" length="132" weight="0.65" excluded_item_usage_features="widegrip">
+  <CraftingPiece id="crpg_aserai_2haxe_2_t4_handle" name="{=l13RibeF}Steel Reinforced Great Axe Handle" tier="4" piece_type="Handle" mesh="axe_craft_10_handle" length="132" weight="1.825" excluded_item_usage_features="widegrip">
     <BuildData piece_offset="28.87" next_piece_offset="2.5" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -2442,7 +2442,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_2_t4_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.6">
+  <CraftingPiece id="crpg_aserai_2haxe_2_t4_blade" name="{=0gteBOD7}Bardiche Head" tier="4" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.185">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2403,7 +2403,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_2haxe_2_t5_blade" name="{=IxCaIvUk}Large Northern Broad Head With Decorated Neck" tier="5" piece_type="Blade" mesh="axe_craft_22_head" distance_to_next_piece="9.3" distance_to_previous_piece="2" weight="0.66">
+  <CraftingPiece id="crpg_sturgia_2haxe_2_t5_blade" name="{=IxCaIvUk}Large Northern Broad Head With Decorated Neck" tier="5" piece_type="Blade" mesh="axe_craft_22_head" distance_to_next_piece="9.3" distance_to_previous_piece="2" weight="0.6">
     <BuildData piece_offset="-4" />
     <BladeData stack_amount="2" blade_length="20.781" blade_width="30.384" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2429,7 +2429,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_3_t5_blade" name="{=SEsx3kZz}Heavy Bardiche Head" tier="5" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.735">
+  <CraftingPiece id="crpg_aserai_2haxe_3_t5_blade" name="{=SEsx3kZz}Heavy Bardiche Head" tier="5" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.675">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.6" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2506,7 +2506,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_avalanche_2haxe_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.6">
+  <CraftingPiece id="crpg_avalanche_2haxe_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.5">
     <BuildData piece_offset="-5.424" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2340,10 +2340,10 @@
       <Flag name="BonusAgainstShield" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hooked_axe_t4_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.65">
+  <CraftingPiece id="crpg_hooked_axe_t4_blade" name="{=a0erBuF1}Hooked Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_34_head" distance_to_next_piece="8.8" distance_to_previous_piece="4" weight="0.825">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="20.281" blade_width="19.8" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2151,7 +2151,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_3_t5_handle" name="{=1T0XBYlc}Hardened Oaken Two Handed Axe Handle" tier="5" piece_type="Handle" mesh="axe_craft_1_handle" length="157.6" weight="0.7" item_holster_pos_shift="0,0,-0.1" CraftingCost="75">
+  <CraftingPiece id="crpg_aserai_2haxe_3_t5_handle" name="{=1T0XBYlc}Hardened Oaken Two Handed Axe Handle" tier="5" piece_type="Handle" mesh="axe_craft_1_handle" length="157.6" weight="3.0" item_holster_pos_shift="0,0,-0.1" CraftingCost="75">
     <BuildData piece_offset="37.408" next_piece_offset="1.42" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -2429,7 +2429,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_aserai_2haxe_3_t5_blade" name="{=SEsx3kZz}Heavy Bardiche Head" tier="5" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.675">
+  <CraftingPiece id="crpg_aserai_2haxe_3_t5_blade" name="{=SEsx3kZz}Heavy Bardiche Head" tier="5" piece_type="Blade" mesh="axe_craft_16_head" distance_to_next_piece="28.8" distance_to_previous_piece="6" weight="0.01">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.6" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2416,10 +2416,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_sturgia_2haxe_1_t4_blade" name="{=NfPgejKk}Drilled Sparth Blade" tier="4" piece_type="Blade" mesh="axe_craft_1_head" distance_to_next_piece="5.402" distance_to_previous_piece="2.747" weight="0.825">
+  <CraftingPiece id="crpg_sturgia_2haxe_1_t4_blade" name="{=NfPgejKk}Drilled Sparth Blade" tier="4" piece_type="Blade" mesh="axe_craft_1_head" distance_to_next_piece="5.402" distance_to_previous_piece="2.747" weight="0.7">
     <BuildData piece_offset="-8.241" />
     <BladeData stack_amount="2" blade_length="16.651" blade_width="26.744" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -6129,7 +6129,7 @@
 <Material id="Wood" count="1"/>
 </Materials>
 </CraftingPiece>
-<CraftingPiece id="crpg_greataxe_blade" name="{=}Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.65">
+<CraftingPiece id="crpg_greataxe_blade" name="{=}Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.595">
 <BuildData piece_offset="-14.0"/>
 <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
 <Swing damage_type="Cut" damage_factor="4.4"/>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2519,10 +2519,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_peasant_2haxe_1_t1_blade" name="{=LSrJljDL}Adze Head" tier="1" piece_type="Blade" mesh="axe_craft_15_head" distance_to_next_piece="4.1" distance_to_previous_piece="3.2" weight="0.7" is_default="true">
+  <CraftingPiece id="crpg_peasant_2haxe_1_t1_blade" name="{=LSrJljDL}Adze Head" tier="1" piece_type="Blade" mesh="axe_craft_15_head" distance_to_next_piece="4.1" distance_to_previous_piece="3.2" weight="0.315" is_default="true">
     <BuildData piece_offset="-6.4" />
     <BladeData stack_amount="2" blade_length="4.552" blade_width="25.764" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="2.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2433,7 +2433,6 @@
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.6" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2480,10 +2480,10 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_vlandia_2haxe_1_t4_blade" name="{=R62maL2H}Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.52">
+  <CraftingPiece id="crpg_vlandia_2haxe_1_t4_blade" name="{=R62maL2H}Bill Head" tier="4" piece_type="Blade" mesh="axe_craft_17_head" distance_to_next_piece="21" distance_to_previous_piece="3.8" weight="0.505">
     <BuildData piece_offset="-7.6" />
     <BladeData stack_amount="2" blade_length="33.887" blade_width="22.47" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2493,10 +2493,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_northern_axe_t3_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.875">
+  <CraftingPiece id="crpg_northern_axe_t3_blade" name="{=USWfzbuW}Northern Broad Great Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_7_head" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.81">
     <BuildData piece_offset="-5.424" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -6152,7 +6152,7 @@
 <CraftingPiece id="crpg_long_greataxe_blade" name="{=}Long Great Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.45">
 <BuildData piece_offset="-14.0"/>
 <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-<Swing damage_type="Cut" damage_factor="4.1"/>
+<Swing damage_type="Cut" damage_factor="4.3"/>
 </BladeData>
 <Flags>
 <Flag name="CanBePickedUpFromCorpse" type="ItemFlags"/>

--- a/items.json
+++ b/items.json
@@ -5981,9 +5981,9 @@
     "name": "Black Heart Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 3587,
-    "weight": 1.4,
-    "tier": 4.54630756,
+    "price": 5630,
+    "weight": 1.2,
+    "tier": 5.95338249,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5996,8 +5996,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 119,
-        "balance": 0.48,
-        "handling": 75,
+        "balance": 0.69,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -6007,10 +6007,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 96,
-        "swingDamage": 41,
+        "thrustSpeed": 99,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 90
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -612,13 +612,13 @@
     ]
   },
   {
-    "id": "crpg_aserai_2haxe_1_t3",
+    "id": "crpg_aserai_2haxe_1_t3v2",
     "name": "Short Handled Bardiche",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 8433,
-    "weight": 2.64,
-    "tier": 7.52129745,
+    "price": 5060,
+    "weight": 2.82,
+    "tier": 5.590783,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -642,8 +642,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 40,
+        "thrustSpeed": 87,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -2361,13 +2361,13 @@
     "weapons": []
   },
   {
-    "id": "crpg_avalanche_2haxe",
+    "id": "crpg_avalanche_2haxev2",
     "name": "Avalanche",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 7674,
-    "weight": 1.41,
-    "tier": 7.126344,
+    "price": 8524,
+    "weight": 1.43,
+    "tier": 7.56724262,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -2392,7 +2392,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 96,
-        "swingDamage": 40,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
@@ -3272,13 +3272,13 @@
     ]
   },
   {
-    "id": "crpg_battania_2haxe_1_t2",
+    "id": "crpg_battania_2haxe_1_t2v2",
     "name": "Woodsman Two Handed Axe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 3759,
-    "weight": 1.34,
-    "tier": 4.67799664,
+    "price": 1572,
+    "weight": 1.41,
+    "tier": 2.68337965,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5742,9 +5742,9 @@
     "name": "Dane Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 5575,
-    "weight": 1.39,
-    "tier": 5.919484,
+    "price": 6749,
+    "weight": 1.4,
+    "tier": 6.61742544,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5981,9 +5981,9 @@
     "name": "Black Heart Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 3326,
-    "weight": 1.26,
-    "tier": 4.340472,
+    "price": 3587,
+    "weight": 1.4,
+    "tier": 4.54630756,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13002,9 +13002,9 @@
     "name": "Greataxe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 7444,
+    "price": 8849,
     "weight": 1.41,
-    "tier": 7.00261545,
+    "tier": 7.73023129,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13029,7 +13029,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 97,
-        "swingDamage": 43,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
         "swingSpeed": 90
       }
@@ -14415,9 +14415,9 @@
     "name": "Hooked Two Handed Axe",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 2242,
-    "weight": 1.15,
-    "tier": 3.38759184,
+    "price": 1342,
+    "weight": 1.25,
+    "tier": 2.40916324,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18660,9 +18660,9 @@
     "name": "Long Greataxe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 5743,
+    "price": 6873,
     "weight": 1.38,
-    "tier": 6.023303,
+    "tier": 6.687345,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -22560,13 +22560,13 @@
     ]
   },
   {
-    "id": "crpg_northern_axe_t3",
+    "id": "crpg_northern_axe_t3v2",
     "name": "Broad Two Handed Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 7815,
-    "weight": 1.44,
-    "tier": 7.20116949,
+    "price": 2220,
+    "weight": 1.73,
+    "tier": 3.36657286,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -22590,8 +22590,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 37,
+        "thrustSpeed": 94,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
@@ -24176,9 +24176,9 @@
     "name": "Hoe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 378,
-    "weight": 1.27,
-    "tier": 0.898149133,
+    "price": 582,
+    "weight": 1.41,
+    "tier": 1.29684281,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -27624,9 +27624,9 @@
     "name": "Saxon Short Battle Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 877,
-    "weight": 1.13,
-    "tier": 1.77898908,
+    "price": 5389,
+    "weight": 1.43,
+    "tier": 5.80263472,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -30124,13 +30124,13 @@
     "weapons": []
   },
   {
-    "id": "crpg_sturgia_2haxe_1_t4",
+    "id": "crpg_sturgia_2haxe_1_t4v2",
     "name": "Drilled Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 2438,
-    "weight": 1.08,
-    "tier": 3.57466745,
+    "price": 3283,
+    "weight": 1.25,
+    "tier": 4.30568027,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -30208,9 +30208,9 @@
     "name": "Northlander Decorated Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 5272,
-    "weight": 1.23,
-    "tier": 5.728039,
+    "price": 7183,
+    "weight": 1.26,
+    "tier": 6.860324,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -33207,9 +33207,9 @@
     "name": "Short Bill",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 2861,
-    "weight": 1.5,
-    "tier": 3.95399928,
+    "price": 5495,
+    "weight": 1.36,
+    "tier": 5.86925459,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"

--- a/items.json
+++ b/items.json
@@ -5738,7 +5738,7 @@
     ]
   },
   {
-    "id": "crpg_bearded_axe_t3",
+    "id": "crpg_bearded_axe_t3v2",
     "name": "Dane Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
@@ -30128,9 +30128,9 @@
     "name": "Drilled Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 3283,
-    "weight": 1.25,
-    "tier": 4.30568027,
+    "price": 4614,
+    "weight": 1.13,
+    "tier": 5.29203749,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -30143,8 +30143,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 90,
-        "balance": 0.25,
-        "handling": 74,
+        "balance": 0.39,
+        "handling": 77,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30152,10 +30152,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 37,
+        "thrustSpeed": 94,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 81
       },
       {
         "class": "TwoHandedAxe",
@@ -30164,8 +30164,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 90,
-        "balance": 0.81,
-        "handling": 83,
+        "balance": 0.93,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30175,10 +30175,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 99,
-        "swingDamage": 37,
+        "thrustSpeed": 100,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 97
       },
       {
         "class": "OneHandedAxe",
@@ -30187,8 +30187,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 90,
-        "balance": 0.25,
-        "handling": 74,
+        "balance": 0.39,
+        "handling": 77,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30196,10 +30196,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 37,
+        "thrustSpeed": 94,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 81
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -693,7 +693,7 @@
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
     "price": 12870,
-    "weight": 1.37,
+    "weight": 2.71,
     "tier": 9.543342,
     "requirement": 0,
     "flags": [
@@ -707,7 +707,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.49,
+        "balance": 0.47,
         "handling": 76,
         "bodyArmor": 0,
         "flags": [
@@ -718,7 +718,7 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
+        "thrustSpeed": 87,
         "swingDamage": 46,
         "swingDamageType": "Cut",
         "swingSpeed": 84

--- a/items.json
+++ b/items.json
@@ -692,9 +692,9 @@
     "name": "Chainbreaker",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 8040,
-    "weight": 1.44,
-    "tier": 7.318816,
+    "price": 12870,
+    "weight": 1.37,
+    "tier": 9.543342,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -707,8 +707,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 128,
-        "balance": 0.43,
-        "handling": 74,
+        "balance": 0.49,
+        "handling": 76,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -718,10 +718,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 96,
+        "thrustSpeed": 97,
         "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -14415,9 +14415,9 @@
     "name": "Hooked Two Handed Axe",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 1342,
-    "weight": 1.25,
-    "tier": 2.40916324,
+    "price": 2145,
+    "weight": 1.3,
+    "tier": 3.29326582,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -14429,9 +14429,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 123,
-        "balance": 0.49,
-        "handling": 73,
+        "length": 98,
+        "balance": 0.67,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -14442,9 +14442,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 35,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 90
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -18660,9 +18660,9 @@
     "name": "Long Greataxe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 6873,
+    "price": 9834,
     "weight": 1.38,
-    "tier": 6.687345,
+    "tier": 8.207248,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -18687,7 +18687,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 97,
-        "swingDamage": 41,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
         "swingSpeed": 88
       }

--- a/items.json
+++ b/items.json
@@ -13002,9 +13002,9 @@
     "name": "Greataxe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 8849,
-    "weight": 1.41,
-    "tier": 7.73023129,
+    "price": 13045,
+    "weight": 1.35,
+    "tier": 9.615709,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -13017,8 +13017,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.68,
-        "handling": 80,
+        "balance": 0.76,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -13028,10 +13028,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
+        "thrustSpeed": 98,
         "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -33207,9 +33207,9 @@
     "name": "Short Bill",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
-    "price": 5495,
-    "weight": 1.36,
-    "tier": 5.86925459,
+    "price": 7954,
+    "weight": 1.35,
+    "tier": 7.274298,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -33222,7 +33222,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 138,
-        "balance": 0.53,
+        "balance": 0.55,
         "handling": 76,
         "bodyArmor": 0,
         "flags": [
@@ -33235,9 +33235,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 97,
-        "swingDamage": 38,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -5742,9 +5742,9 @@
     "name": "Dane Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 6749,
-    "weight": 1.4,
-    "tier": 6.61742544,
+    "price": 9637,
+    "weight": 1.38,
+    "tier": 8.113654,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -5757,8 +5757,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.31,
-        "handling": 78,
+        "balance": 0.34,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5766,10 +5766,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 91,
-        "swingDamage": 38,
+        "thrustSpeed": 92,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 80
       },
       {
         "class": "TwoHandedAxe",
@@ -5778,7 +5778,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.85,
+        "balance": 0.88,
         "handling": 86,
         "bodyArmor": 0,
         "flags": [
@@ -5790,9 +5790,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 38,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 95
+        "swingSpeed": 96
       },
       {
         "class": "OneHandedAxe",
@@ -5801,8 +5801,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.31,
-        "handling": 78,
+        "balance": 0.34,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5810,10 +5810,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 91,
-        "swingDamage": 38,
+        "thrustSpeed": 92,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 80
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -30208,9 +30208,9 @@
     "name": "Northlander Decorated Two Handed Axe",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 7183,
-    "weight": 1.26,
-    "tier": 6.860324,
+    "price": 11177,
+    "weight": 1.2,
+    "tier": 8.820229,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -30223,8 +30223,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 121,
-        "balance": 0.6,
-        "handling": 77,
+        "balance": 0.65,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30234,10 +30234,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 98,
+        "thrustSpeed": 99,
         "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -613,12 +613,12 @@
   },
   {
     "id": "crpg_aserai_2haxe_1_t3v2",
-    "name": "Short Handled Bardiche",
+    "name": "Great Bardiche",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 5060,
-    "weight": 2.82,
-    "tier": 5.590783,
+    "price": 10720,
+    "weight": 3.57,
+    "tier": 8.615792,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -632,7 +632,7 @@
         "stackAmount": 0,
         "length": 115,
         "balance": 0.47,
-        "handling": 79,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -642,8 +642,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 43,
+        "thrustSpeed": 83,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
         "swingSpeed": 84
       }
@@ -27620,7 +27620,7 @@
     ]
   },
   {
-    "id": "crpg_simple_sparth_axe_t2",
+    "id": "crpg_simple_sparth_axe_t2v2",
     "name": "Saxon Short Battle Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",

--- a/items.json
+++ b/items.json
@@ -22564,9 +22564,9 @@
     "name": "Broad Two Handed Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 2220,
-    "weight": 1.73,
-    "tier": 3.36657286,
+    "price": 3279,
+    "weight": 1.69,
+    "tier": 4.302921,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -22578,7 +22578,7 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 104,
+        "length": 109,
         "balance": 0.55,
         "handling": 79,
         "bodyArmor": 0,
@@ -22590,8 +22590,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 94,
-        "swingDamage": 39,
+        "thrustSpeed": 95,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }

--- a/items.json
+++ b/items.json
@@ -14411,7 +14411,7 @@
     "weapons": []
   },
   {
-    "id": "crpg_hooked_axe_t4",
+    "id": "crpg_hooked_axe_t4v2",
     "name": "Hooked Two Handed Axe",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
@@ -24176,9 +24176,9 @@
     "name": "Hoe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 582,
-    "weight": 1.41,
-    "tier": 1.29684281,
+    "price": 442,
+    "weight": 1.2,
+    "tier": 1.03199649,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -24191,9 +24191,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 92,
-        "balance": 0.17,
-        "handling": 74,
+        "length": 134,
+        "balance": 0.1,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24201,10 +24201,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 29,
+        "thrustSpeed": 93,
+        "swingDamage": 22,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 72
       },
       {
         "class": "TwoHandedAxe",
@@ -24212,9 +24212,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 92,
-        "balance": 0.76,
-        "handling": 82,
+        "length": 134,
+        "balance": 0.71,
+        "handling": 80,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24224,10 +24224,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 98,
-        "swingDamage": 29,
+        "thrustSpeed": 99,
+        "swingDamage": 22,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 91
       },
       {
         "class": "OneHandedAxe",
@@ -24235,9 +24235,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 92,
-        "balance": 0.17,
-        "handling": 74,
+        "length": 134,
+        "balance": 0.1,
+        "handling": 70,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24245,10 +24245,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 29,
+        "thrustSpeed": 93,
+        "swingDamage": 22,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 72
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -2365,9 +2365,9 @@
     "name": "Avalanche",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 8524,
-    "weight": 1.43,
-    "tier": 7.56724262,
+    "price": 13267,
+    "weight": 1.35,
+    "tier": 9.706127,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -2379,9 +2379,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 126,
-        "balance": 0.53,
-        "handling": 76,
+        "length": 130,
+        "balance": 0.6,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -2391,10 +2391,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 96,
+        "thrustSpeed": 98,
         "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 87
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -631,8 +631,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 115,
-        "balance": 0.64,
-        "handling": 83,
+        "balance": 0.47,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -645,7 +645,7 @@
         "thrustSpeed": 89,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 84
       }
     ]
   },
@@ -2379,9 +2379,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 138,
-        "balance": 0.5,
-        "handling": 75,
+        "length": 126,
+        "balance": 0.53,
+        "handling": 76,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -2394,7 +2394,7 @@
         "thrustSpeed": 96,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -3273,7 +3273,7 @@
   },
   {
     "id": "crpg_battania_2haxe_1_t2",
-    "name": "Square Bit Two Handed Axe",
+    "name": "Woodsman Two Handed Axe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
     "price": 3759,
@@ -3290,9 +3290,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 100,
-        "balance": 0.76,
-        "handling": 82,
+        "length": 85,
+        "balance": 0.83,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -3303,9 +3303,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 37,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -5739,7 +5739,7 @@
   },
   {
     "id": "crpg_bearded_axe_t3",
-    "name": "Bearded Axe",
+    "name": "Dane Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
     "price": 5575,
@@ -5756,9 +5756,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 112,
-        "balance": 0.16,
-        "handling": 74,
+        "length": 95,
+        "balance": 0.31,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5766,10 +5766,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 36,
+        "thrustSpeed": 91,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 79
       },
       {
         "class": "TwoHandedAxe",
@@ -5777,9 +5777,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 112,
-        "balance": 0.76,
-        "handling": 83,
+        "length": 95,
+        "balance": 0.85,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5790,9 +5790,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 36,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 95
       },
       {
         "class": "OneHandedAxe",
@@ -5800,9 +5800,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 112,
-        "balance": 0.16,
-        "handling": 74,
+        "length": 95,
+        "balance": 0.31,
+        "handling": 78,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -5810,10 +5810,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 36,
+        "thrustSpeed": 91,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 79
       }
     ]
   },
@@ -5978,7 +5978,7 @@
   },
   {
     "id": "crpg_black_heart_2haxe_t3",
-    "name": "Black Heart",
+    "name": "Black Heart Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
     "price": 3326,
@@ -5995,9 +5995,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 120,
-        "balance": 0.62,
-        "handling": 78,
+        "length": 119,
+        "balance": 0.48,
+        "handling": 75,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -6007,10 +6007,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 98,
-        "swingDamage": 36,
+        "thrustSpeed": 96,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 84
       }
     ]
   },
@@ -14412,7 +14412,7 @@
   },
   {
     "id": "crpg_hooked_axe_t4",
-    "name": "Hooked Axe",
+    "name": "Hooked Two Handed Axe",
     "culture": "Vlandia",
     "type": "TwoHandedWeapon",
     "price": 2242,
@@ -14429,9 +14429,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 117,
-        "balance": 0.65,
-        "handling": 77,
+        "length": 123,
+        "balance": 0.49,
+        "handling": 73,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -14441,10 +14441,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 99,
-        "swingDamage": 34,
+        "thrustSpeed": 98,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 84
       }
     ]
   },
@@ -18674,8 +18674,8 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
-        "balance": 0.62,
+        "length": 115,
+        "balance": 0.61,
         "handling": 78,
         "bodyArmor": 0,
         "flags": [
@@ -22561,8 +22561,8 @@
   },
   {
     "id": "crpg_northern_axe_t3",
-    "name": "Northlander Broad Axe",
-    "culture": "Sturgia",
+    "name": "Broad Two Handed Axe",
+    "culture": "Neutral",
     "type": "TwoHandedWeapon",
     "price": 7815,
     "weight": 1.44,
@@ -22578,9 +22578,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 115,
-        "balance": 0.76,
-        "handling": 83,
+        "length": 104,
+        "balance": 0.55,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -22593,7 +22593,7 @@
         "thrustSpeed": 97,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 86
       }
     ]
   },
@@ -24192,8 +24192,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.33,
-        "handling": 77,
+        "balance": 0.17,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24201,10 +24201,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 90,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 75
       },
       {
         "class": "TwoHandedAxe",
@@ -24213,8 +24213,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.88,
-        "handling": 85,
+        "balance": 0.76,
+        "handling": 82,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24224,10 +24224,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 99,
-        "swingDamage": 24,
+        "thrustSpeed": 98,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 96
+        "swingSpeed": 92
       },
       {
         "class": "OneHandedAxe",
@@ -24236,8 +24236,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.33,
-        "handling": 77,
+        "balance": 0.17,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -24245,10 +24245,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 90,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 75
       }
     ]
   },
@@ -27621,7 +27621,7 @@
   },
   {
     "id": "crpg_simple_sparth_axe_t2",
-    "name": "Simple Sparth Axe",
+    "name": "Saxon Short Battle Axe",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
     "price": 877,
@@ -27639,8 +27639,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 78,
-        "balance": 1.0,
-        "handling": 89,
+        "balance": 0.85,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -27650,10 +27650,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 100,
-        "swingDamage": 27,
+        "thrustSpeed": 98,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 102
+        "swingSpeed": 95
       }
     ]
   },
@@ -30142,9 +30142,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
+        "length": 90,
         "balance": 0.25,
-        "handling": 73,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30152,8 +30152,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 94,
-        "swingDamage": 31,
+        "thrustSpeed": 92,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
         "swingSpeed": 77
       },
@@ -30163,9 +30163,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
+        "length": 90,
         "balance": 0.81,
-        "handling": 82,
+        "handling": 83,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30175,8 +30175,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 100,
-        "swingDamage": 31,
+        "thrustSpeed": 99,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
         "swingSpeed": 94
       },
@@ -30186,9 +30186,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 111,
+        "length": 90,
         "balance": 0.25,
-        "handling": 73,
+        "handling": 74,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -30196,8 +30196,8 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 94,
-        "swingDamage": 31,
+        "thrustSpeed": 92,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
         "swingSpeed": 77
       }
@@ -30222,8 +30222,8 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 127,
-        "balance": 0.58,
+        "length": 121,
+        "balance": 0.6,
         "handling": 77,
         "bodyArmor": 0,
         "flags": [
@@ -30235,7 +30235,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 38,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
@@ -33221,9 +33221,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 132,
-        "balance": 0.4,
-        "handling": 74,
+        "length": 138,
+        "balance": 0.53,
+        "handling": 76,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -33234,10 +33234,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 95,
-        "swingDamage": 39,
+        "thrustSpeed": 97,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -654,9 +654,9 @@
     "name": "Bardiche",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 4107,
-    "weight": 1.46,
-    "tier": 4.9351,
+    "price": 7744,
+    "weight": 2.56,
+    "tier": 7.163469,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -669,8 +669,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 143,
-        "balance": 0.38,
-        "handling": 73,
+        "balance": 0.45,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -680,10 +680,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 96,
+        "thrustSpeed": 89,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -3276,9 +3276,9 @@
     "name": "Woodsman Two Handed Axe",
     "culture": "Battania",
     "type": "TwoHandedWeapon",
-    "price": 1572,
+    "price": 2287,
     "weight": 1.41,
-    "tier": 2.68337965,
+    "tier": 3.431022,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -3303,7 +3303,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 98,
-        "swingDamage": 34,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
         "swingSpeed": 94
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -51,7 +51,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_peasant_2haxe_1_t1" name="{=7phSQw5i}Hoe" crafting_template="crpg_TwoHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_peasant_2haxe_1_t1_blade" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_peasant_2haxe_1_t1_blade" Type="Blade" scale_factor="120" />
       <Piece id="crpg_peasant_2haxe_1_t1_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
@@ -204,10 +204,10 @@
       <Piece id="crpg_judgement_mace_t3_handle" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_heart_2haxe_t3" name="{=2dJ5HB8a}Black Heart" crafting_template="crpg_TwoHandedAxe" is_merchandise="false">
+  <CraftedItem id="crpg_black_heart_2haxe_t3" name="{=2dJ5HB8a}Black Heart Axe" crafting_template="crpg_TwoHandedAxe" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_black_heart_2haxe_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_black_heart_2haxe_t3_handle" Type="Handle" scale_factor="101" />
+      <Piece id="crpg_black_heart_2haxe_t3_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_reaper_falx" name="{=oXrbTRJo}Reaper" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
@@ -226,10 +226,10 @@
       <Piece id="crpg_justicier_2hsword_pommel" Type="Pommel" scale_factor="93" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_avalanche_2haxe" name="{=IClH3Pus}Avalanche" crafting_template="crpg_TwoHandedAxe" is_merchandise="false">
+  <CraftedItem id="crpg_avalanche_2haxev2" name="{=IClH3Pus}Avalanche" crafting_template="crpg_TwoHandedAxe" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_avalanche_2haxe_blade" Type="Blade" />
-      <Piece id="crpg_avalanche_2haxe_handle" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_avalanche_2haxe_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_sentinel_2hsword_abearirl" name="{=XIRtmaQt}Longsword" crafting_template="crpg_SideTwoHandedSword" is_merchandise="false">
@@ -366,40 +366,40 @@
       <Piece id="crpg_battania_axe_3_t5_handle" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_battania_2haxe_1_t2" name="{=bNABNs8O}Square Bit Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_battania_2haxe_1_t2v2" name="{=bNABNs8O}Woodsman Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_battania_2haxe_1_t2_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_battania_2haxe_1_t2_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_battania_2haxe_1_t2_handle" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_sparth_axe_t2" name="{=gJPogg0J}Simple Sparth Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_simple_sparth_axe_t2" name="{=gJPogg0J}Saxon Short Battle Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_simple_sparth_axe_t2_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_sparth_axe_t2_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_aserai_2haxe_1_t3" name="{=HECAP8QW}Short Handled Bardiche" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_aserai_2haxe_1_t3v2" name="{=HECAP8QW}Short Handled Bardiche" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_aserai_2haxe_1_t3_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_aserai_2haxe_1_t3_handle" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bearded_axe_t3" name="{=Mb0CuONB}Bearded Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_bearded_axe_t3" name="{=Mb0CuONB}Dane Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_bearded_axe_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_bearded_axe_t3_handle" Type="Handle" scale_factor="109" />
+      <Piece id="crpg_bearded_axe_t3_handle" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_northern_axe_t3" name="{=QnyD1yWB}Northlander Broad Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_northern_axe_t3v2" name="{=QnyD1yWB}Broad Two Handed Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_northern_axe_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_northern_axe_t3_handle" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_northern_axe_t3_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_2haxe_1_t4" name="{=K2Xtca1a}Short Bill" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_vlandia_2haxe_1_t4_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_vlandia_2haxe_1_t4_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_vlandia_2haxe_1_t4_handle" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_aserai_2haxe_2_t4" name="{=BAsjzOiH}Bardiche" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
@@ -414,16 +414,16 @@
       <Piece id="crpg_long_bardiche_handle" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sturgia_2haxe_1_t4" name="{=jhFSLdve}Drilled Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_sturgia_2haxe_1_t4v2" name="{=jhFSLdve}Drilled Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_sturgia_2haxe_1_t4_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_sturgia_2haxe_1_t4_handle" Type="Handle" scale_factor="96" />
+      <Piece id="crpg_sturgia_2haxe_1_t4_handle" Type="Handle" scale_factor="78" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hooked_axe_t4" name="{=P9PcIk4q}Hooked Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_hooked_axe_t4" name="{=P9PcIk4q}Hooked Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_hooked_axe_t4_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_hooked_axe_t4_handle" Type="Handle" scale_factor="128" />
+      <Piece id="crpg_hooked_axe_t4_handle" Type="Handle" scale_factor="134" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_aserai_2haxe_3_t5" name="{=hTPJXK1w}Chainbreaker" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
@@ -435,7 +435,7 @@
   <CraftedItem id="crpg_sturgia_2haxe_2_t5" name="{=cKtkyroA}Northlander Decorated Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_sturgia_2haxe_2_t5_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_sturgia_2haxe_2_t5_handle" Type="Handle" scale_factor="105" />
+      <Piece id="crpg_sturgia_2haxe_2_t5_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_western_spear_1_t2" name="{=hyq1zBg5}Simple Commoner Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
@@ -2420,7 +2420,7 @@
 	<CraftedItem id="crpg_long_greataxe" name="{=}Long Greataxe" crafting_template="crpg_TwoHandedAxe">
 		<Pieces>
 			<Piece id="crpg_long_greataxe_blade" Type="Blade" scale_factor="120"/>
-			<Piece id="crpg_long_greataxe_handle" Type="Handle" scale_factor="120"/>
+			<Piece id="crpg_long_greataxe_handle" Type="Handle" scale_factor="124"/>
 		</Pieces>
 	</CraftedItem>
   <CraftedItem id="crpg_long_hafted_spiked_mace" name="{=}Long Hafted Spiked Mace" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -229,7 +229,7 @@
   <CraftedItem id="crpg_avalanche_2haxev2" name="{=IClH3Pus}Avalanche" crafting_template="crpg_TwoHandedAxe" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_avalanche_2haxe_blade" Type="Blade" />
-      <Piece id="crpg_avalanche_2haxe_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_avalanche_2haxe_handle" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_sentinel_2hsword_abearirl" name="{=XIRtmaQt}Longsword" crafting_template="crpg_SideTwoHandedSword" is_merchandise="false">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -393,7 +393,7 @@
   <CraftedItem id="crpg_northern_axe_t3v2" name="{=QnyD1yWB}Broad Two Handed Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_northern_axe_t3_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_northern_axe_t3_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_northern_axe_t3_handle" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_vlandia_2haxe_1_t4" name="{=K2Xtca1a}Short Bill" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -52,7 +52,7 @@
   <CraftedItem id="crpg_peasant_2haxe_1_t1" name="{=7phSQw5i}Hoe" crafting_template="crpg_TwoHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_peasant_2haxe_1_t1_blade" Type="Blade" scale_factor="120" />
-      <Piece id="crpg_peasant_2haxe_1_t1_handle" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_peasant_2haxe_1_t1_handle" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_peasant_pitchfork_1_t1" name="{=oFEzCTpW}Iron Pitchfork" crafting_template="crpg_TwoHandedPolearm" modifier_group="cheap_weapon">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -378,7 +378,7 @@
       <Piece id="crpg_simple_sparth_axe_t2_handle" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_aserai_2haxe_1_t3v2" name="{=HECAP8QW}Short Handled Bardiche" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_aserai_2haxe_1_t3v2" name="{=HECAP8QW}Great Bardiche" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_aserai_2haxe_1_t3_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_aserai_2haxe_1_t3_handle" Type="Handle" scale_factor="114" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -420,7 +420,7 @@
       <Piece id="crpg_sturgia_2haxe_1_t4_handle" Type="Handle" scale_factor="78" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hooked_axe_t4" name="{=P9PcIk4q}Hooked Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_hooked_axe_t4v2" name="{=P9PcIk4q}Hooked Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_hooked_axe_t4_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_hooked_axe_t4_handle" Type="Handle" scale_factor="106" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -384,7 +384,7 @@
       <Piece id="crpg_aserai_2haxe_1_t3_handle" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bearded_axe_t3" name="{=Mb0CuONB}Dane Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_bearded_axe_t3v2" name="{=Mb0CuONB}Dane Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_bearded_axe_t3_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bearded_axe_t3_handle" Type="Handle" scale_factor="90" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -423,7 +423,7 @@
   <CraftedItem id="crpg_hooked_axe_t4" name="{=P9PcIk4q}Hooked Two Handed Axe" crafting_template="crpg_TwoHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_hooked_axe_t4_blade" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_hooked_axe_t4_handle" Type="Handle" scale_factor="134" />
+      <Piece id="crpg_hooked_axe_t4_handle" Type="Handle" scale_factor="106" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_aserai_2haxe_3_t5" name="{=hTPJXK1w}Chainbreaker" crafting_template="crpg_TwoHandedAxe" culture="Culture.aserai" modifier_group="axe">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -372,7 +372,7 @@
       <Piece id="crpg_battania_2haxe_1_t2_handle" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_sparth_axe_t2" name="{=gJPogg0J}Saxon Short Battle Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_simple_sparth_axe_t2v2" name="{=gJPogg0J}Saxon Short Battle Axe" crafting_template="crpg_TwoHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_simple_sparth_axe_t2_blade" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_sparth_axe_t2_handle" Type="Handle" scale_factor="100" />


### PR DESCRIPTION
Since axes suffer from sweet spots, lowered length on most to make it less likely to get bad swing. Increased damage to make them more dangerous and destroy shields better.  Moved 2 ugly axes (Squarebit and Northlander Broad) that noone uses to lower tiers in order to bump up some other ones.