### PR TITLE
1h sword & mace heirlooms

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -900,7 +900,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bone_crusher_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.92" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_bone_crusher_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.8" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
@@ -908,23 +908,23 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bone_crusher_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.92" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_bone_crusher_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.8" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_bone_crusher_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.92" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_bone_crusher_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.8" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_shishpar_mace_blade_h0" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.50" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_shishpar_mace_blade_h0" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="1.7" />
     </BladeData>
@@ -932,7 +932,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_shishpar_mace_blade_h1" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.50" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_shishpar_mace_blade_h1" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.44" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="1.7" />
     </BladeData>
@@ -940,17 +940,17 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_shishpar_mace_blade_h2" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.50" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_shishpar_mace_blade_h2" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.44" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_shishpar_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.50" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_shishpar_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1174,7 +1174,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_imperial_light_mace_blade_h1" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.725" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1182,15 +1182,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_imperial_light_mace_blade_h2" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.725" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_imperial_light_mace_blade_h3" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.725" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_imperial_light_mace_blade_h3" name="{=1yEQNTG1}Long Shestopyor Head" tier="4" piece_type="Blade" mesh="mace_head_3" length="18.181" weight="0.66" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.9" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1252,7 +1252,7 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_hammer_blade_h1" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_wooden_hammer_blade_h1" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="1.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="1.5" />
     </BladeData>
@@ -1264,9 +1264,9 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_hammer_blade_h2" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_wooden_hammer_blade_h2" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="1.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Swing damage_type="Blunt" damage_factor="1.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1276,9 +1276,9 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wooden_hammer_blade_h3" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_wooden_hammer_blade_h3" name="{=Dix4EYD8}Mallet Head" tier="1" piece_type="Blade" mesh="mace_head_24" length="12.6" weight="1.85" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1300,7 +1300,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.85" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.0" />
@@ -1312,10 +1312,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.8" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1324,10 +1324,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.8" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1500,7 +1500,7 @@
       <Material id="Iron3" count="5" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h1" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.238" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h1" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.1" />
     </BladeData>
@@ -1508,17 +1508,17 @@
       <Material id="Iron3" count="5" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h2" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.238" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h2" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h3" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.238" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_eastern_heavy_mace_blade_h3" name="{=fhbGCsdC}Eastern Heavy Mace Head" tier="4" piece_type="Blade" mesh="mace_head_11" length="18.3" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="5" />
@@ -1568,7 +1568,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiralled_mace_blade_h1" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_spiralled_mace_blade_h1" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
@@ -1576,17 +1576,17 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiralled_mace_blade_h2" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_spiralled_mace_blade_h2" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiralled_mace_blade_h3" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_spiralled_mace_blade_h3" name="{=rSs1M2EJ}Spiralled Mace Head" tier="4" piece_type="Blade" mesh="mace_head_15" length="13.5" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1642,15 +1642,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knights_fall_blade_h2" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.55" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knights_fall_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.55" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knights_fall_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.52" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1696,7 +1696,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fullered_light_mace_blade_h1" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.3" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+  <CraftingPiece id="crpg_fullered_light_mace_blade_h1" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.2" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
@@ -1704,17 +1704,17 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fullered_light_mace_blade_h2" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.3" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+  <CraftingPiece id="crpg_fullered_light_mace_blade_h2" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.2" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="1.9" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fullered_light_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.3" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+  <CraftingPiece id="crpg_fullered_light_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="1.15" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.8" />
+      <Swing damage_type="Blunt" damage_factor="2.0" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1794,7 +1794,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_calradic_mace_blade_h1" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1802,15 +1802,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_calradic_mace_blade_h2" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_calradic_mace_blade_h3" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_calradic_mace_blade_h3" name="{=trGnmFsh}Calradic Mace Head" tier="4" piece_type="Blade" mesh="mace_head_8" length="7" weight="0.295" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1824,7 +1824,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_mace_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_mace_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.6" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="1.5" />
     </BladeData>
@@ -1832,17 +1832,17 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_mace_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_mace_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.6" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Swing damage_type="Blunt" damage_factor="1.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_mace_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_mace_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.6" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Swing damage_type="Blunt" damage_factor="1.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1889,7 +1889,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_club_blade_h1" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.75" full_scale="true">
+  <CraftingPiece id="crpg_spiked_club_blade_h1" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.68" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Pierce" damage_factor="2.3" />
@@ -1898,19 +1898,19 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_club_blade_h2" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.75" full_scale="true">
+  <CraftingPiece id="crpg_spiked_club_blade_h2" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.68" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Pierce" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_club_blade_h3" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.75" full_scale="true">
+  <CraftingPiece id="crpg_spiked_club_blade_h3" name="{=L3vLdPJT}Improved Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_23" distance_to_next_piece="15.4" distance_to_previous_piece="8.2" weight="0.68" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20784,7 +20784,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h1" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.93">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h1" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -20796,10 +20796,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h2" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.93">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h2" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20808,10 +20808,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h3" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.93">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h3" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.69">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20870,7 +20870,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_gripped_ild_blade_h1" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.14">
+  <CraftingPiece id="crpg_tall_gripped_ild_blade_h1" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.04">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
@@ -20880,21 +20880,21 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_gripped_ild_blade_h2" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.14">
+  <CraftingPiece id="crpg_tall_gripped_ild_blade_h2" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.04">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_gripped_ild_blade_h3" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.14">
+  <CraftingPiece id="crpg_tall_gripped_ild_blade_h3" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="1.0">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
@@ -22368,7 +22368,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_broadsword_blade_h1" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.08">
+  <CraftingPiece id="crpg_steel_broadsword_blade_h1" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -22380,10 +22380,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_broadsword_blade_h2" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.08">
+  <CraftingPiece id="crpg_steel_broadsword_blade_h2" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22392,10 +22392,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_broadsword_blade_h3" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="1.08">
+  <CraftingPiece id="crpg_steel_broadsword_blade_h3" name="{=QCE1sAu3}Broadsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_3" culture="Culture.battania" length="80.8" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22728,7 +22728,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_thegn_blade_blade_h1" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_iron_thegn_blade_blade_h1" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.85">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -22740,10 +22740,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_thegn_blade_blade_h2" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_iron_thegn_blade_blade_h2" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22752,10 +22752,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_thegn_blade_blade_h3" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_iron_thegn_blade_blade_h3" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.75">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23665,7 +23665,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h1" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.82">
+  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h1" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -23674,19 +23674,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h2" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.82">
+  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h2" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h3" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.82">
+  <CraftingPiece id="crpg_fine_steel_paramerion_blade_h3" name="{=y5A3HGua}Fine Steel Paramerion Blade" tier="4" piece_type="Blade" mesh="empire_blade_5" culture="Culture.empire" length="95.7" weight="0.69">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20138,7 +20138,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_engraved_pointed_sword_blade_h3" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.02">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -20688,7 +20688,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_backsword_blade_h1" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.95">
+  <CraftingPiece id="crpg_engraved_backsword_blade_h1" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.85">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -20700,10 +20700,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_backsword_blade_h2" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.95">
+  <CraftingPiece id="crpg_engraved_backsword_blade_h2" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20712,10 +20712,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_backsword_blade_h3" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.95">
+  <CraftingPiece id="crpg_engraved_backsword_blade_h3" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21508,7 +21508,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_arming_sword_blade_h1" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.83">
+  <CraftingPiece id="crpg_short_arming_sword_blade_h1" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -21520,10 +21520,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_arming_sword_blade_h2" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.83">
+  <CraftingPiece id="crpg_short_arming_sword_blade_h2" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21532,10 +21532,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_arming_sword_blade_h3" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.83">
+  <CraftingPiece id="crpg_short_arming_sword_blade_h3" name="{=BXW4LeQT}Wide Fullered Short Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_9" culture="Culture.sturgia" length="56.1" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21998,7 +21998,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_tyrhung_blade_h2" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -22008,9 +22008,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.56">
+  <CraftingPiece id="crpg_tyrhung_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.48">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
@@ -23389,7 +23389,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_scalpel_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.88">
+  <CraftingPiece id="crpg_scalpel_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -23398,19 +23398,19 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_scalpel_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.88">
+  <CraftingPiece id="crpg_scalpel_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_scalpel_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.88">
+  <CraftingPiece id="crpg_scalpel_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -23914,7 +23914,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h2" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -23926,7 +23926,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h3" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.15">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1468,15 +1468,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h1" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h2" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h1" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
@@ -1484,9 +1476,17 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.195" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h2" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.6" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.21" full_scale="true" excluded_item_usage_features="thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -1972,9 +1972,9 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20736,7 +20736,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_long_warsword_blade_h1" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.1">
+  <CraftingPiece id="crpg_decorated_long_warsword_blade_h1" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -20748,10 +20748,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_long_warsword_blade_h2" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.1">
+  <CraftingPiece id="crpg_decorated_long_warsword_blade_h2" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20760,10 +20760,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_long_warsword_blade_h3" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="1.1">
+  <CraftingPiece id="crpg_decorated_long_warsword_blade_h3" name="{=vx2VIbmb}Decorated Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_3" culture="Culture.sturgia" length="73" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21402,7 +21402,7 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_blade_h1" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.66">
+  <CraftingPiece id="crpg_winds_fury_blade_h1" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.5">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
@@ -21412,21 +21412,21 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_blade_h2" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.66">
+  <CraftingPiece id="crpg_winds_fury_blade_h2" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.4">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_winds_fury_blade_h3" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.66">
+  <CraftingPiece id="crpg_winds_fury_blade_h3" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.4">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -22413,7 +22413,7 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h1" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.19">
+  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h1" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.8" />
@@ -22422,19 +22422,19 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h2" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.19">
+  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h2" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.06">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h3" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.19">
+  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h3" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.06">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -23425,7 +23425,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h1" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="1.15">
+  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h1" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -23434,19 +23434,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h2" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="1.15">
+  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h2" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h3" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="1.15">
+  <CraftingPiece id="crpg_narrow_fine_steel_kaskara_blade_h3" name="{=k66YIIWR}Narrow Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_1" culture="Culture.aserai" length="102.3" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -24002,9 +24002,9 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_arming_sword_blade_h2" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.32">
+  <CraftingPiece id="crpg_narrow_arming_sword_blade_h2" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.36">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
@@ -24013,7 +24013,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_narrow_arming_sword_blade_h3" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.32">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -836,7 +836,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_mace_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
@@ -844,17 +844,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_mace_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_mace_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.18" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1436,7 +1436,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knobbed_club_blade_h1" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knobbed_club_blade_h1" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.9" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
@@ -1444,17 +1444,17 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knobbed_club_blade_h2" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knobbed_club_blade_h2" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.82" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knobbed_club_blade_h3" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_knobbed_club_blade_h3" name="{=knobbedclubcraftingpiece}Knobbed Club" tier="2" piece_type="Blade" mesh="mace_head_6" length="11.4" weight="1.82" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -26142,7 +26142,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26151,18 +26151,18 @@
   <CraftingPiece id="crpg_medium_goedendag_blade_h2" name="{=}Medium Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_short_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.9" weight="0.84" full_scale="true">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_medium_goedendag_blade_h3" name="{=}Medium Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_short_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.9" weight="0.84" full_scale="true">
+  <CraftingPiece id="crpg_medium_goedendag_blade_h3" name="{=}Medium Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_short_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.9" weight="0.81" full_scale="true">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26731,7 +26731,7 @@
   <CraftingPiece id="crpg_military_hammer_blade_h1" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -26743,7 +26743,7 @@
   <CraftingPiece id="crpg_military_hammer_blade_h2" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -26752,10 +26752,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_military_hammer_blade_h3" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.38" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_military_hammer_blade_h3" name="{=}Military Hammer Head" tier="4" piece_type="Blade" mesh="military_hammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="20.4" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20112,7 +20112,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h1" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.16">
+  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h1" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.06">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -20124,10 +20124,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h2" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.16">
+  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h2" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.02">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20136,10 +20136,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h3" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.16">
+  <CraftingPiece id="crpg_engraved_pointed_sword_blade_h3" name="{=O2kPKeuK}Arming Sword Blade With Gold Engraving" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_2" culture="Culture.vlandia" length="74.5" weight="1.02">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21984,7 +21984,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_blade_h1" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.74">
+  <CraftingPiece id="crpg_tyrhung_blade_h1" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -21996,10 +21996,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_blade_h2" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.74">
+  <CraftingPiece id="crpg_tyrhung_blade_h2" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="3.1" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22008,10 +22008,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tyrhung_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.74">
+  <CraftingPiece id="crpg_tyrhung_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="3.1" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22536,7 +22536,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_warsword_blade_h1" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.0">
+  <CraftingPiece id="crpg_pointed_warsword_blade_h1" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight=".9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -22548,10 +22548,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_warsword_blade_h2" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.0">
+  <CraftingPiece id="crpg_pointed_warsword_blade_h2" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight=".82">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22560,10 +22560,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_warsword_blade_h3" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight="1.0">
+  <CraftingPiece id="crpg_pointed_warsword_blade_h3" name="{=alti0PsZ}Pointy Warsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_7" culture="Culture.sturgia" length="74.5" weight=".75">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22584,7 +22584,7 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h1" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h1" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
       <Thrust damage_type="Pierce" damage_factor="3.2" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -22596,10 +22596,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h2" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h2" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.85">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
       <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22608,10 +22608,10 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h3" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="1.0">
+  <CraftingPiece id="crpg_thamaskene_pointed_warsword_blade_h3" name="{=weIT4gUP}Fullered Narrow Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_6" culture="Culture.sturgia" length="73.7" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23157,7 +23157,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h1" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.19">
+  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h1" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_11_scabbard_11">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -23166,19 +23166,19 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h2" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.19">
+  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h2" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_11_scabbard_11">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h3" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.19">
+  <CraftingPiece id="crpg_thamaskene_steel_kaskara_blade_h3" name="{=aTnuOUCC}Thamaskene Steel Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_blade_11" culture="Culture.aserai" length="102.3" weight="1.05">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_11_scabbard_11">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
@@ -23900,7 +23900,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h1" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.3">
+  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h1" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.22">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -23912,10 +23912,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h2" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.3">
+  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h2" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23924,10 +23924,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h3" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.3">
+  <CraftingPiece id="crpg_knightly_cavalry_sword_blade_h3" name="{=C89rbAz6}Knightly Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_7" culture="Culture.vlandia" length="89.1" weight="1.15">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="3.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -23353,7 +23353,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.96">
+  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.94">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -23362,7 +23362,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.9">
+  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.94">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
       <Swing damage_type="Cut" damage_factor="3.3" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20244,7 +20244,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h0" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.80">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h0" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -20253,7 +20253,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h1" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.80">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h1" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -20262,19 +20262,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h2" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.80">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h2" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.80">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -22776,7 +22776,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h1" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.03">
+  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h1" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.91">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -22788,10 +22788,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h2" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.03">
+  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h2" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22800,10 +22800,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h3" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="1.03">
+  <CraftingPiece id="crpg_engraved_thegn_blade_blade_h3" name="{=xbB9Ga5X}Tapered Northern Blade" tier="2" piece_type="Blade" mesh="sturgian_blade_1" culture="Culture.sturgia" length="73.7" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23016,7 +23016,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.45">
+  <CraftingPiece id="crpg_straight_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -23028,10 +23028,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.45">
+  <CraftingPiece id="crpg_straight_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23040,10 +23040,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.45">
+  <CraftingPiece id="crpg_straight_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24032,7 +24032,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h1" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.35">
+  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h1" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -24044,10 +24044,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h2" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.35">
+  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h2" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24056,10 +24056,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h3" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.35">
+  <CraftingPiece id="crpg_iron_cavalry_sword_blade_h3" name="{=zCYuj3yr}Ridged Tipped Arming Sword Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_4" culture="Culture.vlandia" length="93.5" weight="1.18">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24149,7 +24149,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h1" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.35">
+  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h1" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.27">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -24158,19 +24158,19 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h2" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.35">
+  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h2" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.22">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h3" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.35">
+  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h3" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.18">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -836,15 +836,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_mace_blade_h1" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
@@ -852,9 +844,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_mace_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.18" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_mace_blade_h2" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.8" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_steel_mace_blade_h3" name="{=o2kFafbu}Eastern Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_26" length="21.4" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -26798,31 +26798,31 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h1" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.44" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h1" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.49" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h2" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.44" full_scale="true">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.4" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h2" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.49" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Blunt" damage_factor="2.8" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.46" full_scale="true">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20208,7 +20208,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h1" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.81">
+  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h1" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -20220,10 +20220,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h2" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.81">
+  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h2" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20232,10 +20232,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h3" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.81">
+  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h3" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20289,7 +20289,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h1" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h1" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.16">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_10_scabbard_10">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -20298,19 +20298,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h2" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h2" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_10_scabbard_10">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h3" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_long_kaskara_blade_h3" name="{=N1qLYlxF}Fine Steel Kaskara Blade" tier="4" piece_type="Blade" mesh="aserai_blade_10" culture="Culture.aserai" length="101" weight="1.04">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_10_scabbard_10">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -20361,7 +20361,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_blade_h1" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.01">
+  <CraftingPiece id="crpg_pointed_falchion_blade_h1" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.91">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -20370,19 +20370,19 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_blade_h2" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.01">
+  <CraftingPiece id="crpg_pointed_falchion_blade_h2" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_blade_h3" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.01">
+  <CraftingPiece id="crpg_pointed_falchion_blade_h3" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.82">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="4" />
@@ -20910,7 +20910,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h1" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.96">
+  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h1" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.89">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
@@ -20920,21 +20920,21 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h2" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.96">
+  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h2" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.89">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h3" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.96">
+  <CraftingPiece id="crpg_decorated_cavalry_saber_blade_h3" name="{=SJssgxmf}Decorated Ild Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_2" culture="Culture.khuzait" length="72.5" weight="0.86">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="2" />
@@ -21120,7 +21120,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h1" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.74">
+  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h1" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -21132,10 +21132,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h2" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.74">
+  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h2" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.59">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21144,10 +21144,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h3" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.74">
+  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h3" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21168,9 +21168,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_arming_sword_blade_h1" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.98">
+  <CraftingPiece id="crpg_decorated_arming_sword_blade_h1" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.89">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -21180,10 +21180,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_arming_sword_blade_h2" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.98">
+  <CraftingPiece id="crpg_decorated_arming_sword_blade_h2" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.86">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21192,10 +21192,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_arming_sword_blade_h3" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.98">
+  <CraftingPiece id="crpg_decorated_arming_sword_blade_h3" name="{=UKWwPPkx}Arming Sword Blade With Golden Petals Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_4" culture="Culture.vlandia" length="68" weight="0.83">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22488,7 +22488,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_long_warsword_blade_h1" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.12">
+  <CraftingPiece id="crpg_steel_long_warsword_blade_h1" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.03">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -22500,10 +22500,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_long_warsword_blade_h2" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.12">
+  <CraftingPiece id="crpg_steel_long_warsword_blade_h2" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22512,10 +22512,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_long_warsword_blade_h3" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.12">
+  <CraftingPiece id="crpg_steel_long_warsword_blade_h3" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.93">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22968,7 +22968,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.17">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -22980,10 +22980,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.17">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22992,10 +22992,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
+  <CraftingPiece id="crpg_fine_steel_cavalry_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.14">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23398,7 +23398,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_scalpel_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.76">
+  <CraftingPiece id="crpg_scalpel_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -23407,7 +23407,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_scalpel_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.68">
+  <CraftingPiece id="crpg_scalpel_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.62">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -23533,7 +23533,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h1" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.89">
+  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h1" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -23542,19 +23542,19 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h2" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.89">
+  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h2" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h3" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.89">
+  <CraftingPiece id="crpg_thamaskene_steel_spathion_blade_h3" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.72">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -1018,7 +1018,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_morningstar_blade_h1" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Pierce" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1030,7 +1030,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_light_morningstar_blade_h2" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1040,9 +1040,9 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_morningstar_blade_h3" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.48" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_morningstar_blade_h3" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.44" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1100,7 +1100,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h0" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.70" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h0" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
@@ -1108,25 +1108,25 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h1" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.70" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h1" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h2" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.70" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h2" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.7" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h3" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.70" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_flanged_mace_blade_h3" name="{=I9yrLqPc}Eastern Flanged Steel Mace Head" tier="5" piece_type="Blade" mesh="mace_head_12" length="20" weight="0.65" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1140,7 +1140,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_shestopyor_blade_h1" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.34" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_shestopyor_blade_h1" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
@@ -1148,17 +1148,17 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_shestopyor_blade_h2" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.34" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_shestopyor_blade_h2" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_shestopyor_blade_h3" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.34" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_steel_shestopyor_blade_h3" name="{=Zc2Mb991}Shestopyor Head" tier="3" piece_type="Blade" mesh="mace_head_4" length="16.5" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1349,7 +1349,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.28" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
@@ -1362,10 +1362,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.28" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1375,10 +1375,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.28" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_warhammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -1398,7 +1398,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_spiked_club_blade_h1" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.44" full_scale="true">
+  <CraftingPiece id="crpg_highland_spiked_club_blade_h1" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.39" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Pierce" damage_factor="2.5" />
@@ -1408,20 +1408,20 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_spiked_club_blade_h2" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.44" full_scale="true">
+  <CraftingPiece id="crpg_highland_spiked_club_blade_h2" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.39" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_spiked_club_blade_h3" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.44" full_scale="true">
+  <CraftingPiece id="crpg_highland_spiked_club_blade_h3" name="{=0SpLcthg}Highland Spiked Club" tier="2" piece_type="Blade" mesh="mace_head_5" length="25.5" weight="0.39" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1468,7 +1468,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h1" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h1" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
@@ -1476,17 +1476,17 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h2" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h2" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.2" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.22" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_mace_blade_h3" name="{=yWvSjlnb}Eastern Fine Steel Mace Head" tier="4" piece_type="Blade" mesh="mace_head_10" length="17.6" weight="0.195" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -1533,7 +1533,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steppe_light_mace_blade_h1" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.5" full_scale="true">
+  <CraftingPiece id="crpg_steppe_light_mace_blade_h1" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.4" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.8" />
       <Swing damage_type="Blunt" damage_factor="2.5" />
@@ -1542,19 +1542,19 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steppe_light_mace_blade_h2" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.5" full_scale="true">
+  <CraftingPiece id="crpg_steppe_light_mace_blade_h2" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.4" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.8" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steppe_light_mace_blade_h3" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.5" full_scale="true">
+  <CraftingPiece id="crpg_steppe_light_mace_blade_h3" name="{=1e9OaUWk}Eastern Light Mace Head" tier="2" piece_type="Blade" mesh="mace_head_14" length="20.8" weight="1.4" full_scale="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.8" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -1610,15 +1610,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h2" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_horsemans_mace_blade_h3" name="{=qQrmuHQ9}Heavy Horsemans Mace Head" tier="3" piece_type="Blade" mesh="mace_head_19" length="11" weight="0.3" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1664,7 +1664,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_mace_blade_h1" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.55" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_mace_blade_h1" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.45" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
@@ -1672,17 +1672,17 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_mace_blade_h2" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.55" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_mace_blade_h2" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_mace_blade_h3" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.55" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_mace_blade_h3" name="{=b9bboB3v}Southern Infantry Mace Head" tier="2" piece_type="Blade" mesh="mace_head_17" length="8.1" weight="1.4" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -1760,7 +1760,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_royal_mace_blade_h1" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.68" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_royal_mace_blade_h1" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.6" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
@@ -1768,17 +1768,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_royal_mace_blade_h2" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.68" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_royal_mace_blade_h2" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.6" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_royal_mace_blade_h3" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.68" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_light_royal_mace_blade_h3" name="{=3Q3FFqu0}Light Royal Mace Head" tier="5" piece_type="Blade" mesh="mace_head_13" length="9.2" weight="0.56" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1956,7 +1956,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.29" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
@@ -1964,17 +1964,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.29" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_militia_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1990,7 +1990,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fullered_western_mace_blade_h1" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.26" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -1998,15 +1998,15 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fullered_western_mace_blade_h2" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.26" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fullered_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.26" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fullered_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="0.24" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -26078,7 +26078,7 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -26088,17 +26088,17 @@
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_goedendag_blade_h3" name="{=}Light Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_1h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="13.3" weight="0.98" full_scale="true">
+  <CraftingPiece id="crpg_light_goedendag_blade_h3" name="{=}Light Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_1h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="13.3" weight="0.95" full_scale="true">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20640,7 +20640,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_pointed_blade_blade_h1" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.99">
+  <CraftingPiece id="crpg_highland_pointed_blade_blade_h1" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -20652,10 +20652,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_pointed_blade_blade_h2" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.99">
+  <CraftingPiece id="crpg_highland_pointed_blade_blade_h2" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.86">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20664,10 +20664,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_pointed_blade_blade_h3" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.99">
+  <CraftingPiece id="crpg_highland_pointed_blade_blade_h3" name="{=finesteelbladecraftingpiece}Highland Fine Steel Blade" tier="4" piece_type="Blade" mesh="battania_blade_3_fine_steel" culture="Culture.battania" length="80.8" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21285,7 +21285,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_pointed_sword_blade_h1" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.69">
+  <CraftingPiece id="crpg_iron_pointed_sword_blade_h1" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.62">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -21294,19 +21294,19 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_pointed_sword_blade_h2" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.69">
+  <CraftingPiece id="crpg_iron_pointed_sword_blade_h2" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_pointed_sword_blade_h3" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.69">
+  <CraftingPiece id="crpg_iron_pointed_sword_blade_h3" name="{=KFqa2uF1}Broad Two Hander Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_2" culture="Culture.vlandia" length="99" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -23993,7 +23993,7 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_arming_sword_blade_h1" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.46">
+  <CraftingPiece id="crpg_narrow_arming_sword_blade_h1" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.36">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -24002,19 +24002,19 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_arming_sword_blade_h2" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.46">
+  <CraftingPiece id="crpg_narrow_arming_sword_blade_h2" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.32">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_arming_sword_blade_h3" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.46">
+  <CraftingPiece id="crpg_narrow_arming_sword_blade_h3" name="{=OTtMvvJK}Ridged Arming Sword Blade" tier="4" piece_type="Blade" mesh="vlandian_blade_5" culture="Culture.vlandia" length="99" weight="1.32">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -19920,9 +19920,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_broadsword_blade_h1" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.28">
+  <CraftingPiece id="crpg_decorated_broadsword_blade_h1" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.18">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
@@ -19932,10 +19932,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_broadsword_blade_h2" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.28">
+  <CraftingPiece id="crpg_decorated_broadsword_blade_h2" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.18">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -19944,10 +19944,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_broadsword_blade_h3" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.28">
+  <CraftingPiece id="crpg_decorated_broadsword_blade_h3" name="{=Izstbt9y}Highland Decorated Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_2" culture="Culture.battania" length="93.2" weight="1.12">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20160,7 +20160,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h1" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.23">
+  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h1" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.12">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -20172,10 +20172,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h2" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.23">
+  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h2" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.04">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20184,10 +20184,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h3" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.23">
+  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h3" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21362,7 +21362,7 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_saber_blade_h1" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.00">
+  <CraftingPiece id="crpg_ridged_saber_blade_h1" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.9">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
@@ -21372,21 +21372,21 @@
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_saber_blade_h2" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.00">
+  <CraftingPiece id="crpg_ridged_saber_blade_h2" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.9">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_saber_blade_h3" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="1.00">
+  <CraftingPiece id="crpg_ridged_saber_blade_h3" name="{=19a3jJ1s}Ridged Great Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_8" culture="Culture.khuzait" length="99" weight="0.87">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -21936,7 +21936,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_blade_h1" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.75">
+  <CraftingPiece id="crpg_dawnbreaker_blade_h1" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="4.0" />
@@ -21948,10 +21948,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_blade_h2" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.75">
+  <CraftingPiece id="crpg_dawnbreaker_blade_h2" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.55">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21960,10 +21960,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_dawnbreaker_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.75">
+  <CraftingPiece id="crpg_dawnbreaker_blade_h3" name="{=GXhZ8NKv}Wide Fullered Northern Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_3" culture="Culture.sturgia" length="87.3" weight="0.45">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22224,7 +22224,7 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_broad_blade_blade_h1" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.93">
+  <CraftingPiece id="crpg_highland_broad_blade_blade_h1" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.85">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -22236,10 +22236,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_broad_blade_blade_h2" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.93">
+  <CraftingPiece id="crpg_highland_broad_blade_blade_h2" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.8">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22248,10 +22248,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_broad_blade_blade_h3" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.93">
+  <CraftingPiece id="crpg_highland_broad_blade_blade_h3" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.8">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22872,7 +22872,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_saber_blade_h1" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.82">
+  <CraftingPiece id="crpg_iron_saber_blade_h1" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -22884,10 +22884,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_saber_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.82">
+  <CraftingPiece id="crpg_iron_saber_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.64">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22896,10 +22896,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_saber_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.82">
+  <CraftingPiece id="crpg_iron_saber_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23064,9 +23064,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_saber_blade_h1" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.93">
+  <CraftingPiece id="crpg_heavy_saber_blade_h1" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.81">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -23076,10 +23076,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_saber_blade_h2" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.93">
+  <CraftingPiece id="crpg_heavy_saber_blade_h2" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.81">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23088,10 +23088,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_saber_blade_h3" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.93">
+  <CraftingPiece id="crpg_heavy_saber_blade_h3" name="{=C2hTDlWq}Heavy Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_2" culture="Culture.khuzait" length="94.6" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23461,7 +23461,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h1" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="1.10">
+  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h1" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="1.01">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -23470,19 +23470,19 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h2" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="1.10">
+  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h2" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="1.01">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h3" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="1.10">
+  <CraftingPiece id="crpg_thamaskene_steel_spatha_blade_h3" name="{=dafrn0mR}Thamaskene Steel Spatha Blade" tier="5" piece_type="Blade" mesh="empire_blade_7" culture="Culture.vlandia" length="99" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_7_scabbard_7">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="4" />
@@ -23620,7 +23620,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_spatha_blade_h1" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.15">
+  <CraftingPiece id="crpg_fine_steel_spatha_blade_h1" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.09">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -23632,10 +23632,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_spatha_blade_h2" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.15">
+  <CraftingPiece id="crpg_fine_steel_spatha_blade_h2" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.05">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23644,10 +23644,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_spatha_blade_h3" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.15">
+  <CraftingPiece id="crpg_fine_steel_spatha_blade_h3" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.0">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20016,9 +20016,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h1" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.82">
+  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h1" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
@@ -20028,10 +20028,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h2" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.82">
+  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h2" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20040,10 +20040,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h3" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.82">
+  <CraftingPiece id="crpg_engraved_angular_kaskara_blade_h3" name="{=RdVX1jC0}Engraved Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_3" culture="Culture.aserai" length="71" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21716,7 +21716,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_saber_blade_h1" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.9">
+  <CraftingPiece id="crpg_simple_saber_blade_h1" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.81">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -21728,10 +21728,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_saber_blade_h2" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.9">
+  <CraftingPiece id="crpg_simple_saber_blade_h2" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21740,10 +21740,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_saber_blade_h3" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.9">
+  <CraftingPiece id="crpg_simple_saber_blade_h3" name="{=czhTpYo8}Iron Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_6" culture="Culture.khuzait" length="82.5" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21764,7 +21764,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_falchion_blade_h1" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.68">
+  <CraftingPiece id="crpg_iron_falchion_blade_h1" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.59">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -21776,10 +21776,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_falchion_blade_h2" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.68">
+  <CraftingPiece id="crpg_iron_falchion_blade_h2" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.54">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21788,10 +21788,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_falchion_blade_h3" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.68">
+  <CraftingPiece id="crpg_iron_falchion_blade_h3" name="{=i7d3En7L}Hooked Falchion Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_9" length="62.59" weight="0.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_9_scabbard_9">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22632,7 +22632,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_northern_backsword_blade_h1" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.69">
+  <CraftingPiece id="crpg_northern_backsword_blade_h1" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -22644,10 +22644,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_northern_backsword_blade_h2" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.69">
+  <CraftingPiece id="crpg_northern_backsword_blade_h2" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.49">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22656,10 +22656,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_northern_backsword_blade_h3" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.69">
+  <CraftingPiece id="crpg_northern_backsword_blade_h3" name="{=bGfs8gNv}Northern Backsword Blade" tier="3" piece_type="Blade" mesh="sturgian_blade_5" culture="Culture.sturgia" length="68.2" weight="0.44">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22920,7 +22920,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.77">
+  <CraftingPiece id="crpg_broad_ild_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -22932,10 +22932,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.77">
+  <CraftingPiece id="crpg_broad_ild_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22944,10 +22944,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_ild_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.77">
+  <CraftingPiece id="crpg_broad_ild_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="0.68">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23705,7 +23705,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_warsword_blade_h1" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.09">
+  <CraftingPiece id="crpg_simple_short_warsword_blade_h1" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="0.98">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
@@ -23718,11 +23718,11 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_warsword_blade_h2" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.09">
+  <CraftingPiece id="crpg_simple_short_warsword_blade_h2" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="0.91">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23731,11 +23731,11 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_warsword_blade_h3" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="1.09">
+  <CraftingPiece id="crpg_simple_short_warsword_blade_h3" name="{=TUbTwW9U}Flat Ridged Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_4" culture="Culture.empire" length="91.3" weight="0.84">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20210,7 +20210,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_decorated_northern_backsword_blade_h1" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -20220,9 +20220,9 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h2" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.66">
+  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h2" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -20232,10 +20232,10 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h3" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.6">
+  <CraftingPiece id="crpg_decorated_northern_backsword_blade_h3" name="{=VbpiYB68}Decorated Wide Fullered Short Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_1" culture="Culture.sturgia" length="61.9" weight="0.73">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -23353,7 +23353,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.03">
+  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h1" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -23362,19 +23362,19 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.03">
+  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h2" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="1.03">
+  <CraftingPiece id="crpg_slightly_ridged_flyssa_blade_h3" name="{=v22onVb2}Slightly Ridged Flyssa Blade" tier="3" piece_type="Blade" mesh="aserai_blade_2" culture="Culture.aserai" length="105.6" weight="0.86">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -23756,9 +23756,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.18">
+  <CraftingPiece id="crpg_spatha_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.09">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
@@ -23768,10 +23768,58 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.18">
+  <CraftingPiece id="crpg_spatha_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.09">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.04">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.2">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23780,58 +23828,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.18">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.20">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.20">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.20">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.20">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20370,18 +20370,18 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_blade_h2" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.87">
+  <CraftingPiece id="crpg_pointed_falchion_blade_h2" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.91">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pointed_falchion_blade_h3" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.82">
+  <CraftingPiece id="crpg_pointed_falchion_blade_h3" name="{=YkWqmDEK}Broad Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="0.87">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
@@ -20688,9 +20688,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_backsword_blade_h1" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.85">
+  <CraftingPiece id="crpg_engraved_backsword_blade_h1" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -20700,9 +20700,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_engraved_backsword_blade_h2" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.8">
+  <CraftingPiece id="crpg_engraved_backsword_blade_h2" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.85">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -20714,8 +20714,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_engraved_backsword_blade_h3" name="{=5Xoa1EFa}Engraved Backsword Blade" tier="5" piece_type="Blade" mesh="battania_noble_blade_1" culture="Culture.battania" length="96" weight="0.8">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21132,9 +21132,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h2" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.59">
+  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h2" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.66">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -21144,9 +21144,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h3" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.56">
+  <CraftingPiece id="crpg_fine_steel_arming_sword_blade_h3" name="{=bki9u9FW}Arming Sword Blade With Golden Circle Imprint" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_1" culture="Culture.vlandia" length="74.3" weight="0.59">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -22415,25 +22415,25 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h1" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h2" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.06">
+  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h2" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h3" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.06">
+  <CraftingPiece id="crpg_fine_steel_cavalry_broadsword_blade_h3" name="{=rKnBJPfp}Fine Steel Cavalry Broadsword Blade" tier="4" piece_type="Blade" mesh="battania_blade_1" culture="Culture.battania" length="98.9" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
@@ -22500,9 +22500,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_long_warsword_blade_h2" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.98">
+  <CraftingPiece id="crpg_steel_long_warsword_blade_h2" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="1.03">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -22512,9 +22512,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_long_warsword_blade_h3" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.93">
+  <CraftingPiece id="crpg_steel_long_warsword_blade_h3" name="{=QIo60ZKh}Fullered Long Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_blade_8" culture="Culture.sturgia" length="87.3" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -23016,9 +23016,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.35">
+  <CraftingPiece id="crpg_straight_saber_blade_h1" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -23028,9 +23028,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.3">
+  <CraftingPiece id="crpg_straight_saber_blade_h2" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
@@ -23040,9 +23040,9 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_straight_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.25">
+  <CraftingPiece id="crpg_straight_saber_blade_h3" name="{=CODGBskg}Long Saber Blade" tier="3" piece_type="Blade" mesh="khuzait_blade_5" culture="Culture.khuzait" length="101.2" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -24158,7 +24158,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h2" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.22">
+  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h2" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.25">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -24167,7 +24167,7 @@
       <Material id="Iron6" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h3" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.18">
+  <CraftingPiece id="crpg_fine_steel_cavalry_sword_blade_h3" name="{=mak3naEe}Wide Fullered Broad Two Hander Blade" tier="5" piece_type="Blade" mesh="vlandian_blade_3" culture="Culture.vlandia" length="99.4" weight="1.21">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.8" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -22080,9 +22080,9 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h1" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.26">
+  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h1" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.14">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -22092,10 +22092,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h2" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.26">
+  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h2" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.14">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22104,10 +22104,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h3" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.26">
+  <CraftingPiece id="crpg_ridged_iron_broadsword_blade_h3" name="{=3Y7plSBX}Iron Broadsword Blade" tier="2" piece_type="Blade" mesh="battania_blade_3_iron" culture="Culture.battania" length="80.8" weight="1.1">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_3_scabbard_3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20162,7 +20162,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h1" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.12">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -20174,7 +20174,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h2" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.04">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
@@ -20184,9 +20184,9 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h3" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.0">
+  <CraftingPiece id="crpg_gold_bound_short_warsword_blade_h3" name="{=blaVlvm2}Decorated Short Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_4" culture="Culture.sturgia" length="74" weight="1.04">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
@@ -22236,9 +22236,9 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_broad_blade_blade_h2" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.8">
+  <CraftingPiece id="crpg_highland_broad_blade_blade_h2" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.85">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
@@ -22250,8 +22250,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_highland_broad_blade_blade_h3" name="{=swb45HVS}Mountain Blade" tier="5" piece_type="Blade" mesh="battania_blade_5" culture="Culture.battania" length="80.8" weight="0.8">
     <BladeData stack_amount="0" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_5_scabbard_5">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -22682,7 +22682,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_iron_long_warsword_blade_h1" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
@@ -22692,9 +22692,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_long_warsword_blade_h2" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.9">
+  <CraftingPiece id="crpg_iron_long_warsword_blade_h2" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
@@ -22704,9 +22704,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_long_warsword_blade_h3" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.86">
+  <CraftingPiece id="crpg_iron_long_warsword_blade_h3" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -22874,7 +22874,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_iron_saber_blade_h1" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -22884,9 +22884,9 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_saber_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.64">
+  <CraftingPiece id="crpg_iron_saber_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
@@ -22896,9 +22896,9 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_saber_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.6">
+  <CraftingPiece id="crpg_iron_saber_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.64">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -23622,7 +23622,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_spatha_blade_h1" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.09">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
@@ -23634,7 +23634,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_spatha_blade_h2" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.05">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -23644,9 +23644,9 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_spatha_blade_h3" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.0">
+  <CraftingPiece id="crpg_fine_steel_spatha_blade_h3" name="{=kIbtwQRF}Fine Steel Spatha Blade" tier="4" piece_type="Blade" mesh="empire_blade_6" culture="Culture.empire" length="92.4" weight="1.05">
     <BladeData stack_amount="3" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_6_scabbard_6">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -968,7 +968,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_morningstar_blade_h1" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_morningstar_blade_h1" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
@@ -980,9 +980,9 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_morningstar_blade_h2" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_morningstar_blade_h2" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -992,9 +992,9 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_morningstar_blade_h3" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.36" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_morningstar_blade_h3" name="{=mU8oVsFW}Morningstar Head" tier="3" piece_type="Blade" mesh="mace_head_9" length="16.7" weight="0.32" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Pierce" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -1728,7 +1728,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_mace_blade_h1" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_cataphract_mace_blade_h1" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.33" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
@@ -1736,17 +1736,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_mace_blade_h2" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_cataphract_mace_blade_h2" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.33" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cataphract_mace_blade_h3" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.35" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_cataphract_mace_blade_h3" name="{=IR8UeIRp}Cataphracts Mace Head" tier="5" piece_type="Blade" mesh="mace_head_7" length="22" weight="0.31" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -1856,7 +1856,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_judgement_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_judgement_blade_h1" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
@@ -1864,17 +1864,17 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_judgement_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_judgement_blade_h2" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.25" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_judgement_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.27" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_judgement_blade_h3" name="{=hRtzRR6C}Imperial Light Mace Head" tier="3" piece_type="Blade" mesh="mace_head_20" length="6.1" weight="0.24" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
@@ -1924,7 +1924,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.17" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_pernach_blade_h1" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.14" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
@@ -1932,17 +1932,17 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.17" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_pernach_blade_h2" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.14" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.17" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_pernach_blade_h3" name="{=cag70E1F}Pernach Head" tier="5" piece_type="Blade" mesh="mace_head_2" length="17" weight="0.1" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.7" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -2021,7 +2021,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_mace_blade_h1" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.475" full_scale="true">
+  <CraftingPiece id="crpg_spiked_mace_blade_h1" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.44" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.9" />
       <Swing damage_type="Pierce" damage_factor="2.6" />
@@ -2030,19 +2030,19 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_mace_blade_h2" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.475" full_scale="true">
+  <CraftingPiece id="crpg_spiked_mace_blade_h2" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.44" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_mace_blade_h3" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.475" full_scale="true">
+  <CraftingPiece id="crpg_spiked_mace_blade_h3" name="{=lZoqaYmx}Spiked Club Head" tier="2" piece_type="Blade" mesh="mace_head_22" distance_to_next_piece="7.6" distance_to_previous_piece="4.1" weight="0.44" full_scale="true">
     <BladeData stack_amount="0" physics_material="wood_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="0.9" />
-      <Swing damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Pierce" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="2" />
@@ -10796,7 +10796,7 @@
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.40" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10805,11 +10805,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h1" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.46">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h1" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.40" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10818,11 +10818,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.46">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.40" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10831,11 +10831,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.46">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.40" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26798,7 +26798,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h1" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.49" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h1" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.44" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
@@ -26808,21 +26808,21 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h2" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.49" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h2" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.44" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.49" full_scale="true">
+  <CraftingPiece id="crpg_warhammer_blade_h3" name="{=}Warhammer Head" tier="4" piece_type="Blade" mesh="warhammer_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" length="16.1" weight="0.4" full_scale="true">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="1" physics_material="metal_weapon" body_name="bo_mace_a">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20991,7 +20991,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h1" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.55" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h1" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.45" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_1_scabbard_1">
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
@@ -21002,9 +21002,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h2" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.55" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h2" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.45" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_1_scabbard_1">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21013,9 +21013,9 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h3" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.55" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_elite_scimitar_blade_h3" name="{=T1xFTaOf}Decorated Long Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_1" culture="Culture.aserai" length="90" weight="0.45" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_1_scabbard_1">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21036,7 +21036,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_kaskara_blade_h1" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.92">
+  <CraftingPiece id="crpg_decorated_kaskara_blade_h1" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -21048,10 +21048,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_kaskara_blade_h2" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.92">
+  <CraftingPiece id="crpg_decorated_kaskara_blade_h2" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.78">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21060,10 +21060,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_kaskara_blade_h3" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.92">
+  <CraftingPiece id="crpg_decorated_kaskara_blade_h3" name="{=gwkR6TZL}Decorated Kaskara Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_2" culture="Culture.aserai" length="93.2" weight="0.74">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21440,7 +21440,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_blade_h1" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.08" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_broad_falchion_blade_h1" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="0.98" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
@@ -21448,17 +21448,17 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_blade_h2" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.08" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_broad_falchion_blade_h2" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="0.98" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_broad_falchion_blade_h3" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="1.08" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_broad_falchion_blade_h3" name="{=G8Fb2RPa}Pointed Falchion Blade" tier="4" piece_type="Blade" mesh="cleaver_blade_3" culture="Culture.aserai" length="101" weight="0.98" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />
@@ -21472,7 +21472,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cleaver_blade_h1" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.97" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cleaver_blade_h1" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.82" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
@@ -21480,17 +21480,17 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cleaver_blade_h2" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.97" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cleaver_blade_h2" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.76" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cleaver_blade_h3" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.97" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cleaver_blade_h3" name="{=hRfqLq4V}Falchion Blade" tier="3" piece_type="Blade" mesh="cleaver_blade_1" culture="Culture.aserai" length="97.9" weight="0.67" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -21596,7 +21596,7 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_blade_h1" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.26" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_falchion_blade_h1" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.16" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
@@ -21604,17 +21604,17 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_blade_h2" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.26" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_falchion_blade_h2" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.16" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_star_falchion_blade_h3" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.26" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_star_falchion_blade_h3" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="1.12" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
@@ -21628,7 +21628,7 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_soldiers_cleaver_blade_h1" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.7" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_soldiers_cleaver_blade_h1" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.55" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
@@ -21636,17 +21636,17 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_soldiers_cleaver_blade_h2" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.7" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_soldiers_cleaver_blade_h2" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.5" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_soldiers_cleaver_blade_h3" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.7" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_soldiers_cleaver_blade_h3" name="{=gTzMtKYu}Star Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_4" culture="Culture.vlandia" length="96.8" weight="0.4" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="4" />
@@ -21665,10 +21665,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h1" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.10">
+  <CraftingPiece id="crpg_iron_spatha_blade_h1" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.01">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -21678,11 +21678,11 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h2" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.10">
+  <CraftingPiece id="crpg_iron_spatha_blade_h2" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.01">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -21691,11 +21691,11 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h3" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.10">
+  <CraftingPiece id="crpg_iron_spatha_blade_h3" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="0.97">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22824,7 +22824,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_scimitar_blade_h1" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.73" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_simple_scimitar_blade_h1" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.63" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="0" />
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -22836,10 +22836,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_scimitar_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.73" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_simple_scimitar_blade_h2" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.63" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="0" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22848,10 +22848,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_scimitar_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.73" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_simple_scimitar_blade_h3" name="{=wQGWxeCc}Thick Saber Blade" tier="2" piece_type="Blade" mesh="khuzait_blade_7" culture="Culture.khuzait" length="82.5" weight="0.63" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="0" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23192,7 +23192,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h1" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.25" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h1" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.15" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_8_scabbard_8">
       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
@@ -23200,17 +23200,17 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h2" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.25" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h2" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.15" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_8_scabbard_8">
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h3" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.25" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_fine_steel_scimitar_blade_h3" name="{=PQ8rR13R}Long Fine Steel Scimitar Blade" tier="4" piece_type="Blade" mesh="aserai_blade_8" culture="Culture.aserai" length="104.5" weight="1.15" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_8_scabbard_8">
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -23264,7 +23264,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_flyssa_blade_h1" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.22">
+  <CraftingPiece id="crpg_iron_flyssa_blade_h1" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.13">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="1.2" />
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -23276,10 +23276,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_flyssa_blade_h2" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.22">
+  <CraftingPiece id="crpg_iron_flyssa_blade_h2" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.13">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23288,10 +23288,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_flyssa_blade_h3" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.22">
+  <CraftingPiece id="crpg_iron_flyssa_blade_h3" name="{=Qw9HWSY7}Iron Flyssa Blade" tier="2" piece_type="Blade" mesh="aserai_blade_4" culture="Culture.aserai" length="104" weight="1.08">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="1.2" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23300,7 +23300,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h0" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.30" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h0" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.3" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_3_scabbard_3">
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
@@ -23311,7 +23311,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h1" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.30" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h1" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.2" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_3_scabbard_3">
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
@@ -23322,9 +23322,9 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h2" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.30" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h2" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.2" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_3_scabbard_3">
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23333,9 +23333,9 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h3" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.30" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_iron_cavalry_scimitar_blade_h3" name="{=WNch6azL}Iron Scimitar Blade" tier="2" piece_type="Blade" mesh="aserai_blade_3" culture="Culture.aserai" length="93.2" weight="1.15" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_blade_3_scabbard_3">
-      <Swing damage_type="Cut" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24286,7 +24286,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_wooden_sword_blade_h1" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="1.13" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Blunt" damage_factor="1.0" />
+      <Thrust damage_type="Blunt" damage_factor="1.2" />
       <Swing damage_type="Blunt" damage_factor="1.0" />
     </BladeData>
     <Flags>
@@ -24298,8 +24298,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_wooden_sword_blade_h2" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="1.13" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Blunt" damage_factor="1.0" />
-      <Swing damage_type="Blunt" damage_factor="1.0" />
+      <Thrust damage_type="Blunt" damage_factor="1.3" />
+      <Swing damage_type="Blunt" damage_factor="1.1" />
     </BladeData>
     <Flags>
       <Flag name="NoBlood" />
@@ -24310,8 +24310,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_wooden_sword_blade_h3" name="{=p2xjr5Bp}Wooden Blade" tier="1" piece_type="Blade" mesh="wood_blade_1" culture="Culture.empire" length="86.9" weight="1.13" is_hidden="true" CraftingCost="75">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Blunt" damage_factor="1.0" />
-      <Swing damage_type="Blunt" damage_factor="1.0" />
+      <Thrust damage_type="Blunt" damage_factor="1.3" />
+      <Swing damage_type="Blunt" damage_factor="1.3" />
     </BladeData>
     <Flags>
       <Flag name="NoBlood" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -19968,7 +19968,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h1" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="1.10">
+  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h1" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -19980,10 +19980,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h2" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="1.10">
+  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h2" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -19992,10 +19992,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h3" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="1.10">
+  <CraftingPiece id="crpg_decorated_scimitar_with_wide_grip_blade_h3" name="{=xYgJN0Ja}Decorated Scimitar Blade" tier="5" piece_type="Blade" mesh="aserai_noble_blade_4" culture="Culture.aserai" length="87.4" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="aserai_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20064,7 +20064,7 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_crescent_arming_sword_blade_h1" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.82">
+  <CraftingPiece id="crpg_crescent_arming_sword_blade_h1" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -20076,10 +20076,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_crescent_arming_sword_blade_h2" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.82">
+  <CraftingPiece id="crpg_crescent_arming_sword_blade_h2" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20088,10 +20088,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_crescent_arming_sword_blade_h3" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.82">
+  <CraftingPiece id="crpg_crescent_arming_sword_blade_h3" name="{=uuover9F}Short Arming Sword Blade" tier="5" piece_type="Blade" mesh="vlandian_noble_blade_3" culture="Culture.vlandia" length="67.5" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_noble_blade_3_scabbard_3">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20830,31 +20830,31 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h1" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.9">
+  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h1" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.81">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h2" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.9">
+  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h2" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.81">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h3" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.9">
+  <CraftingPiece id="crpg_lion_imprinted_saber_blade_h3" name="{=PqoJ1ZeB}Decorated Saber Blade" tier="5" piece_type="Blade" mesh="khuzait_noble_blade_1" culture="Culture.khuzait" length="89.5" weight="0.76">
     <BuildData previous_piece_offset="-0.25" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron6" count="3" />
@@ -21081,28 +21081,28 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_short_spatha_blade_h1" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="1.10">
+  <CraftingPiece id="crpg_decorated_short_spatha_blade_h1" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="1.01">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_short_spatha_blade_h2" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="1.10">
+  <CraftingPiece id="crpg_decorated_short_spatha_blade_h2" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="1.01">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_short_spatha_blade_h3" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="1.10">
+  <CraftingPiece id="crpg_decorated_short_spatha_blade_h3" name="{=PQThPvP6}Decorated Short Spatha Blade" tier="5" piece_type="Blade" mesh="empire_noble_blade_1" culture="Culture.empire" length="84.7" weight="0.98">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
@@ -22272,7 +22272,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h1" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.79">
+  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h1" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.4" />
@@ -22284,10 +22284,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h2" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.79">
+  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h2" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.6">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22296,10 +22296,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h3" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.79">
+  <CraftingPiece id="crpg_fine_steel_broad_shortsword_blade_h3" name="{=zAdloN6Y}Broad Ridged Shortsword Blade" tier="3" piece_type="Blade" mesh="battania_blade_4" culture="Culture.battania" length="67.4" weight="0.52">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="battania_blade_4_scabbard_4">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22680,7 +22680,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_long_warsword_blade_h1" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="1.07">
+  <CraftingPiece id="crpg_iron_long_warsword_blade_h1" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.2" />
@@ -22692,10 +22692,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_long_warsword_blade_h2" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="1.07">
+  <CraftingPiece id="crpg_iron_long_warsword_blade_h2" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -22704,10 +22704,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_long_warsword_blade_h3" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="1.07">
+  <CraftingPiece id="crpg_iron_long_warsword_blade_h3" name="{=7ZWtiHKj}Long Warsword Blade" tier="4" piece_type="Blade" mesh="sturgian_blade_2" culture="Culture.sturgia" length="86.9" weight="0.86">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_blade_2_scabbard_2">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23112,7 +23112,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_saber_blade_h1" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="1.03">
+  <CraftingPiece id="crpg_fine_steel_saber_blade_h1" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -23124,10 +23124,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_saber_blade_h2" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="1.03">
+  <CraftingPiece id="crpg_fine_steel_saber_blade_h2" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.95">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23136,10 +23136,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_saber_blade_h3" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="1.03">
+  <CraftingPiece id="crpg_fine_steel_saber_blade_h3" name="{=Ld1nfdj4}Fine Steel Saber Blade" tier="4" piece_type="Blade" mesh="khuzait_blade_1" culture="Culture.khuzait" length="92.4" weight="0.92">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="khuzait_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24188,7 +24188,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_arming_sword_blade_h1" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.96">
+  <CraftingPiece id="crpg_iron_arming_sword_blade_h1" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.81">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -24200,10 +24200,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_arming_sword_blade_h2" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.96">
+  <CraftingPiece id="crpg_iron_arming_sword_blade_h2" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.76">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -24212,10 +24212,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_arming_sword_blade_h3" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.96">
+  <CraftingPiece id="crpg_iron_arming_sword_blade_h3" name="{=q7jHkLam}Fullered Narrow Arming Sword Blade" tier="2" piece_type="Blade" mesh="vlandian_blade_1" culture="Culture.vlandia" length="94.6" weight="0.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -41400,10 +41400,17 @@
     "name": "Engraved Thegn Blade +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4997,
     "weight": 1.93,
     "rank": 1,
     "tier": 7.95805073,
+=======
+    "price": 6956,
+    "weight": 1.81,
+    "heirloomLevel": 1,
+    "tier": 9.589299,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41416,7 +41423,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 86,
-        "balance": 0.64,
+        "balance": 0.71,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
@@ -41424,10 +41431,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -41437,10 +41444,17 @@
     "name": "Engraved Thegn Blade +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3693,
     "weight": 1.93,
     "rank": 2,
     "tier": 6.686969,
+=======
+    "price": 7497,
+    "weight": 1.76,
+    "heirloomLevel": 2,
+    "tier": 9.998379,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41453,7 +41467,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 86,
-        "balance": 0.64,
+        "balance": 0.74,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
@@ -41461,10 +41475,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 32,
+        "thrustSpeed": 88,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 92
       }
     ]
   },
@@ -41474,10 +41488,17 @@
     "name": "Engraved Thegn Blade +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2814,
     "weight": 1.93,
     "rank": 3,
     "tier": 5.69777536,
+=======
+    "price": 8668,
+    "weight": 1.76,
+    "heirloomLevel": 3,
+    "tier": 10.83528,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41490,7 +41511,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 86,
-        "balance": 0.64,
+        "balance": 0.74,
         "handling": 87,
         "bodyArmor": 1,
         "flags": [
@@ -41498,10 +41519,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 32,
+        "thrustSpeed": 88,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 92
       }
     ]
   },
@@ -43150,10 +43171,17 @@
     "name": "Fine Steel Cavalry Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3702,
     "weight": 2.04,
     "rank": 1,
     "tier": 6.6959815,
+=======
+    "price": 5547,
+    "weight": 1.95,
+    "heirloomLevel": 1,
+    "tier": 8.444318,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43164,18 +43192,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.29,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 78
       }
     ]
   },
@@ -43185,10 +43213,17 @@
     "name": "Fine Steel Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2755,
     "weight": 2.04,
     "rank": 2,
     "tier": 5.62648439,
+=======
+    "price": 6125,
+    "weight": 1.9,
+    "heirloomLevel": 2,
+    "tier": 8.93003,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43199,18 +43234,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.32,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 79
       }
     ]
   },
@@ -43220,10 +43255,17 @@
     "name": "Fine Steel Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2114,
     "weight": 2.04,
     "rank": 3,
     "tier": 4.79416466,
+=======
+    "price": 6913,
+    "weight": 1.85,
+    "heirloomLevel": 3,
+    "tier": 9.556135,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43234,18 +43276,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.36,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 80
       }
     ]
   },
@@ -64211,10 +64253,17 @@
     "name": "Iron Cavalry Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2098,
     "weight": 2.16,
     "rank": 1,
     "tier": 4.77212048,
+=======
+    "price": 3235,
+    "weight": 2.05,
+    "heirloomLevel": 1,
+    "tier": 6.18787766,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64227,18 +64276,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 115,
-        "balance": 0.21,
-        "handling": 83,
+        "balance": 0.29,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 86,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 78
       }
     ]
   },
@@ -64248,10 +64297,17 @@
     "name": "Iron Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1586,
     "weight": 2.16,
     "rank": 2,
     "tier": 4.00990629,
+=======
+    "price": 3647,
+    "weight": 1.99,
+    "heirloomLevel": 2,
+    "tier": 6.63873672,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64264,18 +64320,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 115,
-        "balance": 0.21,
-        "handling": 83,
+        "balance": 0.33,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 79
       }
     ]
   },
@@ -64285,10 +64341,17 @@
     "name": "Iron Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1236,
     "weight": 2.16,
     "rank": 3,
     "tier": 3.41672635,
+=======
+    "price": 4005,
+    "weight": 1.97,
+    "heirloomLevel": 3,
+    "tier": 7.00923443,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64301,18 +64364,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 115,
-        "balance": 0.21,
-        "handling": 83,
+        "balance": 0.35,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 80
       }
     ]
   },
@@ -124585,10 +124648,17 @@
     "name": "Spatha Blade with Ring Pommel +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4996,
     "weight": 2.51,
     "rank": 1,
     "tier": 7.95747232,
+=======
+    "price": 7597,
+    "weight": 2.42,
+    "heirloomLevel": 1,
+    "tier": 10.0722523,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124599,18 +124669,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.56,
-        "handling": 89,
+        "balance": 0.63,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -124620,10 +124690,17 @@
     "name": "Spatha Blade with Ring Pommel +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3693,
     "weight": 2.51,
     "rank": 2,
     "tier": 6.68648767,
+=======
+    "price": 8262,
+    "weight": 2.38,
+    "heirloomLevel": 2,
+    "tier": 10.5513067,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124634,18 +124711,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.56,
-        "handling": 89,
+        "balance": 0.66,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 31,
+        "thrustSpeed": 84,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -124655,10 +124732,17 @@
     "name": "Spatha Blade with Ring Pommel +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2813,
     "weight": 2.51,
     "rank": 3,
     "tier": 5.69736242,
+=======
+    "price": 8047,
+    "weight": 2.38,
+    "heirloomLevel": 3,
+    "tier": 10.398489,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124669,18 +124753,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.56,
-        "handling": 89,
+        "balance": 0.66,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 31,
+        "thrustSpeed": 84,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -130391,10 +130475,17 @@
     "name": "Straight Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3003,
     "weight": 1.41,
     "rank": 1,
     "tier": 5.923041,
+=======
+    "price": 4308,
+    "weight": 1.31,
+    "heirloomLevel": 1,
+    "tier": 7.310702,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -130407,18 +130498,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.6,
+        "handling": 89,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
+        "thrustSpeed": 93,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -130428,10 +130519,17 @@
     "name": "Straight Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2247,
     "weight": 1.41,
     "rank": 2,
     "tier": 4.97699833,
+=======
+    "price": 4879,
+    "weight": 1.26,
+    "heirloomLevel": 2,
+    "tier": 7.85113525,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -130444,18 +130542,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.62,
+        "handling": 90,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 29,
+        "thrustSpeed": 93,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -130465,10 +130563,17 @@
     "name": "Straight Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1734,
     "weight": 1.41,
     "rank": 3,
     "tier": 4.24075651,
+=======
+    "price": 5673,
+    "weight": 1.22,
+    "heirloomLevel": 3,
+    "tier": 8.552039,
+>>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -130481,18 +130586,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.66,
+        "handling": 91,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 29,
+        "thrustSpeed": 94,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -44800,10 +44800,17 @@
     "name": "Fine Steel Paramerion +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5289,
     "weight": 2.47,
     "rank": 1,
     "tier": 8.219167,
+=======
+    "price": 7929,
+    "weight": 2.39,
+    "heirloomLevel": 1,
+    "tier": 10.31418,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44814,18 +44821,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.49,
-        "handling": 85,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -44835,10 +44842,17 @@
     "name": "Fine Steel Paramerion +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3904,
     "weight": 2.47,
     "rank": 2,
     "tier": 6.90638256,
+=======
+    "price": 7346,
+    "weight": 2.39,
+    "heirloomLevel": 2,
+    "tier": 9.885995,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44849,18 +44863,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.49,
-        "handling": 85,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 34,
+        "thrustSpeed": 84,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -44870,10 +44884,17 @@
     "name": "Fine Steel Paramerion +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2971,
     "weight": 2.47,
     "rank": 3,
     "tier": 5.884727,
+=======
+    "price": 8654,
+    "weight": 2.35,
+    "heirloomLevel": 3,
+    "tier": 10.8255053,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44884,18 +44905,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.49,
-        "handling": 85,
+        "balance": 0.59,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 34,
+        "thrustSpeed": 84,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -66612,10 +66633,17 @@
     "name": "Iron Thegn Blade +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2824,
     "weight": 2.0,
     "rank": 1,
     "tier": 5.710654,
+=======
+    "price": 3907,
+    "weight": 1.85,
+    "heirloomLevel": 1,
+    "tier": 6.90969372,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66628,7 +66656,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 83,
-        "balance": 0.64,
+        "balance": 0.72,
         "handling": 85,
         "bodyArmor": 1,
         "flags": [
@@ -66639,7 +66667,7 @@
         "thrustSpeed": 87,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -66649,10 +66677,17 @@
     "name": "Iron Thegn Blade +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2117,
     "weight": 2.0,
     "rank": 2,
     "tier": 4.798536,
+=======
+    "price": 4293,
+    "weight": 1.8,
+    "heirloomLevel": 2,
+    "tier": 7.29556942,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66665,7 +66700,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 83,
-        "balance": 0.64,
+        "balance": 0.75,
         "handling": 85,
         "bodyArmor": 1,
         "flags": [
@@ -66673,10 +66708,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 92
       }
     ]
   },
@@ -66686,10 +66721,17 @@
     "name": "Iron Thegn Blade +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1636,
     "weight": 2.0,
     "rank": 3,
     "tier": 4.08869267,
+=======
+    "price": 4788,
+    "weight": 1.75,
+    "heirloomLevel": 3,
+    "tier": 7.766935,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66702,7 +66744,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 83,
-        "balance": 0.64,
+        "balance": 0.77,
         "handling": 85,
         "bodyArmor": 1,
         "flags": [
@@ -66710,10 +66752,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 93
       }
     ]
   },
@@ -127518,10 +127560,17 @@
     "name": "Steel Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3039,
     "weight": 2.18,
     "rank": 1,
     "tier": 5.964445,
+=======
+    "price": 4556,
+    "weight": 2.09,
+    "heirloomLevel": 1,
+    "tier": 7.54939651,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127534,8 +127583,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.36,
-        "handling": 83,
+        "balance": 0.41,
+        "handling": 84,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -127545,7 +127594,7 @@
         "thrustSpeed": 85,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -127555,10 +127604,17 @@
     "name": "Steel Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2273,
     "weight": 2.18,
     "rank": 2,
     "tier": 5.01179,
+=======
+    "price": 4314,
+    "weight": 2.09,
+    "heirloomLevel": 2,
+    "tier": 7.31625462,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127571,18 +127627,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.36,
-        "handling": 83,
+        "balance": 0.41,
+        "handling": 84,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 35,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -127592,10 +127648,17 @@
     "name": "Steel Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1753,
     "weight": 2.18,
     "rank": 3,
     "tier": 4.270402,
+=======
+    "price": 5104,
+    "weight": 2.04,
+    "heirloomLevel": 3,
+    "tier": 8.05456,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127608,18 +127671,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.36,
-        "handling": 83,
+        "balance": 0.44,
+        "handling": 85,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 86,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -137250,10 +137313,17 @@
     "name": "Tall Gripped Ild +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5201,
     "weight": 1.71,
     "rank": 1,
     "tier": 8.141615,
+=======
+    "price": 7830,
+    "weight": 1.61,
+    "heirloomLevel": 1,
+    "tier": 10.2421312,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -137264,18 +137334,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.71,
-        "handling": 94,
+        "balance": 0.79,
+        "handling": 96,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -137285,10 +137355,17 @@
     "name": "Tall Gripped Ild +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3841,
     "weight": 1.71,
     "rank": 2,
     "tier": 6.841217,
+=======
+    "price": 7479,
+    "weight": 1.61,
+    "heirloomLevel": 2,
+    "tier": 9.984653,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -137299,18 +137376,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.71,
-        "handling": 94,
+        "balance": 0.79,
+        "handling": 96,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -137320,10 +137397,17 @@
     "name": "Tall Gripped Ild +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2924,
     "weight": 1.71,
     "rank": 3,
     "tier": 5.82920265,
+=======
+    "price": 8573,
+    "weight": 1.57,
+    "heirloomLevel": 3,
+    "tier": 10.76921,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -137334,18 +137418,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.71,
-        "handling": 94,
+        "balance": 0.82,
+        "handling": 96,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 94
       }
     ]
   },
@@ -139296,10 +139380,17 @@
     "name": "Thamaskene Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4252,
     "weight": 2.15,
     "rank": 1,
     "tier": 7.255455,
+=======
+    "price": 6018,
+    "weight": 2.0,
+    "heirloomLevel": 1,
+    "tier": 8.841901,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -139312,7 +139403,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 82,
-        "balance": 0.58,
+        "balance": 0.66,
         "handling": 83,
         "bodyArmor": 0,
         "flags": [
@@ -139320,10 +139411,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -139333,10 +139424,17 @@
     "name": "Thamaskene Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3154,
     "weight": 2.15,
     "rank": 2,
     "tier": 6.09659624,
+=======
+    "price": 6476,
+    "weight": 1.95,
+    "heirloomLevel": 2,
+    "tier": 9.213385,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -139349,7 +139447,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 82,
-        "balance": 0.58,
+        "balance": 0.68,
         "handling": 83,
         "bodyArmor": 0,
         "flags": [
@@ -139357,10 +139455,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -139370,10 +139468,17 @@
     "name": "Thamaskene Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2412,
     "weight": 2.15,
     "rank": 3,
     "tier": 5.19473362,
+=======
+    "price": 7097,
+    "weight": 1.87,
+    "heirloomLevel": 3,
+    "tier": 9.697372,
+>>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -139386,7 +139491,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 82,
-        "balance": 0.58,
+        "balance": 0.71,
         "handling": 83,
         "bodyArmor": 0,
         "flags": [
@@ -139394,10 +139499,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 91
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -16957,10 +16957,17 @@
     "name": "Blacksmith Warhammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4952,
     "weight": 2.15,
     "rank": 1,
     "tier": 7.91753864,
+=======
+    "price": 7967,
+    "weight": 2.06,
+    "heirloomLevel": 1,
+    "tier": 10.3413792,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16973,8 +16980,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 75,
-        "balance": 0.32,
-        "handling": 84,
+        "balance": 0.39,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -16982,10 +16989,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
+        "thrustSpeed": 86,
         "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -16995,10 +17002,17 @@
     "name": "Blacksmith Warhammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3661,
     "weight": 2.15,
     "rank": 2,
     "tier": 6.65293264,
+=======
+    "price": 7989,
+    "weight": 2.06,
+    "heirloomLevel": 2,
+    "tier": 10.3570261,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17011,8 +17025,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 75,
-        "balance": 0.32,
-        "handling": 84,
+        "balance": 0.39,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -17020,10 +17034,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 24,
+        "thrustSpeed": 86,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -17033,10 +17047,17 @@
     "name": "Blacksmith Warhammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2790,
     "weight": 2.15,
     "rank": 3,
     "tier": 5.66877174,
+=======
+    "price": 8113,
+    "weight": 2.06,
+    "heirloomLevel": 3,
+    "tier": 10.4461021,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17049,8 +17070,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 75,
-        "balance": 0.32,
-        "handling": 84,
+        "balance": 0.39,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -17058,10 +17079,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 24,
+        "thrustSpeed": 86,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -44655,10 +44676,17 @@
     "name": "Fine Steel Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4242,
     "weight": 1.37,
     "rank": 1,
     "tier": 7.24529552,
+=======
+    "price": 6660,
+    "weight": 1.27,
+    "heirloomLevel": 1,
+    "tier": 9.359575,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44669,18 +44697,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.44,
-        "handling": 85,
+        "balance": 0.53,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
+        "thrustSpeed": 93,
         "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -44690,10 +44718,17 @@
     "name": "Fine Steel Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3146,
     "weight": 1.37,
     "rank": 2,
     "tier": 6.088062,
+=======
+    "price": 6678,
+    "weight": 1.27,
+    "heirloomLevel": 2,
+    "tier": 9.373738,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44704,18 +44739,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.44,
-        "handling": 85,
+        "balance": 0.53,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 93,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -44725,10 +44760,17 @@
     "name": "Fine Steel Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2406,
     "weight": 1.37,
     "rank": 3,
     "tier": 5.18746042,
+=======
+    "price": 8504,
+    "weight": 1.25,
+    "heirloomLevel": 3,
+    "tier": 10.7215729,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44739,18 +44781,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.44,
-        "handling": 85,
+        "balance": 0.55,
+        "handling": 88,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 93,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -48494,10 +48536,15 @@
     "name": "Fullered Western Mace +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5031,
+    "price": 6869,
     "weight": 1.92,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 7.98907375,
+=======
+    "heirloomLevel": 1,
+    "tier": 9.522043,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48517,7 +48564,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
         "swingSpeed": 86
       }
@@ -48529,10 +48576,15 @@
     "name": "Fullered Western Mace +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 3718,
+    "price": 6803,
     "weight": 1.92,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.71304035,
+=======
+    "heirloomLevel": 2,
+    "tier": 9.47101,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48552,7 +48604,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
         "swingSpeed": 86
       }
@@ -48564,10 +48616,17 @@
     "name": "Fullered Western Mace +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2832,
     "weight": 1.92,
     "rank": 3,
     "tier": 5.719989,
+=======
+    "price": 8201,
+    "weight": 1.88,
+    "heirloomLevel": 3,
+    "tier": 10.5083361,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48578,7 +48637,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.55,
+        "balance": 0.58,
         "handling": 82,
         "bodyArmor": 0,
         "flags": [
@@ -48587,9 +48646,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 87
       }
     ]
   },
@@ -55140,10 +55199,15 @@
     "name": "Heavy Flanged Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 5226,
+    "price": 7140,
     "weight": 1.99,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 8.163455,
+=======
+    "heirloomLevel": 1,
+    "tier": 9.729882,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55163,7 +55227,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
         "swingSpeed": 88
       }
@@ -55175,10 +55239,15 @@
     "name": "Heavy Flanged Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-    "price": 3859,
+    "price": 7071,
     "weight": 1.99,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.8595705,
+=======
+    "heirloomLevel": 2,
+    "tier": 9.677736,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55198,7 +55267,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
         "swingSpeed": 88
       }
@@ -55210,10 +55279,17 @@
     "name": "Heavy Flanged Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2937,
     "weight": 1.99,
     "rank": 3,
     "tier": 5.84484,
+=======
+    "price": 8856,
+    "weight": 1.94,
+    "heirloomLevel": 3,
+    "tier": 10.9636345,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55224,8 +55300,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 74,
-        "balance": 0.61,
-        "handling": 86,
+        "balance": 0.64,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -55233,9 +55309,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 24,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 88
+        "swingSpeed": 89
       }
     ]
   },
@@ -55791,10 +55867,15 @@
     "name": "Heavy Horsemans Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 2840,
+    "price": 3828,
     "weight": 1.6,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 5.729106,
+=======
+    "heirloomLevel": 2,
+    "tier": 6.82842731,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55814,7 +55895,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 90,
-        "swingDamage": 24,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
         "swingSpeed": 82
       }
@@ -55826,10 +55907,17 @@
     "name": "Heavy Horsemans Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2177,
     "weight": 1.6,
     "rank": 3,
     "tier": 4.881606,
+=======
+    "price": 6494,
+    "weight": 1.58,
+    "heirloomLevel": 3,
+    "tier": 9.228334,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55840,8 +55928,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.43,
-        "handling": 84,
+        "balance": 0.45,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -55849,9 +55937,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 90,
-        "swingDamage": 24,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 83
       }
     ]
   },
@@ -59813,10 +59901,17 @@
     "name": "Highland Spiked Club +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1644,
     "weight": 2.19,
     "rank": 1,
     "tier": 4.10250139,
+=======
+    "price": 2501,
+    "weight": 2.12,
+    "heirloomLevel": 1,
+    "tier": 5.30998373,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -59827,8 +59922,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.38,
-        "handling": 87,
+        "balance": 0.45,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -59838,7 +59933,7 @@
         "thrustSpeed": 85,
         "swingDamage": 25,
         "swingDamageType": "Pierce",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -59848,10 +59943,17 @@
     "name": "Highland Spiked Club +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1253,
     "weight": 2.19,
     "rank": 2,
     "tier": 3.447242,
+=======
+    "price": 2473,
+    "weight": 2.12,
+    "heirloomLevel": 2,
+    "tier": 5.273571,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -59862,8 +59964,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.38,
-        "handling": 87,
+        "balance": 0.45,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -59871,9 +59973,9 @@
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 25,
+        "swingDamage": 26,
         "swingDamageType": "Pierce",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -59883,10 +59985,17 @@
     "name": "Highland Spiked Club +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 985,
     "weight": 2.19,
     "rank": 3,
     "tier": 2.93729448,
+=======
+    "price": 3214,
+    "weight": 2.12,
+    "heirloomLevel": 3,
+    "tier": 6.16421652,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -59897,8 +60006,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 92,
-        "balance": 0.38,
-        "handling": 87,
+        "balance": 0.45,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -59906,9 +60015,9 @@
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 25,
+        "swingDamage": 28,
         "swingDamageType": "Pierce",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -78365,10 +78474,15 @@
     "name": "Light Goedendag +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4177,
+    "price": 5722,
     "weight": 1.69,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 7.18120337,
+=======
+    "heirloomLevel": 1,
+    "tier": 8.59388,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78388,7 +78502,7 @@
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 23,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
         "swingSpeed": 92
       }
@@ -78400,10 +78514,15 @@
     "name": "Light Goedendag +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3099,
+    "price": 5707,
     "weight": 1.69,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.034205,
+=======
+    "heirloomLevel": 2,
+    "tier": 8.58104,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78423,7 +78542,7 @@
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 23,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
         "swingSpeed": 92
       }
@@ -78435,10 +78554,17 @@
     "name": "Light Goedendag +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2371,
     "weight": 1.69,
     "rank": 3,
     "tier": 5.14157343,
+=======
+    "price": 6822,
+    "weight": 1.66,
+    "heirloomLevel": 3,
+    "tier": 9.486297,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78449,7 +78575,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 0.76,
+        "balance": 0.78,
         "handling": 97,
         "bodyArmor": 0,
         "flags": [
@@ -78457,10 +78583,10 @@
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 23,
+        "thrustSpeed": 90,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 92
+        "swingSpeed": 93
       }
     ]
   },
@@ -78896,10 +79022,15 @@
     "name": "Light Morningstar +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4338,
+    "price": 5906,
     "weight": 1.79,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 7.340049,
+=======
+    "heirloomLevel": 1,
+    "tier": 8.748481,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -78922,7 +79053,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 88,
-        "swingDamage": 24,
+        "swingDamage": 25,
         "swingDamageType": "Pierce",
         "swingSpeed": 90
       }
@@ -78934,10 +79065,15 @@
     "name": "Light Morningstar +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 3217,
+    "price": 5850,
     "weight": 1.79,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.16768,
+=======
+    "heirloomLevel": 2,
+    "tier": 8.701598,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -78960,7 +79096,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 88,
-        "swingDamage": 24,
+        "swingDamage": 26,
         "swingDamageType": "Pierce",
         "swingSpeed": 90
       }
@@ -78972,10 +79108,17 @@
     "name": "Light Morningstar +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2459,
     "weight": 1.79,
     "rank": 3,
     "tier": 5.255302,
+=======
+    "price": 7533,
+    "weight": 1.72,
+    "heirloomLevel": 3,
+    "tier": 10.0246773,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -78988,8 +79131,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 72,
-        "balance": 0.67,
-        "handling": 94,
+        "balance": 0.73,
+        "handling": 96,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -78997,10 +79140,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 88,
-        "swingDamage": 24,
+        "thrustSpeed": 89,
+        "swingDamage": 27,
         "swingDamageType": "Pierce",
-        "swingSpeed": 90
+        "swingSpeed": 91
       }
     ]
   },
@@ -79045,10 +79188,17 @@
     "name": "Light Royal Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2140,
     "weight": 2.42,
     "rank": 1,
     "tier": 4.831107,
+=======
+    "price": 3168,
+    "weight": 2.32,
+    "heirloomLevel": 1,
+    "tier": 6.112012,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79059,18 +79209,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.42,
-        "handling": 86,
+        "balance": 0.49,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -79080,10 +79230,17 @@
     "name": "Light Royal Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1617,
     "weight": 2.42,
     "rank": 2,
     "tier": 4.059472,
+=======
+    "price": 3139,
+    "weight": 2.32,
+    "heirloomLevel": 2,
+    "tier": 6.079256,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79094,18 +79251,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.42,
-        "handling": 86,
+        "balance": 0.49,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 25,
+        "thrustSpeed": 84,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -79115,10 +79272,17 @@
     "name": "Light Royal Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1260,
     "weight": 2.42,
     "rank": 3,
     "tier": 3.45896,
+=======
+    "price": 3915,
+    "weight": 2.28,
+    "heirloomLevel": 3,
+    "tier": 6.917684,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79129,18 +79293,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.42,
-        "handling": 86,
+        "balance": 0.53,
+        "handling": 88,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 25,
+        "thrustSpeed": 85,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -86744,10 +86908,17 @@
     "name": "Militia Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 588,
     "weight": 2.48,
     "rank": 1,
     "tier": 2.03992414,
+=======
+    "price": 847,
+    "weight": 2.35,
+    "heirloomLevel": 1,
+    "tier": 2.65025067,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86758,18 +86929,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 0.33,
-        "handling": 89,
+        "balance": 0.4,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -86779,10 +86950,17 @@
     "name": "Militia Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 469,
     "weight": 2.48,
     "rank": 2,
     "tier": 1.7141031,
+=======
+    "price": 992,
+    "weight": 2.28,
+    "heirloomLevel": 2,
+    "tier": 2.95303679,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86793,18 +86971,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 0.33,
-        "handling": 89,
+        "balance": 0.43,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 24,
+        "thrustSpeed": 85,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -86814,10 +86992,17 @@
     "name": "Militia Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 384,
     "weight": 2.48,
     "rank": 3,
     "tier": 1.46053755,
+=======
+    "price": 1285,
+    "weight": 2.28,
+    "heirloomLevel": 3,
+    "tier": 3.50321651,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86828,18 +87013,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 0.33,
-        "handling": 89,
+        "balance": 0.43,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 24,
+        "thrustSpeed": 85,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -86884,10 +87069,17 @@
     "name": "Militia Pernach +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2886,
     "weight": 2.58,
     "rank": 1,
     "tier": 5.78435564,
+=======
+    "price": 4271,
+    "weight": 2.5,
+    "heirloomLevel": 1,
+    "tier": 7.274137,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86898,18 +87090,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 73,
-        "balance": 0.49,
-        "handling": 90,
+        "balance": 0.54,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 82,
+        "thrustSpeed": 83,
         "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -86919,10 +87111,17 @@
     "name": "Militia Pernach +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2162,
     "weight": 2.58,
     "rank": 2,
     "tier": 4.860465,
+=======
+    "price": 4282,
+    "weight": 2.5,
+    "heirloomLevel": 2,
+    "tier": 7.28514338,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86933,18 +87132,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 73,
-        "balance": 0.49,
-        "handling": 90,
+        "balance": 0.54,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 82,
-        "swingDamage": 24,
+        "thrustSpeed": 83,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -86954,10 +87153,17 @@
     "name": "Militia Pernach +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1669,
     "weight": 2.58,
     "rank": 3,
     "tier": 4.141461,
+=======
+    "price": 5397,
+    "weight": 2.45,
+    "heirloomLevel": 3,
+    "tier": 8.314444,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86968,18 +87174,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 73,
-        "balance": 0.49,
-        "handling": 90,
+        "balance": 0.57,
+        "handling": 92,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 82,
-        "swingDamage": 24,
+        "thrustSpeed": 84,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -129412,10 +129618,17 @@
     "name": "Steel Shestopyor +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5194,
     "weight": 1.39,
     "rank": 1,
     "tier": 8.135389,
+=======
+    "price": 8073,
+    "weight": 1.29,
+    "heirloomLevel": 1,
+    "tier": 10.4173927,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129426,18 +129639,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 80,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.62,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
+        "thrustSpeed": 93,
         "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -129447,10 +129660,17 @@
     "name": "Steel Shestopyor +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3836,
     "weight": 1.39,
     "rank": 2,
     "tier": 6.83598328,
+=======
+    "price": 8095,
+    "weight": 1.29,
+    "heirloomLevel": 2,
+    "tier": 10.4331493,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129461,18 +129681,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 80,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.62,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 93,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -129482,10 +129702,17 @@
     "name": "Steel Shestopyor +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2920,
     "weight": 1.39,
     "rank": 3,
     "tier": 5.824744,
+=======
+    "price": 8221,
+    "weight": 1.29,
+    "heirloomLevel": 3,
+    "tier": 10.5228825,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129496,18 +129723,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 80,
-        "balance": 0.53,
-        "handling": 88,
+        "balance": 0.62,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 24,
+        "thrustSpeed": 93,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -131472,10 +131699,17 @@
     "name": "Steppe Light Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1327,
     "weight": 2.15,
     "rank": 1,
     "tier": 3.5771594,
+=======
+    "price": 1949,
+    "weight": 2.05,
+    "heirloomLevel": 1,
+    "tier": 4.561429,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -131486,18 +131720,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 72,
-        "balance": 0.31,
-        "handling": 86,
+        "balance": 0.38,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 8,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -131507,10 +131741,17 @@
     "name": "Steppe Light Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1019,
     "weight": 2.15,
     "rank": 2,
     "tier": 3.005807,
+=======
+    "price": 1932,
+    "weight": 2.05,
+    "heirloomLevel": 2,
+    "tier": 4.53660965,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -131521,18 +131762,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 72,
-        "balance": 0.31,
-        "handling": 86,
+        "balance": 0.38,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 8,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 25,
+        "thrustSpeed": 87,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -131542,10 +131783,17 @@
     "name": "Steppe Light Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 807,
     "weight": 2.15,
     "rank": 3,
     "tier": 2.56116247,
+=======
+    "price": 2505,
+    "weight": 2.05,
+    "heirloomLevel": 3,
+    "tier": 5.315473,
+>>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -131556,18 +131804,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 72,
-        "balance": 0.31,
-        "handling": 86,
+        "balance": 0.38,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 8,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 25,
+        "thrustSpeed": 87,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -16808,17 +16808,10 @@
     "name": "Blacksmith Hammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 458,
-    "weight": 2.4,
-    "rank": 1,
-    "tier": 1.68400609,
-=======
     "price": 622,
     "weight": 2.25,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 2.12674212,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16852,17 +16845,10 @@
     "name": "Blacksmith Hammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 370,
-    "weight": 2.4,
-    "rank": 2,
-    "tier": 1.4150331,
-=======
     "price": 746,
     "weight": 2.2,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 2.42420173,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16896,17 +16882,10 @@
     "name": "Blacksmith Hammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 307,
-    "weight": 2.4,
-    "rank": 3,
-    "tier": 1.20570874,
-=======
     "price": 1044,
     "weight": 2.2,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 3.05443859,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16978,17 +16957,10 @@
     "name": "Blacksmith Warhammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4952,
-    "weight": 2.15,
-    "rank": 1,
-    "tier": 7.91753864,
-=======
     "price": 7967,
     "weight": 2.06,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.3413792,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17023,17 +16995,10 @@
     "name": "Blacksmith Warhammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3661,
-    "weight": 2.15,
-    "rank": 2,
-    "tier": 6.65293264,
-=======
     "price": 7989,
     "weight": 2.06,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.3570261,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -17068,17 +17033,10 @@
     "name": "Blacksmith Warhammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2790,
-    "weight": 2.15,
-    "rank": 3,
-    "tier": 5.66877174,
-=======
     "price": 8113,
     "weight": 2.06,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.4461021,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -19454,17 +19412,10 @@
     "name": "Bone Crusher +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5213,
-    "weight": 1.75,
-    "rank": 1,
-    "tier": 8.152554,
-=======
     "price": 7910,
     "weight": 1.63,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.3005533,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19496,17 +19447,10 @@
     "name": "Bone Crusher +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3850,
-    "weight": 1.75,
-    "rank": 2,
-    "tier": 6.850408,
-=======
     "price": 8159,
     "weight": 1.63,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.4784174,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19538,17 +19482,10 @@
     "name": "Bone Crusher +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2930,
-    "weight": 1.75,
-    "rank": 3,
-    "tier": 5.837035,
-=======
     "price": 8504,
     "weight": 1.63,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.7213669,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22021,17 +21958,10 @@
     "name": "Broad Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3532,
-    "weight": 1.99,
-    "rank": 1,
-    "tier": 6.514932,
-=======
     "price": 5222,
     "weight": 1.89,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.160145,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22063,17 +21993,10 @@
     "name": "Broad Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2631,
-    "weight": 1.99,
-    "rank": 2,
-    "tier": 5.474352,
-=======
     "price": 4889,
     "weight": 1.89,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.859778,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22105,17 +22028,10 @@
     "name": "Broad Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2021,
-    "weight": 1.99,
-    "rank": 3,
-    "tier": 4.66453648,
-=======
     "price": 5838,
     "weight": 1.89,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.691618,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22184,17 +22100,10 @@
     "name": "Broad Ild +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3529,
-    "weight": 2.21,
-    "rank": 1,
-    "tier": 6.51216364,
-=======
     "price": 5060,
     "weight": 2.15,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.014909,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22228,17 +22137,10 @@
     "name": "Broad Ild +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2629,
-    "weight": 2.21,
-    "rank": 2,
-    "tier": 5.472026,
-=======
     "price": 4793,
     "weight": 2.15,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.771138,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22272,17 +22174,10 @@
     "name": "Broad Ild +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2020,
-    "weight": 2.21,
-    "rank": 3,
-    "tier": 4.66255569,
-=======
     "price": 5848,
     "weight": 2.15,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.699919,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -23677,13 +23572,8 @@
     "type": "OneHandedWeapon",
     "price": 3300,
     "weight": 1.79,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 5.125899,
-=======
-    "heirloomLevel": 1,
     "tier": 6.261012,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23717,13 +23607,8 @@
     "type": "OneHandedWeapon",
     "price": 3398,
     "weight": 1.79,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 4.307178,
-=======
-    "heirloomLevel": 2,
     "tier": 6.36912251,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23755,17 +23640,10 @@
     "name": "Calradic Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1380,
-    "weight": 1.79,
-    "rank": 3,
-    "tier": 3.67002344,
-=======
     "price": 4354,
     "weight": 1.78,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.355445,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24252,17 +24130,10 @@
     "name": "Cataphract Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2236,
-    "weight": 2.07,
-    "rank": 1,
-    "tier": 4.961576,
-=======
     "price": 3495,
     "weight": 2.01,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.475282,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24294,17 +24165,10 @@
     "name": "Cataphract Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1687,
-    "weight": 2.07,
-    "rank": 2,
-    "tier": 4.16910172,
-=======
     "price": 3330,
     "weight": 2.01,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.29493952,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24336,17 +24200,10 @@
     "name": "Cataphract Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1312,
-    "weight": 2.07,
-    "rank": 3,
-    "tier": 3.5523715,
-=======
     "price": 4120,
     "weight": 1.96,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.125106,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -27745,17 +27602,10 @@
     "name": "Crescent Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3537,
-    "weight": 2.2,
-    "rank": 1,
-    "tier": 6.52059174,
-=======
     "price": 4988,
     "weight": 2.05,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.950447,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27789,17 +27639,10 @@
     "name": "Crescent Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2635,
-    "weight": 2.2,
-    "rank": 2,
-    "tier": 5.47910833,
-=======
     "price": 5429,
     "weight": 1.99,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.342169,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27833,17 +27676,10 @@
     "name": "Crescent Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2024,
-    "weight": 2.2,
-    "rank": 3,
-    "tier": 4.668589,
-=======
     "price": 5999,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.826276,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30598,17 +30434,10 @@
     "name": "Dawnbreaker +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4863,
-    "weight": 2.39,
-    "rank": 1,
-    "tier": 7.835578,
-=======
     "price": 7099,
     "weight": 2.23,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.699391,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30642,17 +30471,10 @@
     "name": "Dawnbreaker +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3596,
-    "weight": 2.39,
-    "rank": 2,
-    "tier": 6.58406353,
-=======
     "price": 7564,
     "weight": 2.18,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.0479565,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30686,17 +30508,10 @@
     "name": "Dawnbreaker +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2741,
-    "weight": 2.39,
-    "rank": 3,
-    "tier": 5.610091,
-=======
     "price": 8202,
     "weight": 2.07,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.5090961,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30767,17 +30582,10 @@
     "name": "Decorated Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5136,
-    "weight": 2.03,
-    "rank": 1,
-    "tier": 8.08350849,
-=======
     "price": 6584,
     "weight": 1.91,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.299291,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30811,17 +30619,10 @@
     "name": "Decorated Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3794,
-    "weight": 2.03,
-    "rank": 2,
-    "tier": 6.7923913,
-=======
     "price": 7324,
     "weight": 1.88,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.868801,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30855,17 +30656,10 @@
     "name": "Decorated Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2889,
-    "weight": 2.03,
-    "rank": 3,
-    "tier": 5.78759861,
-=======
     "price": 8330,
     "weight": 1.84,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.5998373,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30936,17 +30730,10 @@
     "name": "Decorated Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5173,
-    "weight": 2.25,
-    "rank": 1,
-    "tier": 8.117065,
-=======
     "price": 8086,
     "weight": 2.15,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.4265194,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30980,17 +30767,10 @@
     "name": "Decorated Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3821,
-    "weight": 2.25,
-    "rank": 2,
-    "tier": 6.8205924,
-=======
     "price": 7316,
     "weight": 2.15,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.863284,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31024,17 +30804,10 @@
     "name": "Decorated Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2909,
-    "weight": 2.25,
-    "rank": 3,
-    "tier": 5.811629,
-=======
     "price": 8520,
     "weight": 2.09,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.7326221,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31103,17 +30876,10 @@
     "name": "Decorated Cavalry Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4697,
-    "weight": 2.37,
-    "rank": 1,
-    "tier": 7.682463,
-=======
     "price": 7171,
     "weight": 2.27,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.753942,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31145,17 +30911,10 @@
     "name": "Decorated Cavalry Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3477,
-    "weight": 2.37,
-    "rank": 2,
-    "tier": 6.45540142,
-=======
     "price": 6652,
     "weight": 2.27,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.353273,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31187,17 +30946,10 @@
     "name": "Decorated Cavalry Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2652,
-    "weight": 2.37,
-    "rank": 3,
-    "tier": 5.50046253,
-=======
     "price": 7902,
     "weight": 2.22,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.2945747,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -31586,17 +31338,10 @@
     "name": "Decorated Elite Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5308,
-    "weight": 2.35,
-    "rank": 1,
-    "tier": 8.236036,
-=======
     "price": 7840,
     "weight": 2.25,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.24925,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31630,17 +31375,10 @@
     "name": "Decorated Elite Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3918,
-    "weight": 2.35,
-    "rank": 2,
-    "tier": 6.920559,
-=======
     "price": 7328,
     "weight": 2.25,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.871988,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31674,17 +31412,10 @@
     "name": "Decorated Elite Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2981,
-    "weight": 2.35,
-    "rank": 3,
-    "tier": 5.896807,
-=======
     "price": 8787,
     "weight": 2.25,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.9167919,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32163,17 +31894,10 @@
     "name": "Decorated Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5323,
-    "weight": 1.9,
-    "rank": 1,
-    "tier": 8.249861,
-=======
     "price": 8139,
     "weight": 1.77,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.4640341,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32207,17 +31931,10 @@
     "name": "Decorated Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3929,
-    "weight": 1.9,
-    "rank": 2,
-    "tier": 6.932177,
-=======
     "price": 7593,
     "weight": 1.77,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.0691195,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32251,17 +31968,10 @@
     "name": "Decorated Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2990,
-    "weight": 1.9,
-    "rank": 3,
-    "tier": 5.90670824,
-=======
     "price": 8557,
     "weight": 1.74,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.75799,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32332,17 +32042,10 @@
     "name": "Decorated Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4879,
-    "weight": 2.08,
-    "rank": 1,
-    "tier": 7.85095835,
-=======
     "price": 7572,
     "weight": 1.95,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.0533495,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32376,17 +32079,10 @@
     "name": "Decorated Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3608,
-    "weight": 2.08,
-    "rank": 2,
-    "tier": 6.59698248,
-=======
     "price": 7099,
     "weight": 1.95,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.699401,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32420,17 +32116,10 @@
     "name": "Decorated Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2750,
-    "weight": 2.08,
-    "rank": 3,
-    "tier": 5.6211,
-=======
     "price": 8093,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.4318752,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32693,24 +32382,10 @@
     "name": "Decorated Northern Backsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 5191,
-    "weight": 1.86,
-    "rank": 1,
-    "tier": 8.13249,
-=======
-    "price": 7234,
-    "weight": 1.76,
-    "heirloomLevel": 1,
-    "tier": 9.801615,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 7464,
     "weight": 1.76,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.973673,
->>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32744,24 +32419,10 @@
     "name": "Decorated Northern Backsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3833,
-    "weight": 1.86,
-    "rank": 2,
-    "tier": 6.833552,
-=======
-    "price": 7887,
-    "weight": 1.68,
-    "heirloomLevel": 2,
-    "tier": 10.2837458,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 7125,
     "weight": 1.76,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.718939,
->>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32795,24 +32456,10 @@
     "name": "Decorated Northern Backsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2918,
-    "weight": 1.86,
-    "rank": 3,
-    "tier": 5.82267332,
-=======
-    "price": 9147,
-    "weight": 1.6,
-    "heirloomLevel": 3,
-    "tier": 11.161087,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 8609,
     "weight": 1.76,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.7944517,
->>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32883,17 +32530,10 @@
     "name": "Decorated Scimitar with Wide Grip +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5299,
-    "weight": 2.06,
-    "rank": 1,
-    "tier": 8.22874,
-=======
     "price": 7857,
     "weight": 1.95,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.26215,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32927,17 +32567,10 @@
     "name": "Decorated Scimitar with Wide Grip +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3912,
-    "weight": 2.06,
-    "rank": 2,
-    "tier": 6.91442776,
-=======
     "price": 7380,
     "weight": 1.95,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.911118,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32971,17 +32604,10 @@
     "name": "Decorated Scimitar with Wide Grip +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2977,
-    "weight": 2.06,
-    "rank": 3,
-    "tier": 5.89158535,
-=======
     "price": 8749,
     "weight": 1.91,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.8910208,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -33050,17 +32676,10 @@
     "name": "Decorated Short Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5292,
-    "weight": 1.8,
-    "rank": 1,
-    "tier": 8.22242451,
-=======
     "price": 7965,
     "weight": 1.71,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.3397827,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -33092,17 +32711,10 @@
     "name": "Decorated Short Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3907,
-    "weight": 1.8,
-    "rank": 2,
-    "tier": 6.90912,
-=======
     "price": 7588,
     "weight": 1.71,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.0655518,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -33134,17 +32746,10 @@
     "name": "Decorated Short Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2973,
-    "weight": 1.8,
-    "rank": 3,
-    "tier": 5.887063,
-=======
     "price": 8703,
     "weight": 1.68,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.8589611,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37205,17 +36810,10 @@
     "name": "Eastern Heavy Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5199,
-    "weight": 1.46,
-    "rank": 1,
-    "tier": 8.139377,
-=======
     "price": 7586,
     "weight": 1.39,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.0640364,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37247,17 +36845,10 @@
     "name": "Eastern Heavy Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3839,
-    "weight": 1.46,
-    "rank": 2,
-    "tier": 6.839338,
-=======
     "price": 7950,
     "weight": 1.39,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.3292694,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37289,17 +36880,10 @@
     "name": "Eastern Heavy Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2922,
-    "weight": 1.46,
-    "rank": 3,
-    "tier": 5.82760143,
-=======
     "price": 8409,
     "weight": 1.39,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6551037,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -41372,17 +40956,10 @@
     "name": "Engraved Angular Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5231,
-    "weight": 2.14,
-    "rank": 1,
-    "tier": 8.168509,
-=======
     "price": 7913,
     "weight": 2.04,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.3023968,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41416,17 +40993,10 @@
     "name": "Engraved Angular Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3863,
-    "weight": 2.14,
-    "rank": 2,
-    "tier": 6.863819,
-=======
     "price": 7559,
     "weight": 2.04,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.0437679,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41460,17 +41030,10 @@
     "name": "Engraved Angular Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2940,
-    "weight": 2.14,
-    "rank": 3,
-    "tier": 5.84846,
-=======
     "price": 8681,
     "weight": 1.98,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.843915,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41541,22 +41104,9 @@
     "name": "Engraved Backsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 5094,
-    "weight": 2.03,
-    "rank": 1,
-    "tier": 8.045635,
-=======
-    "price": 7580,
-    "weight": 1.93,
-    "heirloomLevel": 1,
-    "tier": 10.0598507,
->>>>>>> e19d1a9 (fixes)
-=======
     "price": 6364,
     "weight": 1.98,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.124187,
     "requirement": 0,
     "flags": [
@@ -41587,14 +41137,14 @@
   },
   {
     "id": "crpg_engraved_backsword_h2",
+    "baseId": "crpg_engraved_backsword",
     "name": "Engraved Backsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
     "price": 7440,
     "weight": 1.93,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.955603,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41613,55 +41163,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 24,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 34,
-        "swingDamageType": "Cut",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
-    "id": "crpg_engraved_backsword_h2",
-    "baseId": "crpg_engraved_backsword",
-    "name": "Engraved Backsword +2",
-    "culture": "Battania",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3763,
-    "weight": 2.03,
-    "rank": 2,
-    "tier": 6.76056576,
-=======
-    "price": 8153,
-    "weight": 1.89,
-    "heirloomLevel": 2,
-    "tier": 10.4744015,
->>>>>>> e19d1a9 (fixes)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 107,
-        "balance": 0.55,
-        "handling": 83,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 24,
-=======
         "thrustDamage": 26,
->>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 35,
@@ -41676,24 +41178,10 @@
     "name": "Engraved Backsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2866,
-    "weight": 2.03,
-    "rank": 3,
-    "tier": 5.760485,
-=======
-    "price": 9197,
-    "weight": 1.89,
-    "heirloomLevel": 3,
-    "tier": 11.1944332,
->>>>>>> e19d1a9 (fixes)
-=======
     "price": 8471,
     "weight": 1.89,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6980534,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41840,13 +41328,8 @@
     "type": "OneHandedWeapon",
     "price": 8791,
     "weight": 1.6,
-<<<<<<< HEAD
     "rank": 3,
-    "tier": 10.4352427,
-=======
-    "heirloomLevel": 3,
     "tier": 10.9196434,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41917,17 +41400,10 @@
     "name": "Engraved Thegn Blade +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4997,
-    "weight": 1.93,
-    "rank": 1,
-    "tier": 7.95805073,
-=======
     "price": 6956,
     "weight": 1.81,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.589299,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41961,17 +41437,10 @@
     "name": "Engraved Thegn Blade +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3693,
-    "weight": 1.93,
-    "rank": 2,
-    "tier": 6.686969,
-=======
     "price": 7497,
     "weight": 1.76,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.998379,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42005,17 +41474,10 @@
     "name": "Engraved Thegn Blade +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2814,
-    "weight": 1.93,
-    "rank": 3,
-    "tier": 5.69777536,
-=======
     "price": 8668,
     "weight": 1.76,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.83528,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43106,17 +42568,10 @@
     "name": "Fine Steel Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4392,
-    "weight": 2.11,
-    "rank": 1,
-    "tier": 7.39236736,
-=======
     "price": 6543,
     "weight": 2.01,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.266528,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43150,22 +42605,9 @@
     "name": "Fine Steel Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3256,
-    "weight": 2.11,
-    "rank": 2,
-    "tier": 6.21164227,
-=======
-    "price": 7112,
-    "weight": 1.92,
-    "heirloomLevel": 2,
-    "tier": 9.709291,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 6156,
     "weight": 2.01,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.95559,
     "requirement": 0,
     "flags": [
@@ -43196,14 +42638,14 @@
   },
   {
     "id": "crpg_fine_steel_arming_sword_h3",
+    "baseId": "crpg_fine_steel_arming_sword",
     "name": "Fine Steel Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
     "price": 7268,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.827183,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43222,55 +42664,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 22,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 34,
-        "swingDamageType": "Cut",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_fine_steel_arming_sword_h3",
-    "baseId": "crpg_fine_steel_arming_sword",
-    "name": "Fine Steel Arming Sword +3",
-    "culture": "Vlandia",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2488,
-    "weight": 2.11,
-    "rank": 3,
-    "tier": 5.29276037,
-=======
-    "price": 7879,
-    "weight": 1.88,
-    "heirloomLevel": 3,
-    "tier": 10.2775841,
->>>>>>> 150f2d5 (0203)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 105,
-        "balance": 0.61,
-        "handling": 84,
-        "bodyArmor": 5,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 22,
-=======
         "thrustDamage": 25,
->>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 35,
@@ -43322,17 +42716,10 @@
     "name": "Fine Steel Broad Shortsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3907,
-    "weight": 2.22,
-    "rank": 1,
-    "tier": 6.90941525,
-=======
     "price": 5717,
     "weight": 2.07,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.589457,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43366,17 +42753,10 @@
     "name": "Fine Steel Broad Shortsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2904,
-    "weight": 2.22,
-    "rank": 2,
-    "tier": 5.805825,
-=======
     "price": 6192,
     "weight": 2.01,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.984725,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43410,17 +42790,10 @@
     "name": "Fine Steel Broad Shortsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2225,
-    "weight": 2.22,
-    "rank": 3,
-    "tier": 4.94697857,
-=======
     "price": 6796,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.465937,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43489,24 +42862,10 @@
     "name": "Fine Steel Cavalry Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3646,
-    "weight": 2.33,
-    "rank": 1,
-    "tier": 6.63714838,
-=======
-    "price": 5833,
-    "weight": 2.23,
-    "heirloomLevel": 1,
-    "tier": 8.687544,
->>>>>>> 8c8f0e2 (1723)
-=======
     "price": 6089,
     "weight": 2.23,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.900615,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43538,24 +42897,10 @@
     "name": "Fine Steel Cavalry Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2714,
-    "weight": 2.33,
-    "rank": 2,
-    "tier": 5.57705,
-=======
-    "price": 6242,
-    "weight": 2.19,
-    "heirloomLevel": 2,
-    "tier": 9.025386,
->>>>>>> 8c8f0e2 (1723)
-=======
     "price": 5377,
     "weight": 2.23,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.297085,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43587,24 +42932,10 @@
     "name": "Fine Steel Cavalry Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2083,
-    "weight": 2.33,
-    "rank": 3,
-    "tier": 4.75204372,
-=======
-    "price": 6748,
-    "weight": 2.19,
-    "heirloomLevel": 3,
-    "tier": 9.428659,
->>>>>>> 8c8f0e2 (1723)
-=======
     "price": 6027,
     "weight": 2.23,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.849361,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43673,17 +43004,10 @@
     "name": "Fine Steel Cavalry Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3740,
-    "weight": 2.23,
-    "rank": 1,
-    "tier": 6.736767,
-=======
     "price": 5898,
     "weight": 2.14,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.742244,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43717,17 +43041,10 @@
     "name": "Fine Steel Cavalry Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2783,
-    "weight": 2.23,
-    "rank": 2,
-    "tier": 5.660756,
-=======
     "price": 5476,
     "weight": 2.14,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.38256,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43761,17 +43078,10 @@
     "name": "Fine Steel Cavalry Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2135,
-    "weight": 2.23,
-    "rank": 3,
-    "tier": 4.823366,
-=======
     "price": 6238,
     "weight": 2.11,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.021925,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43840,17 +43150,10 @@
     "name": "Fine Steel Cavalry Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3702,
-    "weight": 2.04,
-    "rank": 1,
-    "tier": 6.6959815,
-=======
     "price": 5547,
     "weight": 1.95,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.444318,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43882,24 +43185,10 @@
     "name": "Fine Steel Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2755,
-    "weight": 2.04,
-    "rank": 2,
-    "tier": 5.62648439,
-=======
-    "price": 6125,
-    "weight": 1.9,
-    "heirloomLevel": 2,
-    "tier": 8.93003,
->>>>>>> 050a4f8 (0130)
-=======
     "price": 5873,
     "weight": 1.93,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.721147,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43931,24 +43220,10 @@
     "name": "Fine Steel Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2114,
-    "weight": 2.04,
-    "rank": 3,
-    "tier": 4.79416466,
-=======
-    "price": 6913,
-    "weight": 1.85,
-    "heirloomLevel": 3,
-    "tier": 9.556135,
->>>>>>> 050a4f8 (0130)
-=======
     "price": 6629,
     "weight": 1.89,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.335194,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44595,17 +43870,10 @@
     "name": "Fine Steel Long Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1679,
-    "weight": 1.8,
-    "rank": 1,
-    "tier": 4.157275,
-=======
     "price": 2409,
     "weight": 1.72,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.191718,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44637,17 +43905,10 @@
     "name": "Fine Steel Long Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1279,
-    "weight": 1.8,
-    "rank": 2,
-    "tier": 3.49326754,
-=======
     "price": 2757,
     "weight": 1.66,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.62910938,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44679,17 +43940,10 @@
     "name": "Fine Steel Long Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1004,
-    "weight": 1.8,
-    "rank": 3,
-    "tier": 2.976512,
-=======
     "price": 3230,
     "weight": 1.6,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.18233347,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44756,24 +44010,10 @@
     "name": "Fine Steel Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 4242,
-    "weight": 1.37,
-    "rank": 1,
-    "tier": 7.24529552,
-=======
-    "price": 6660,
-    "weight": 1.27,
-    "heirloomLevel": 1,
-    "tier": 9.359575,
->>>>>>> 617d082 (1507)
-=======
     "price": 5771,
     "weight": 1.37,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.635548,
->>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44805,24 +44045,10 @@
     "name": "Fine Steel Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3146,
-    "weight": 1.37,
-    "rank": 2,
-    "tier": 6.088062,
-=======
-    "price": 6678,
-    "weight": 1.27,
-    "heirloomLevel": 2,
-    "tier": 9.373738,
->>>>>>> 617d082 (1507)
-=======
     "price": 5717,
     "weight": 1.37,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.589266,
->>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44854,24 +44080,10 @@
     "name": "Fine Steel Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2406,
-    "weight": 1.37,
-    "rank": 3,
-    "tier": 5.18746042,
-=======
-    "price": 8504,
-    "weight": 1.25,
-    "heirloomLevel": 3,
-    "tier": 10.7215729,
->>>>>>> 617d082 (1507)
-=======
     "price": 7221,
     "weight": 1.32,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.7913,
->>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45090,17 +44302,10 @@
     "name": "Fine Steel Paramerion +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5289,
-    "weight": 2.47,
-    "rank": 1,
-    "tier": 8.219167,
-=======
     "price": 7929,
     "weight": 2.39,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.31418,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45132,17 +44337,10 @@
     "name": "Fine Steel Paramerion +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3904,
-    "weight": 2.47,
-    "rank": 2,
-    "tier": 6.90638256,
-=======
     "price": 7346,
     "weight": 2.39,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.885995,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45174,17 +44372,10 @@
     "name": "Fine Steel Paramerion +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2971,
-    "weight": 2.47,
-    "rank": 3,
-    "tier": 5.884727,
-=======
     "price": 8654,
     "weight": 2.35,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.8255053,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45253,17 +44444,10 @@
     "name": "Fine Steel Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4079,
-    "weight": 1.97,
-    "rank": 1,
-    "tier": 7.08412457,
-=======
     "price": 5939,
     "weight": 1.89,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.775941,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45297,17 +44481,10 @@
     "name": "Fine Steel Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3029,
-    "weight": 1.97,
-    "rank": 2,
-    "tier": 5.952631,
-=======
     "price": 5663,
     "weight": 1.89,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.543802,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45341,17 +44518,10 @@
     "name": "Fine Steel Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2318,
-    "weight": 1.97,
-    "rank": 3,
-    "tier": 5.07206631,
-=======
     "price": 6788,
     "weight": 1.86,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.45975,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45420,17 +44590,10 @@
     "name": "Fine Steel Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4208,
-    "weight": 1.5,
-    "rank": 1,
-    "tier": 7.2121377,
-=======
     "price": 6148,
     "weight": 1.42,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.948861,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45462,17 +44625,10 @@
     "name": "Fine Steel Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3122,
-    "weight": 1.5,
-    "rank": 2,
-    "tier": 6.06019974,
-=======
     "price": 5798,
     "weight": 1.42,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.65814,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45504,17 +44660,10 @@
     "name": "Fine Steel Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2388,
-    "weight": 1.5,
-    "rank": 3,
-    "tier": 5.163722,
-=======
     "price": 7038,
     "weight": 1.42,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.652838,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45583,24 +44732,10 @@
     "name": "Fine Steel Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2110,
-    "weight": 1.91,
-    "rank": 1,
-    "tier": 4.78916025,
-=======
-    "price": 3066,
-    "weight": 1.84,
-    "heirloomLevel": 1,
-    "tier": 5.995843,
->>>>>>> cbed0ab (1808)
-=======
     "price": 3174,
     "weight": 1.84,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.119334,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45634,24 +44769,10 @@
     "name": "Fine Steel Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 1595,
-    "weight": 1.91,
-    "rank": 2,
-    "tier": 4.024225,
-=======
-    "price": 3526,
-    "weight": 1.8,
-    "heirloomLevel": 2,
-    "tier": 6.508357,
->>>>>>> cbed0ab (1808)
-=======
     "price": 3770,
     "weight": 1.8,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.76727057,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45685,24 +44806,10 @@
     "name": "Fine Steel Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 1243,
-    "weight": 1.91,
-    "rank": 3,
-    "tier": 3.428925,
-=======
-    "price": 4139,
-    "weight": 1.75,
-    "heirloomLevel": 3,
-    "tier": 7.143512,
->>>>>>> cbed0ab (1808)
-=======
     "price": 3710,
     "weight": 1.8,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.705321,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -48497,17 +47604,10 @@
     "name": "Fullered Light Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 839,
-    "weight": 1.72,
-    "rank": 1,
-    "tier": 2.632216,
-=======
     "price": 1144,
     "weight": 1.62,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 3.246553,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48539,17 +47639,10 @@
     "name": "Fullered Light Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 657,
-    "weight": 1.72,
-    "rank": 2,
-    "tier": 2.21179271,
-=======
     "price": 1250,
     "weight": 1.62,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 3.44202423,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48581,17 +47674,10 @@
     "name": "Fullered Light Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 530,
-    "weight": 1.72,
-    "rank": 3,
-    "tier": 1.88460445,
-=======
     "price": 1640,
     "weight": 1.57,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 4.095804,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48660,13 +47746,8 @@
     "type": "OneHandedWeapon",
     "price": 6869,
     "weight": 1.92,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 7.98907375,
-=======
-    "heirloomLevel": 1,
     "tier": 9.522043,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48700,13 +47781,8 @@
     "type": "OneHandedWeapon",
     "price": 6803,
     "weight": 1.92,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.71304035,
-=======
-    "heirloomLevel": 2,
     "tier": 9.47101,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48738,17 +47814,10 @@
     "name": "Fullered Western Mace +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2832,
-    "weight": 1.92,
-    "rank": 3,
-    "tier": 5.719989,
-=======
     "price": 8201,
     "weight": 1.88,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.5083361,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -50725,24 +49794,10 @@
     "name": "Gold Bound Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 5208,
-    "weight": 2.13,
-    "rank": 1,
-    "tier": 8.148066,
-=======
-    "price": 7755,
-    "weight": 2.02,
-    "heirloomLevel": 1,
-    "tier": 10.1876535,
->>>>>>> cbed0ab (1808)
-=======
     "price": 7889,
     "weight": 2.02,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.2847309,
->>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50776,24 +49831,10 @@
     "name": "Gold Bound Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3846,
-    "weight": 2.13,
-    "rank": 2,
-    "tier": 6.846637,
-=======
-    "price": 8320,
-    "weight": 1.94,
-    "heirloomLevel": 2,
-    "tier": 10.5928211,
->>>>>>> cbed0ab (1808)
-=======
     "price": 8995,
     "weight": 1.94,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 11.0583,
->>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50827,24 +49868,10 @@
     "name": "Gold Bound Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2928,
-    "weight": 2.13,
-    "rank": 3,
-    "tier": 5.83382225,
-=======
-    "price": 9096,
-    "weight": 1.9,
-    "heirloomLevel": 3,
-    "tier": 11.1268253,
->>>>>>> cbed0ab (1808)
-=======
     "price": 8432,
     "weight": 1.94,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6707478,
->>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -55323,13 +54350,8 @@
     "type": "OneHandedWeapon",
     "price": 7140,
     "weight": 1.99,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 8.163455,
-=======
-    "heirloomLevel": 1,
     "tier": 9.729882,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55363,13 +54385,8 @@
     "type": "OneHandedWeapon",
     "price": 7071,
     "weight": 1.99,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.8595705,
-=======
-    "heirloomLevel": 2,
     "tier": 9.677736,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55401,17 +54418,10 @@
     "name": "Heavy Flanged Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2937,
-    "weight": 1.99,
-    "rank": 3,
-    "tier": 5.84484,
-=======
     "price": 8856,
     "weight": 1.94,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.9636345,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55991,13 +55001,8 @@
     "type": "OneHandedWeapon",
     "price": 3828,
     "weight": 1.6,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 5.729106,
-=======
-    "heirloomLevel": 2,
     "tier": 6.82842731,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -56029,17 +55034,10 @@
     "name": "Heavy Horsemans Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2177,
-    "weight": 1.6,
-    "rank": 3,
-    "tier": 4.881606,
-=======
     "price": 6494,
     "weight": 1.58,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.228334,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -57240,17 +56238,10 @@
     "name": "Heavy Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3838,
-    "weight": 2.2,
-    "rank": 1,
-    "tier": 6.83820868,
-=======
     "price": 5791,
     "weight": 2.08,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.651993,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57284,17 +56275,10 @@
     "name": "Heavy Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2854,
-    "weight": 2.2,
-    "rank": 2,
-    "tier": 5.74599552,
-=======
     "price": 5472,
     "weight": 2.08,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.379686,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57328,17 +56312,10 @@
     "name": "Heavy Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2188,
-    "weight": 2.2,
-    "rank": 3,
-    "tier": 4.895997,
-=======
     "price": 6295,
     "weight": 2.03,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.068188,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57921,17 +56898,10 @@
     "name": "Highland Broad Blade +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4203,
-    "weight": 2.1,
-    "rank": 1,
-    "tier": 7.20706558,
-=======
     "price": 6388,
     "weight": 2.01,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.14334,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57965,24 +56935,10 @@
     "name": "Highland Broad Blade +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3118,
-    "weight": 2.1,
-    "rank": 2,
-    "tier": 6.05593538,
-=======
-    "price": 6911,
-    "weight": 1.95,
-    "heirloomLevel": 2,
-    "tier": 9.554945,
->>>>>>> cbed0ab (1808)
-=======
     "price": 6043,
     "weight": 2.01,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.862477,
->>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -58016,24 +56972,10 @@
     "name": "Highland Broad Blade +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2385,
-    "weight": 2.1,
-    "rank": 3,
-    "tier": 5.16008854,
-=======
-    "price": 7704,
-    "weight": 1.95,
-    "heirloomLevel": 3,
-    "tier": 10.1506023,
->>>>>>> cbed0ab (1808)
-=======
     "price": 7049,
     "weight": 1.95,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.661266,
->>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -59264,17 +58206,10 @@
     "name": "Highland Pointed Blade +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3785,
-    "weight": 1.88,
-    "rank": 1,
-    "tier": 6.78317928,
-=======
     "price": 5452,
     "weight": 1.78,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.362564,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -59308,17 +58243,10 @@
     "name": "Highland Pointed Blade +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2815,
-    "weight": 1.88,
-    "rank": 2,
-    "tier": 5.699755,
-=======
     "price": 5858,
     "weight": 1.73,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.708277,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -59352,17 +58280,10 @@
     "name": "Highland Pointed Blade +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2159,
-    "weight": 1.88,
-    "rank": 3,
-    "tier": 4.85659742,
-=======
     "price": 6637,
     "weight": 1.66,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.341043,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -60023,17 +58944,10 @@
     "name": "Highland Spiked Club +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1644,
-    "weight": 2.19,
-    "rank": 1,
-    "tier": 4.10250139,
-=======
     "price": 2501,
     "weight": 2.12,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.30998373,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -60065,17 +58979,10 @@
     "name": "Highland Spiked Club +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1253,
-    "weight": 2.19,
-    "rank": 2,
-    "tier": 3.447242,
-=======
     "price": 2473,
     "weight": 2.12,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.273571,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -60107,17 +59014,10 @@
     "name": "Highland Spiked Club +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 985,
-    "weight": 2.19,
-    "rank": 3,
-    "tier": 2.93729448,
-=======
     "price": 3214,
     "weight": 2.12,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.16421652,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63544,13 +62444,8 @@
     "type": "OneHandedWeapon",
     "price": 2745,
     "weight": 1.9,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 4.50350475,
-=======
-    "heirloomLevel": 1,
     "tier": 5.61486149,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63584,13 +62479,8 @@
     "type": "OneHandedWeapon",
     "price": 2915,
     "weight": 1.9,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 3.78419423,
-=======
-    "heirloomLevel": 2,
     "tier": 5.81936932,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63622,17 +62512,10 @@
     "name": "Imperial Light Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1132,
-    "weight": 1.9,
-    "rank": 3,
-    "tier": 3.22440267,
-=======
     "price": 3808,
     "weight": 1.83,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.80763149,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -64821,17 +63704,10 @@
     "name": "Iron Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2879,
-    "weight": 2.02,
-    "rank": 1,
-    "tier": 5.77565861,
-=======
     "price": 4239,
     "weight": 1.88,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.242883,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64865,17 +63741,10 @@
     "name": "Iron Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2156,
-    "weight": 2.02,
-    "rank": 2,
-    "tier": 4.85315657,
-=======
     "price": 4612,
     "weight": 1.83,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.60243845,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64909,17 +63778,10 @@
     "name": "Iron Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1665,
-    "weight": 2.02,
-    "rank": 3,
-    "tier": 4.135235,
-=======
     "price": 5121,
     "weight": 1.77,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.070484,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65180,17 +64042,10 @@
     "name": "Iron Cavalry Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3074,
-    "weight": 1.85,
-    "rank": 1,
-    "tier": 6.00507832,
-=======
     "price": 4676,
     "weight": 1.74,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.662101,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65224,17 +64079,10 @@
     "name": "Iron Cavalry Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2299,
-    "weight": 1.85,
-    "rank": 2,
-    "tier": 5.04593372,
-=======
     "price": 4264,
     "weight": 1.74,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.267396,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65268,17 +64116,10 @@
     "name": "Iron Cavalry Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1772,
-    "weight": 1.85,
-    "rank": 3,
-    "tier": 4.299495,
-=======
     "price": 4982,
     "weight": 1.68,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.94463825,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65349,17 +64190,10 @@
     "name": "Iron Cavalry Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2098,
-    "weight": 2.16,
-    "rank": 1,
-    "tier": 4.77212048,
-=======
     "price": 3235,
     "weight": 2.05,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.18787766,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65393,17 +64227,10 @@
     "name": "Iron Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1586,
-    "weight": 2.16,
-    "rank": 2,
-    "tier": 4.00990629,
-=======
     "price": 3647,
     "weight": 1.99,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.63873672,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65437,17 +64264,10 @@
     "name": "Iron Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1236,
-    "weight": 2.16,
-    "rank": 3,
-    "tier": 3.41672635,
-=======
     "price": 4005,
     "weight": 1.97,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.00923443,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65516,17 +64336,10 @@
     "name": "Iron Cleaver +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2710,
-    "weight": 2.14,
-    "rank": 1,
-    "tier": 5.571284,
-=======
     "price": 4088,
     "weight": 2.0,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.093058,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65558,17 +64371,10 @@
     "name": "Iron Cleaver +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2033,
-    "weight": 2.14,
-    "rank": 2,
-    "tier": 4.68142557,
-=======
     "price": 4429,
     "weight": 1.95,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.427265,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65600,17 +64406,10 @@
     "name": "Iron Cleaver +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1573,
-    "weight": 2.14,
-    "rank": 3,
-    "tier": 3.98890734,
-=======
     "price": 4882,
     "weight": 1.86,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.8531127,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65679,17 +64478,10 @@
     "name": "Iron Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2627,
-    "weight": 1.97,
-    "rank": 1,
-    "tier": 5.469384,
-=======
     "price": 3801,
     "weight": 1.85,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.79953527,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65723,17 +64515,10 @@
     "name": "Iron Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1973,
-    "weight": 1.97,
-    "rank": 2,
-    "tier": 4.595802,
-=======
     "price": 4248,
     "weight": 1.78,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.251519,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65767,17 +64552,10 @@
     "name": "Iron Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1528,
-    "weight": 1.97,
-    "rank": 3,
-    "tier": 3.91594887,
-=======
     "price": 4831,
     "weight": 1.72,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.80689,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65848,17 +64626,10 @@
     "name": "Iron Flyssa +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2743,
-    "weight": 1.56,
-    "rank": 1,
-    "tier": 5.61180973,
-=======
     "price": 4199,
     "weight": 1.48,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.20373,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65892,17 +64663,10 @@
     "name": "Iron Flyssa +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2057,
-    "weight": 1.56,
-    "rank": 2,
-    "tier": 4.715478,
-=======
     "price": 3962,
     "weight": 1.48,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.96567774,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65936,17 +64700,10 @@
     "name": "Iron Flyssa +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1591,
-    "weight": 1.56,
-    "rank": 3,
-    "tier": 4.017924,
-=======
     "price": 4706,
     "weight": 1.43,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.69085932,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66169,24 +64926,10 @@
     "name": "Iron Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2793,
-    "weight": 2.11,
-    "rank": 1,
-    "tier": 5.67289925,
-=======
-    "price": 4295,
-    "weight": 1.98,
-    "heirloomLevel": 1,
-    "tier": 7.2975297,
->>>>>>> 9e69aca (0231)
-=======
     "price": 4427,
     "weight": 1.98,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.42545557,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66220,22 +64963,9 @@
     "name": "Iron Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2094,
-    "weight": 2.11,
-    "rank": 2,
-    "tier": 4.766809,
-=======
-    "price": 4706,
-    "weight": 1.92,
-    "heirloomLevel": 2,
-    "tier": 7.6900177,
->>>>>>> 9e69aca (0231)
-=======
     "price": 4208,
     "weight": 1.98,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.21247,
     "requirement": 0,
     "flags": [
@@ -66266,14 +64996,14 @@
   },
   {
     "id": "crpg_iron_long_warsword_h3",
+    "baseId": "crpg_iron_long_warsword",
     "name": "Iron Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
     "price": 4826,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.802027,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66292,55 +65022,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 21,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 33,
-        "swingDamageType": "Cut",
-        "swingSpeed": 86
-      }
-    ]
-  },
-  {
-    "id": "crpg_iron_long_warsword_h3",
-    "baseId": "crpg_iron_long_warsword",
-    "name": "Iron Long Warsword +3",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1618,
-    "weight": 2.11,
-    "rank": 3,
-    "tier": 4.061661,
-=======
-    "price": 5249,
-    "weight": 1.88,
-    "heirloomLevel": 3,
-    "tier": 8.184298,
->>>>>>> 9e69aca (0231)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 103,
-        "balance": 0.59,
-        "handling": 86,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 21,
-=======
         "thrustDamage": 24,
->>>>>>> d2d2909 (afewmorebroughtdown)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 34,
@@ -66634,17 +65316,10 @@
     "name": "Iron Pointed Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2326,
-    "weight": 1.6,
-    "rank": 1,
-    "tier": 5.081744,
-=======
     "price": 3217,
     "weight": 1.54,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.16824436,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -66676,17 +65351,10 @@
     "name": "Iron Pointed Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1753,
-    "weight": 1.6,
-    "rank": 2,
-    "tier": 4.270076,
-=======
     "price": 3544,
     "weight": 1.49,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.52847672,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -66718,17 +65386,10 @@
     "name": "Iron Pointed Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1362,
-    "weight": 1.6,
-    "rank": 3,
-    "tier": 3.63840818,
-=======
     "price": 4053,
     "weight": 1.49,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.05796528,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -66797,24 +65458,10 @@
     "name": "Iron Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2564,
-    "weight": 2.12,
-    "rank": 1,
-    "tier": 5.390258,
-=======
-    "price": 3714,
-    "weight": 1.99,
-    "heirloomLevel": 1,
-    "tier": 6.70851231,
->>>>>>> cbed0ab (1808)
-=======
     "price": 3826,
     "weight": 1.99,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.82574749,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66848,22 +65495,9 @@
     "name": "Iron Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 1927,
-    "weight": 2.12,
-    "rank": 2,
-    "tier": 4.52931356,
-=======
-    "price": 4125,
-    "weight": 1.92,
-    "heirloomLevel": 2,
-    "tier": 7.13018656,
->>>>>>> cbed0ab (1808)
-=======
     "price": 3719,
     "weight": 1.99,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.714681,
     "requirement": 0,
     "flags": [
@@ -66894,14 +65528,14 @@
   },
   {
     "id": "crpg_iron_saber_h3",
+    "baseId": "crpg_iron_saber",
     "name": "Iron Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
     "price": 4316,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.318255,
->>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66920,55 +65554,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 21,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
-        "swingDamageType": "Cut",
-        "swingSpeed": 90
-      }
-    ]
-  },
-  {
-    "id": "crpg_iron_saber_h3",
-    "baseId": "crpg_iron_saber",
-    "name": "Iron Saber +3",
-    "culture": "Khuzait",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1493,
-    "weight": 2.12,
-    "rank": 3,
-    "tier": 3.85929728,
-=======
-    "price": 4852,
-    "weight": 1.88,
-    "heirloomLevel": 3,
-    "tier": 7.82577372,
->>>>>>> cbed0ab (1808)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 99,
-        "balance": 0.73,
-        "handling": 88,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 21,
-=======
         "thrustDamage": 24,
->>>>>>> d2d2909 (afewmorebroughtdown)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 31,
@@ -67020,17 +65606,10 @@
     "name": "Iron Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2456,
-    "weight": 1.99,
-    "rank": 1,
-    "tier": 5.2521925,
-=======
     "price": 3588,
     "weight": 1.91,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.575177,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -67064,17 +65643,10 @@
     "name": "Iron Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1848,
-    "weight": 1.99,
-    "rank": 2,
-    "tier": 4.413302,
-=======
     "price": 3452,
     "weight": 1.91,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.428775,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -67108,17 +65680,10 @@
     "name": "Iron Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1434,
-    "weight": 1.99,
-    "rank": 3,
-    "tier": 3.76044536,
-=======
     "price": 4133,
     "weight": 1.88,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.13725042,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -67189,17 +65754,10 @@
     "name": "Iron Thegn Blade +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2824,
-    "weight": 2.0,
-    "rank": 1,
-    "tier": 5.710654,
-=======
     "price": 3907,
     "weight": 1.85,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.90969372,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -67233,17 +65791,10 @@
     "name": "Iron Thegn Blade +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2117,
-    "weight": 2.0,
-    "rank": 2,
-    "tier": 4.798536,
-=======
     "price": 4293,
     "weight": 1.8,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.29556942,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -67277,17 +65828,10 @@
     "name": "Iron Thegn Blade +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1636,
-    "weight": 2.0,
-    "rank": 3,
-    "tier": 4.08869267,
-=======
     "price": 4788,
     "weight": 1.75,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.766935,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -69716,17 +68260,10 @@
     "name": "Judgement +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3579,
-    "weight": 2.36,
-    "rank": 1,
-    "tier": 6.565557,
-=======
     "price": 5684,
     "weight": 2.28,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.561754,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -69758,17 +68295,10 @@
     "name": "Judgement +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2666,
-    "weight": 2.36,
-    "rank": 2,
-    "tier": 5.516889,
-=======
     "price": 5407,
     "weight": 2.28,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.323303,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -69800,17 +68330,10 @@
     "name": "Judgement +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2047,
-    "weight": 2.36,
-    "rank": 3,
-    "tier": 4.70078373,
-=======
     "price": 6331,
     "weight": 2.24,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.097019,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -72834,13 +71357,8 @@
     "type": "OneHandedWeapon",
     "price": 7699,
     "weight": 1.66,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 8.733721,
-=======
-    "heirloomLevel": 2,
     "tier": 10.14724,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -72876,13 +71394,8 @@
     "type": "OneHandedWeapon",
     "price": 8199,
     "weight": 1.59,
-<<<<<<< HEAD
     "rank": 3,
-    "tier": 9.99612,
-=======
-    "heirloomLevel": 3,
     "tier": 10.5068913,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -73273,17 +71786,10 @@
     "name": "Knightly Spiked Battle Axe +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3894,
-    "weight": 0.91,
-    "rank": 1,
-    "tier": 6.89577961,
-=======
     "price": 6069,
     "weight": 0.87,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.884193,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -73317,17 +71823,10 @@
     "name": "Knightly Spiked Battle Axe +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2894,
-    "weight": 0.91,
-    "rank": 2,
-    "tier": 5.794369,
-=======
     "price": 5690,
     "weight": 0.87,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.566359,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -73361,17 +71860,10 @@
     "name": "Knightly Spiked Battle Axe +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2218,
-    "weight": 0.91,
-    "rank": 3,
-    "tier": 4.93721437,
-=======
     "price": 6627,
     "weight": 0.87,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.333597,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -73477,13 +71969,8 @@
     "type": "OneHandedWeapon",
     "price": 2983,
     "weight": 1.68,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 4.91268253,
-=======
-    "heirloomLevel": 2,
     "tier": 5.89925766,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -73515,17 +72002,10 @@
     "name": "Knight's Fall +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1698,
-    "weight": 1.68,
-    "rank": 3,
-    "tier": 4.185955,
-=======
     "price": 5095,
     "weight": 1.64,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.04654,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74248,17 +72728,10 @@
     "name": "Knobbed Club +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 859,
-    "weight": 2.44,
-    "rank": 1,
-    "tier": 2.67501688,
-=======
     "price": 1232,
     "weight": 2.34,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 3.40950155,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74290,17 +72763,10 @@
     "name": "Knobbed Club +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 672,
-    "weight": 2.44,
-    "rank": 2,
-    "tier": 2.24775743,
-=======
     "price": 1481,
     "weight": 2.26,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 3.83876228,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74332,17 +72798,10 @@
     "name": "Knobbed Club +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 541,
-    "weight": 2.44,
-    "rank": 3,
-    "tier": 1.91524887,
-=======
     "price": 1871,
     "weight": 2.26,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 4.44748259,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78627,13 +77086,8 @@
     "type": "OneHandedWeapon",
     "price": 5722,
     "weight": 1.69,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 7.18120337,
-=======
-    "heirloomLevel": 1,
     "tier": 8.59388,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78667,13 +77121,8 @@
     "type": "OneHandedWeapon",
     "price": 5707,
     "weight": 1.69,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.034205,
-=======
-    "heirloomLevel": 2,
     "tier": 8.58104,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78705,17 +77154,10 @@
     "name": "Light Goedendag +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2371,
-    "weight": 1.69,
-    "rank": 3,
-    "tier": 5.14157343,
-=======
     "price": 6822,
     "weight": 1.66,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.486297,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79030,17 +77472,10 @@
     "name": "Light Mace +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 402,
-    "weight": 1.8,
-    "rank": 1,
-    "tier": 1.51508188,
-=======
     "price": 530,
     "weight": 1.7,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 1.88605559,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79072,17 +77507,10 @@
     "name": "Light Mace +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 327,
-    "weight": 1.8,
-    "rank": 2,
-    "tier": 1.27308929,
-=======
     "price": 609,
     "weight": 1.7,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 2.09170675,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79114,17 +77542,10 @@
     "name": "Light Mace +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 273,
-    "weight": 1.8,
-    "rank": 3,
-    "tier": 1.08476281,
-=======
     "price": 995,
     "weight": 1.7,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 2.957553,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79196,13 +77617,8 @@
     "type": "OneHandedWeapon",
     "price": 5906,
     "weight": 1.79,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 7.340049,
-=======
-    "heirloomLevel": 1,
     "tier": 8.748481,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -79239,13 +77655,8 @@
     "type": "OneHandedWeapon",
     "price": 5850,
     "weight": 1.79,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.16768,
-=======
-    "heirloomLevel": 2,
     "tier": 8.701598,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -79280,17 +77691,10 @@
     "name": "Light Morningstar +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2459,
-    "weight": 1.79,
-    "rank": 3,
-    "tier": 5.255302,
-=======
     "price": 7533,
     "weight": 1.72,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.0246773,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -79360,17 +77764,10 @@
     "name": "Light Royal Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2140,
-    "weight": 2.42,
-    "rank": 1,
-    "tier": 4.831107,
-=======
     "price": 3168,
     "weight": 2.32,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.112012,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79402,17 +77799,10 @@
     "name": "Light Royal Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1617,
-    "weight": 2.42,
-    "rank": 2,
-    "tier": 4.059472,
-=======
     "price": 3139,
     "weight": 2.32,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.079256,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79444,17 +77834,10 @@
     "name": "Light Royal Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1260,
-    "weight": 2.42,
-    "rank": 3,
-    "tier": 3.45896,
-=======
     "price": 3915,
     "weight": 2.28,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.917684,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79521,17 +77904,10 @@
     "name": "Light Shishpar Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1087,
-    "weight": 1.99,
-    "rank": 1,
-    "tier": 3.139505,
-=======
     "price": 1485,
     "weight": 1.91,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 3.84629321,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79563,17 +77939,10 @@
     "name": "Light Shishpar Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 842,
-    "weight": 1.99,
-    "rank": 2,
-    "tier": 2.638056,
-=======
     "price": 1663,
     "weight": 1.91,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 4.13244152,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79605,17 +77974,10 @@
     "name": "Light Shishpar Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 672,
-    "weight": 1.99,
-    "rank": 3,
-    "tier": 2.24781132,
-=======
     "price": 2233,
     "weight": 1.87,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 4.958194,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79782,17 +78144,10 @@
     "name": "Lion Imprinted Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5384,
-    "weight": 2.05,
-    "rank": 1,
-    "tier": 8.303297,
-=======
     "price": 7818,
     "weight": 1.96,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.2332878,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79824,17 +78179,10 @@
     "name": "Lion Imprinted Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3973,
-    "weight": 2.05,
-    "rank": 2,
-    "tier": 6.977075,
-=======
     "price": 7387,
     "weight": 1.96,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.916577,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79866,17 +78214,10 @@
     "name": "Lion Imprinted Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3022,
-    "weight": 2.05,
-    "rank": 3,
-    "tier": 5.94496441,
-=======
     "price": 8781,
     "weight": 1.91,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.9123325,
->>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86201,13 +84542,8 @@
     "type": "OneHandedWeapon",
     "price": 6378,
     "weight": 1.76,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 7.773378,
-=======
-    "heirloomLevel": 1,
     "tier": 9.135416,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86241,13 +84577,8 @@
     "type": "OneHandedWeapon",
     "price": 6336,
     "weight": 1.76,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.53179646,
-=======
-    "heirloomLevel": 2,
     "tier": 9.10117149,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86279,17 +84610,10 @@
     "name": "Medium Goedendag +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2705,
-    "weight": 1.76,
-    "rank": 3,
-    "tier": 5.56555557,
-=======
     "price": 7928,
     "weight": 1.73,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.3131495,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -86940,13 +85264,8 @@
     "type": "OneHandedWeapon",
     "price": 7001,
     "weight": 1.45,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 8.130808,
-=======
-    "heirloomLevel": 1,
     "tier": 9.624474,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -86982,13 +85301,8 @@
     "type": "OneHandedWeapon",
     "price": 6856,
     "weight": 1.45,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 6.83213568,
-=======
-    "heirloomLevel": 2,
     "tier": 9.512148,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -87022,17 +85336,10 @@
     "name": "Military Hammer +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2917,
-    "weight": 1.45,
-    "rank": 3,
-    "tier": 5.821466,
-=======
     "price": 8195,
     "weight": 1.42,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.5043592,
->>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -87101,17 +85408,10 @@
     "name": "Militia Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 588,
-    "weight": 2.48,
-    "rank": 1,
-    "tier": 2.03992414,
-=======
     "price": 847,
     "weight": 2.35,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 2.65025067,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87143,17 +85443,10 @@
     "name": "Militia Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 469,
-    "weight": 2.48,
-    "rank": 2,
-    "tier": 1.7141031,
-=======
     "price": 992,
     "weight": 2.28,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 2.95303679,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87185,17 +85478,10 @@
     "name": "Militia Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 384,
-    "weight": 2.48,
-    "rank": 3,
-    "tier": 1.46053755,
-=======
     "price": 1285,
     "weight": 2.28,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 3.50321651,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87262,17 +85548,10 @@
     "name": "Militia Pernach +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2886,
-    "weight": 2.58,
-    "rank": 1,
-    "tier": 5.78435564,
-=======
     "price": 4271,
     "weight": 2.5,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.274137,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87304,17 +85583,10 @@
     "name": "Militia Pernach +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2162,
-    "weight": 2.58,
-    "rank": 2,
-    "tier": 4.860465,
-=======
     "price": 4282,
     "weight": 2.5,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.28514338,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87346,24 +85618,10 @@
     "name": "Militia Pernach +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 1669,
-    "weight": 2.58,
-    "rank": 3,
-    "tier": 4.141461,
-=======
-    "price": 5397,
-    "weight": 2.45,
-    "heirloomLevel": 3,
-    "tier": 8.314444,
->>>>>>> 617d082 (1507)
-=======
     "price": 4821,
     "weight": 2.55,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.79715443,
->>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87533,17 +85791,10 @@
     "name": "Morningstar +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4875,
-    "weight": 1.94,
-    "rank": 1,
-    "tier": 7.847093,
-=======
     "price": 7008,
     "weight": 1.85,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.629232,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87578,17 +85829,10 @@
     "name": "Morningstar +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3605,
-    "weight": 1.94,
-    "rank": 2,
-    "tier": 6.593737,
-=======
     "price": 6723,
     "weight": 1.85,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.40906048,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87623,17 +85867,10 @@
     "name": "Morningstar +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2748,
-    "weight": 1.94,
-    "rank": 3,
-    "tier": 5.618334,
-=======
     "price": 8445,
     "weight": 1.85,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6798763,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -95543,17 +93780,10 @@
     "name": "Narrow Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3586,
-    "weight": 1.41,
-    "rank": 1,
-    "tier": 6.57317257,
-=======
     "price": 5264,
     "weight": 1.32,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.197535,
->>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -95585,24 +93815,10 @@
     "name": "Narrow Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2671,
-    "weight": 1.41,
-    "rank": 2,
-    "tier": 5.523289,
-=======
-    "price": 5805,
-    "weight": 1.29,
-    "heirloomLevel": 2,
-    "tier": 8.664381,
->>>>>>> 4dd0778 (0105)
-=======
     "price": 5227,
     "weight": 1.32,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.164885,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -95634,24 +93850,10 @@
     "name": "Narrow Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2051,
-    "weight": 1.41,
-    "rank": 3,
-    "tier": 4.70623541,
-=======
-    "price": 5842,
-    "weight": 1.29,
-    "heirloomLevel": 3,
-    "tier": 8.69514751,
->>>>>>> 4dd0778 (0105)
-=======
     "price": 6348,
     "weight": 1.29,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.110932,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -95718,17 +93920,10 @@
     "name": "Narrow Fine Steel Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5238,
-    "weight": 2.22,
-    "rank": 1,
-    "tier": 8.174032,
-=======
     "price": 7717,
     "weight": 2.13,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.1603336,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -95760,17 +93955,10 @@
     "name": "Narrow Fine Steel Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3867,
-    "weight": 2.22,
-    "rank": 2,
-    "tier": 6.868459,
-=======
     "price": 7258,
     "weight": 2.13,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.819742,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -95802,17 +93990,10 @@
     "name": "Narrow Fine Steel Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2943,
-    "weight": 2.22,
-    "rank": 3,
-    "tier": 5.85241365,
-=======
     "price": 8645,
     "weight": 2.07,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.819356,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -100757,17 +98938,10 @@
     "name": "Northern Backsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4167,
-    "weight": 1.74,
-    "rank": 1,
-    "tier": 7.171772,
-=======
     "price": 5783,
     "weight": 1.59,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.645561,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -100801,17 +98975,10 @@
     "name": "Northern Backsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3093,
-    "weight": 1.74,
-    "rank": 2,
-    "tier": 6.02628136,
-=======
     "price": 6395,
     "weight": 1.51,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.149115,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -100845,17 +99012,10 @@
     "name": "Northern Backsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2366,
-    "weight": 1.74,
-    "rank": 3,
-    "tier": 5.13482046,
-=======
     "price": 6892,
     "weight": 1.46,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.540372,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -107036,17 +105196,10 @@
     "name": "Pernach +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4839,
-    "weight": 2.12,
-    "rank": 1,
-    "tier": 7.814022,
-=======
     "price": 7048,
     "weight": 2.06,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.659853,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -107078,17 +105231,10 @@
     "name": "Pernach +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3579,
-    "weight": 2.12,
-    "rank": 2,
-    "tier": 6.565947,
-=======
     "price": 6828,
     "weight": 2.06,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.490931,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -107120,17 +105266,10 @@
     "name": "Pernach +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2729,
-    "weight": 2.12,
-    "rank": 3,
-    "tier": 5.59465647,
-=======
     "price": 8100,
     "weight": 1.98,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.4362659,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -109225,17 +107364,10 @@
     "name": "Pointed Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3600,
-    "weight": 1.96,
-    "rank": 1,
-    "tier": 6.58784246,
-=======
     "price": 5255,
     "weight": 1.86,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.189134,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -109267,22 +107399,9 @@
     "name": "Pointed Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2681,
-    "weight": 1.96,
-    "rank": 2,
-    "tier": 5.53561831,
-=======
-    "price": 6016,
-    "weight": 1.82,
-    "heirloomLevel": 2,
-    "tier": 8.839773,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 5043,
     "weight": 1.86,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.000357,
     "requirement": 0,
     "flags": [],
@@ -109311,14 +107430,14 @@
   },
   {
     "id": "crpg_pointed_falchion_h3",
+    "baseId": "crpg_pointed_falchion",
     "name": "Pointed Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
     "price": 6105,
     "weight": 1.82,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.91323948,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -109335,53 +107454,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 23,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 32,
-        "swingDamageType": "Cut",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_pointed_falchion_h3",
-    "baseId": "crpg_pointed_falchion",
-    "name": "Pointed Falchion +3",
-    "culture": "Neutral",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2058,
-    "weight": 1.96,
-    "rank": 3,
-    "tier": 4.71674061,
-=======
-    "price": 6705,
-    "weight": 1.77,
-    "heirloomLevel": 3,
-    "tier": 9.39467049,
->>>>>>> 150f2d5 (0203)
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 108,
-        "balance": 0.62,
-        "handling": 87,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 23,
-=======
         "thrustDamage": 25,
->>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 33,
@@ -113467,17 +111540,10 @@
     "name": "Ridged Iron Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2525,
-    "weight": 2.26,
-    "rank": 1,
-    "tier": 5.340885,
-=======
     "price": 4000,
     "weight": 2.13,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.00439835,
->>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113511,17 +111577,10 @@
     "name": "Ridged Iron Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1899,
-    "weight": 2.26,
-    "rank": 2,
-    "tier": 4.48782635,
-=======
     "price": 3712,
     "weight": 2.13,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.70670033,
->>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113555,17 +111614,10 @@
     "name": "Ridged Iron Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1472,
-    "weight": 2.26,
-    "rank": 3,
-    "tier": 3.82394743,
-=======
     "price": 4193,
     "weight": 2.09,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 7.19720936,
->>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -114034,17 +112086,10 @@
     "name": "Ridged Saber  +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4591,
-    "weight": 2.14,
-    "rank": 1,
-    "tier": 7.582545,
-=======
     "price": 6799,
     "weight": 2.05,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.467809,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -114076,17 +112121,10 @@
     "name": "Ridged Saber  +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3400,
-    "weight": 2.14,
-    "rank": 2,
-    "tier": 6.37144327,
-=======
     "price": 6271,
     "weight": 2.05,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.048825,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -114118,17 +112156,10 @@
     "name": "Ridged Saber  +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2595,
-    "weight": 2.14,
-    "rank": 3,
-    "tier": 5.42892361,
-=======
     "price": 7497,
     "weight": 2.02,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.998306,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -118707,17 +116738,10 @@
     "name": "Scalpel +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5125,
-    "weight": 1.74,
-    "rank": 1,
-    "tier": 8.073632,
-=======
     "price": 7631,
     "weight": 1.64,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.0973539,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -118749,66 +116773,10 @@
     "name": "Scalpel +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3786,
-    "weight": 1.74,
-    "rank": 2,
-    "tier": 6.78409338,
-=======
-    "price": 6857,
-    "weight": 1.64,
-    "heirloomLevel": 2,
-    "tier": 9.513441,
->>>>>>> e19d1a9 (fixes)
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 104,
-        "balance": 0.53,
-        "handling": 77,
-        "bodyArmor": 5,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 24,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 36,
-        "swingDamageType": "Cut",
-        "swingSpeed": 86
-      }
-    ]
-  },
-  {
-    "id": "crpg_scalpel_h3",
-    "baseId": "crpg_scalpel",
-    "name": "Scalpel +3",
-    "culture": "Neutral",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2883,
-    "weight": 1.74,
-    "rank": 3,
-    "tier": 5.7805295,
-=======
-    "price": 7508,
-    "weight": 1.57,
-    "heirloomLevel": 3,
-    "tier": 10.0059519,
->>>>>>> e19d1a9 (fixes)
-=======
     "price": 8190,
     "weight": 1.57,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.5005264,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -118836,12 +116804,13 @@
   },
   {
     "id": "crpg_scalpel_h3",
+    "baseId": "crpg_scalpel",
     "name": "Scalpel +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
     "price": 8925,
     "weight": 1.52,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 11.0111637,
     "requirement": 0,
     "flags": [],
@@ -120703,17 +118672,10 @@
     "name": "Short Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3208,
-    "weight": 1.97,
-    "rank": 1,
-    "tier": 6.15762472,
-=======
     "price": 4581,
     "weight": 1.83,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.572674,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -120747,17 +118709,10 @@
     "name": "Short Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2396,
-    "weight": 1.97,
-    "rank": 2,
-    "tier": 5.1741147,
-=======
     "price": 5053,
     "weight": 1.73,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.008871,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -120791,17 +118746,10 @@
     "name": "Short Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1845,
-    "weight": 1.97,
-    "rank": 3,
-    "tier": 4.40871429,
-=======
     "price": 5670,
     "weight": 1.65,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.549845,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123256,17 +121204,10 @@
     "name": "Simple Saber  +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2003,
-    "weight": 2.17,
-    "rank": 1,
-    "tier": 4.63824368,
-=======
     "price": 2880,
     "weight": 2.08,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.77739143,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123300,17 +121241,10 @@
     "name": "Simple Saber  +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1516,
-    "weight": 2.17,
-    "rank": 2,
-    "tier": 3.89741325,
-=======
     "price": 3228,
     "weight": 2.03,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 6.1799736,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123344,17 +121278,10 @@
     "name": "Simple Saber  +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1184,
-    "weight": 2.17,
-    "rank": 3,
-    "tier": 3.32087278,
-=======
     "price": 3806,
     "weight": 1.96,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.80512476,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123425,17 +121352,10 @@
     "name": "Simple Scimitar +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2097,
-    "weight": 2.12,
-    "rank": 1,
-    "tier": 4.77104855,
-=======
     "price": 3030,
     "weight": 2.02,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.95360041,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123469,17 +121389,10 @@
     "name": "Simple Scimitar +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1585,
-    "weight": 2.12,
-    "rank": 2,
-    "tier": 4.009005,
-=======
     "price": 2889,
     "weight": 2.02,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.787786,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123513,17 +121426,10 @@
     "name": "Simple Scimitar +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1236,
-    "weight": 2.12,
-    "rank": 3,
-    "tier": 3.415958,
-=======
     "price": 3526,
     "weight": 2.02,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.50896549,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123922,17 +121828,10 @@
     "name": "Simple Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1887,
-    "weight": 1.73,
-    "rank": 1,
-    "tier": 4.47138834,
-=======
     "price": 2606,
     "weight": 1.63,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.44288445,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123966,17 +121865,10 @@
     "name": "Simple Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1432,
-    "weight": 1.73,
-    "rank": 2,
-    "tier": 3.75720859,
-=======
     "price": 2974,
     "weight": 1.57,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.88837957,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -124010,17 +121902,10 @@
     "name": "Simple Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1120,
-    "weight": 1.73,
-    "rank": 3,
-    "tier": 3.201408,
-=======
     "price": 3300,
     "weight": 1.51,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.261262,
->>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -124645,24 +122530,10 @@
     "name": "Slightly Ridged Flyssa +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 5140,
-    "weight": 2.4,
-    "rank": 1,
-    "tier": 8.08698,
-=======
-    "price": 6378,
-    "weight": 2.34,
-    "heirloomLevel": 1,
-    "tier": 9.135182,
->>>>>>> a1592ae (1433)
-=======
     "price": 7917,
     "weight": 2.32,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.30562,
->>>>>>> 1559a20 (1543)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124694,24 +122565,10 @@
     "name": "Slightly Ridged Flyssa +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3797,
-    "weight": 2.4,
-    "rank": 2,
-    "tier": 6.795307,
-=======
-    "price": 8745,
-    "weight": 2.29,
-    "heirloomLevel": 2,
-    "tier": 10.8876095,
->>>>>>> a1592ae (1433)
-=======
     "price": 7328,
     "weight": 2.32,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.872506,
->>>>>>> 1559a20 (1543)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124743,17 +122600,10 @@
     "name": "Slightly Ridged Flyssa +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2891,
-    "weight": 2.4,
-    "rank": 3,
-    "tier": 5.7900877,
-=======
     "price": 8573,
     "weight": 2.26,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.7690277,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -125392,17 +123242,10 @@
     "name": "Soldier's Cleaver +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5193,
-    "weight": 2.2,
-    "rank": 1,
-    "tier": 8.134172,
-=======
     "price": 7540,
     "weight": 2.06,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.0302715,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -125434,17 +123277,10 @@
     "name": "Soldier's Cleaver +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3835,
-    "weight": 2.2,
-    "rank": 2,
-    "tier": 6.83496475,
-=======
     "price": 8113,
     "weight": 2.01,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.44585,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -125476,17 +123312,10 @@
     "name": "Soldier's Cleaver +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2919,
-    "weight": 2.2,
-    "rank": 3,
-    "tier": 5.82387447,
-=======
     "price": 8890,
     "weight": 1.92,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.987093,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -126693,17 +124522,10 @@
     "name": "Spatha Blade with Ring Pommel +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4996,
-    "weight": 2.51,
-    "rank": 1,
-    "tier": 7.95747232,
-=======
     "price": 7597,
     "weight": 2.42,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.0722523,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -126735,17 +124557,10 @@
     "name": "Spatha Blade with Ring Pommel +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3693,
-    "weight": 2.51,
-    "rank": 2,
-    "tier": 6.68648767,
-=======
     "price": 8262,
     "weight": 2.38,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.5513067,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -126777,17 +124592,10 @@
     "name": "Spatha Blade with Ring Pommel +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2813,
-    "weight": 2.51,
-    "rank": 3,
-    "tier": 5.69736242,
-=======
     "price": 8047,
     "weight": 2.38,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.398489,
->>>>>>> 050a4f8 (0130)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -126856,17 +124664,10 @@
     "name": "Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1577,
-    "weight": 1.65,
-    "rank": 1,
-    "tier": 3.9958005,
-=======
     "price": 2390,
     "weight": 1.56,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 5.16677,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126900,17 +124701,10 @@
     "name": "Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1204,
-    "weight": 1.65,
-    "rank": 2,
-    "tier": 3.35758138,
-=======
     "price": 2362,
     "weight": 1.56,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.129491,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126944,17 +124738,10 @@
     "name": "Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 947,
-    "weight": 1.65,
-    "rank": 3,
-    "tier": 2.860899,
-=======
     "price": 2776,
     "weight": 1.51,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 5.652436,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127025,17 +124812,10 @@
     "name": "Spatha With Narrow Fuller +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2190,
-    "weight": 1.78,
-    "rank": 1,
-    "tier": 4.899188,
-=======
     "price": 3198,
     "weight": 1.68,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.146165,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127069,17 +124849,10 @@
     "name": "Spatha With Narrow Fuller +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1653,
-    "weight": 1.78,
-    "rank": 2,
-    "tier": 4.116679,
-=======
     "price": 3060,
     "weight": 1.68,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 5.98894453,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127113,17 +124886,10 @@
     "name": "Spatha With Narrow Fuller +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1287,
-    "weight": 1.78,
-    "rank": 3,
-    "tier": 3.507703,
-=======
     "price": 3712,
     "weight": 1.68,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 6.70715332,
->>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127268,17 +125034,10 @@
     "name": "Spiked Club +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1347,
-    "weight": 1.78,
-    "rank": 1,
-    "tier": 3.61332941,
-=======
     "price": 1988,
     "weight": 1.69,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 4.617814,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127310,17 +125069,10 @@
     "name": "Spiked Club +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1034,
-    "weight": 1.78,
-    "rank": 2,
-    "tier": 3.03619933,
-=======
     "price": 2013,
     "weight": 1.69,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 4.65219831,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127352,17 +125104,10 @@
     "name": "Spiked Club +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 818,
-    "weight": 1.78,
-    "rank": 3,
-    "tier": 2.58705735,
-=======
     "price": 2715,
     "weight": 1.69,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 5.57812357,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127789,17 +125534,10 @@
     "name": "Spiked Mace +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1236,
-    "weight": 1.83,
-    "rank": 1,
-    "tier": 3.416224,
-=======
     "price": 1844,
     "weight": 1.73,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 4.40779972,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127831,17 +125569,10 @@
     "name": "Spiked Mace +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 952,
-    "weight": 1.83,
-    "rank": 2,
-    "tier": 2.870578,
-=======
     "price": 1809,
     "weight": 1.73,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 4.35576,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127873,17 +125604,10 @@
     "name": "Spiked Mace +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 756,
-    "weight": 1.83,
-    "rank": 3,
-    "tier": 2.445936,
-=======
     "price": 2298,
     "weight": 1.73,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 5.04529762,
->>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128110,17 +125834,10 @@
     "name": "Spiralled Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5189,
-    "weight": 1.21,
-    "rank": 1,
-    "tier": 8.130823,
-=======
     "price": 7999,
     "weight": 1.12,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.3643179,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128152,17 +125869,10 @@
     "name": "Spiralled Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3832,
-    "weight": 1.21,
-    "rank": 2,
-    "tier": 6.83215046,
-=======
     "price": 8250,
     "weight": 1.12,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.54328,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128194,17 +125904,10 @@
     "name": "Spiralled Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2917,
-    "weight": 1.21,
-    "rank": 3,
-    "tier": 5.82147646,
-=======
     "price": 8600,
     "weight": 1.12,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.7877369,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128499,17 +126202,10 @@
     "name": "Star Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3215,
-    "weight": 2.06,
-    "rank": 1,
-    "tier": 6.166212,
-=======
     "price": 4874,
     "weight": 1.97,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.846354,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128541,17 +126237,10 @@
     "name": "Star Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2401,
-    "weight": 2.06,
-    "rank": 2,
-    "tier": 5.1813283,
-=======
     "price": 4444,
     "weight": 1.97,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.44216061,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128583,17 +126272,10 @@
     "name": "Star Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1849,
-    "weight": 2.06,
-    "rank": 3,
-    "tier": 4.41486263,
-=======
     "price": 5182,
     "weight": 1.93,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.125046,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128700,17 +126382,10 @@
     "name": "Steel Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3039,
-    "weight": 2.18,
-    "rank": 1,
-    "tier": 5.964445,
-=======
     "price": 4556,
     "weight": 2.09,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.54939651,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -128744,17 +126419,10 @@
     "name": "Steel Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2273,
-    "weight": 2.18,
-    "rank": 2,
-    "tier": 5.01179,
-=======
     "price": 4314,
     "weight": 2.09,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.31625462,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -128788,17 +126456,10 @@
     "name": "Steel Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1753,
-    "weight": 2.18,
-    "rank": 3,
-    "tier": 4.270402,
-=======
     "price": 5104,
     "weight": 2.04,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.05456,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -129021,17 +126682,10 @@
     "name": "Steel Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3395,
-    "weight": 1.98,
-    "rank": 1,
-    "tier": 6.36605549,
-=======
     "price": 5011,
     "weight": 1.88,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 7.9709053,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -129065,22 +126719,9 @@
     "name": "Steel Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2532,
-    "weight": 1.98,
-    "rank": 2,
-    "tier": 5.34925461,
-=======
-    "price": 5700,
-    "weight": 1.83,
-    "heirloomLevel": 2,
-    "tier": 8.575342,
->>>>>>> 150f2d5 (0203)
-=======
     "price": 4730,
     "weight": 1.88,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.71264124,
     "requirement": 0,
     "flags": [
@@ -129111,14 +126752,14 @@
   },
   {
     "id": "crpg_steel_long_warsword_h3",
+    "baseId": "crpg_steel_long_warsword",
     "name": "Steel Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
     "price": 5659,
     "weight": 1.83,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.540301,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -129137,55 +126778,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-<<<<<<< HEAD
-        "thrustDamage": 22,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 34,
-        "swingDamageType": "Cut",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
-    "id": "crpg_steel_long_warsword_h3",
-    "baseId": "crpg_steel_long_warsword",
-    "name": "Steel Long Warsword +3",
-    "culture": "Sturgia",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1947,
-    "weight": 1.98,
-    "rank": 3,
-    "tier": 4.55794525,
-=======
-    "price": 6320,
-    "weight": 1.77,
-    "heirloomLevel": 3,
-    "tier": 9.088213,
->>>>>>> 150f2d5 (0203)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 105,
-        "balance": 0.56,
-        "handling": 87,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 22,
-=======
         "thrustDamage": 24,
->>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 35,
@@ -129235,24 +126828,10 @@
     "name": "Steel Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 4272,
-    "weight": 2.31,
-    "rank": 1,
-    "tier": 7.275543,
-=======
-    "price": 6522,
-    "weight": 2.25,
-    "heirloomLevel": 1,
-    "tier": 9.250165,
->>>>>>> 1597247 (0046)
-=======
     "price": 5679,
     "weight": 2.31,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.55744648,
->>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129263,55 +126842,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-<<<<<<< HEAD
-        "balance": 0.45,
-        "handling": 79,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 26,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      }
-    ]
-  },
-  {
-    "id": "crpg_steel_mace_h2",
-    "baseId": "crpg_steel_mace",
-    "name": "Steel Mace +2",
-    "culture": "Khuzait",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3169,
-    "weight": 2.31,
-    "rank": 2,
-    "tier": 6.113476,
-=======
-    "price": 6387,
-    "weight": 2.25,
-    "heirloomLevel": 2,
-    "tier": 9.142207,
->>>>>>> 1597247 (0046)
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Mace",
-        "itemUsage": "onehanded_block_shield_tipdraw_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 93,
-        "balance": 0.45,
-        "handling": 79,
-=======
         "balance": 0.39,
         "handling": 78,
->>>>>>> 5ff5dd5 (sortedwarhammer)
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -129326,33 +126858,15 @@
     ]
   },
   {
-<<<<<<< HEAD
-    "id": "crpg_steel_mace_h3",
-    "baseId": "crpg_steel_mace",
-    "name": "Steel Mace +3",
-    "culture": "Khuzait",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2423,
-    "weight": 2.31,
-    "rank": 3,
-    "tier": 5.209118,
-=======
-    "price": 7663,
-    "weight": 2.22,
-    "heirloomLevel": 3,
-    "tier": 10.1207523,
->>>>>>> 1597247 (0046)
-=======
     "id": "crpg_steel_mace_h2",
+    "baseId": "crpg_steel_mace",
     "name": "Steel Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
     "price": 5505,
     "weight": 2.31,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 8.407801,
->>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129380,12 +126894,13 @@
   },
   {
     "id": "crpg_steel_mace_h3",
+    "baseId": "crpg_steel_mace",
     "name": "Steel Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
     "price": 6866,
     "weight": 2.27,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.520258,
     "requirement": 0,
     "flags": [],
@@ -129917,17 +127432,10 @@
     "name": "Steel Shestopyor +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5194,
-    "weight": 1.39,
-    "rank": 1,
-    "tier": 8.135389,
-=======
     "price": 8073,
     "weight": 1.29,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.4173927,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129959,17 +127467,10 @@
     "name": "Steel Shestopyor +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3836,
-    "weight": 1.39,
-    "rank": 2,
-    "tier": 6.83598328,
-=======
     "price": 8095,
     "weight": 1.29,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 10.4331493,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -130001,17 +127502,10 @@
     "name": "Steel Shestopyor +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2920,
-    "weight": 1.39,
-    "rank": 3,
-    "tier": 5.824744,
-=======
     "price": 8221,
     "weight": 1.29,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.5228825,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -131998,17 +129492,10 @@
     "name": "Steppe Light Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1327,
-    "weight": 2.15,
-    "rank": 1,
-    "tier": 3.5771594,
-=======
     "price": 1949,
     "weight": 2.05,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 4.561429,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -132040,17 +129527,10 @@
     "name": "Steppe Light Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1019,
-    "weight": 2.15,
-    "rank": 2,
-    "tier": 3.005807,
-=======
     "price": 1932,
     "weight": 2.05,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 4.53660965,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -132082,17 +129562,10 @@
     "name": "Steppe Light Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 807,
-    "weight": 2.15,
-    "rank": 3,
-    "tier": 2.56116247,
-=======
     "price": 2505,
     "weight": 2.05,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 5.315473,
->>>>>>> 617d082 (1507)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -132855,22 +130328,9 @@
     "name": "Straight Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3003,
-    "weight": 1.41,
-    "rank": 1,
-    "tier": 5.923041,
-=======
-    "price": 4308,
-    "weight": 1.31,
-    "heirloomLevel": 1,
-    "tier": 7.310702,
->>>>>>> 050a4f8 (0130)
-=======
     "price": 3892,
     "weight": 1.36,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 6.89428425,
     "requirement": 0,
     "flags": [
@@ -132901,14 +130361,14 @@
   },
   {
     "id": "crpg_straight_saber_h2",
+    "baseId": "crpg_straight_saber",
     "name": "Straight Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
     "price": 4245,
     "weight": 1.31,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 7.24904871,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -132937,33 +130397,15 @@
     ]
   },
   {
-<<<<<<< HEAD
-    "id": "crpg_straight_saber_h2",
-    "baseId": "crpg_straight_saber",
-    "name": "Straight Saber +2",
-    "culture": "Khuzait",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2247,
-    "weight": 1.41,
-    "rank": 2,
-    "tier": 4.97699833,
-=======
-    "price": 4879,
-    "weight": 1.26,
-    "heirloomLevel": 2,
-    "tier": 7.85113525,
->>>>>>> 050a4f8 (0130)
-=======
     "id": "crpg_straight_saber_h3",
+    "baseId": "crpg_straight_saber",
     "name": "Straight Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
     "price": 5171,
     "weight": 1.26,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 8.11458,
->>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -132985,53 +130427,6 @@
         "thrustDamage": 27,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
-<<<<<<< HEAD
-        "swingDamage": 30,
-        "swingDamageType": "Cut",
-        "swingSpeed": 88
-      }
-    ]
-  },
-  {
-    "id": "crpg_straight_saber_h3",
-    "baseId": "crpg_straight_saber",
-    "name": "Straight Saber +3",
-    "culture": "Khuzait",
-    "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 1734,
-    "weight": 1.41,
-    "rank": 3,
-    "tier": 4.24075651,
-=======
-    "price": 5673,
-    "weight": 1.22,
-    "heirloomLevel": 3,
-    "tier": 8.552039,
->>>>>>> 050a4f8 (0130)
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "OneHandedSword",
-        "itemUsage": "onehanded_block_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 104,
-        "balance": 0.66,
-        "handling": 91,
-        "bodyArmor": 2,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 25,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-=======
->>>>>>> 3b551c9 (bringingsomedownintier)
         "swingDamage": 31,
         "swingDamageType": "Cut",
         "swingSpeed": 88
@@ -138573,17 +135968,10 @@
     "name": "Tall Gripped Ild +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5201,
-    "weight": 1.71,
-    "rank": 1,
-    "tier": 8.141615,
-=======
     "price": 7830,
     "weight": 1.61,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.2421312,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138615,17 +136003,10 @@
     "name": "Tall Gripped Ild +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3841,
-    "weight": 1.71,
-    "rank": 2,
-    "tier": 6.841217,
-=======
     "price": 7479,
     "weight": 1.61,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.984653,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138657,17 +136038,10 @@
     "name": "Tall Gripped Ild +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2924,
-    "weight": 1.71,
-    "rank": 3,
-    "tier": 5.82920265,
-=======
     "price": 8573,
     "weight": 1.57,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.76921,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -140640,17 +138014,10 @@
     "name": "Thamaskene Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4252,
-    "weight": 2.15,
-    "rank": 1,
-    "tier": 7.255455,
-=======
     "price": 6018,
     "weight": 2.0,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 8.841901,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -140684,17 +138051,10 @@
     "name": "Thamaskene Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3154,
-    "weight": 2.15,
-    "rank": 2,
-    "tier": 6.09659624,
-=======
     "price": 6476,
     "weight": 1.95,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.213385,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -140728,17 +138088,10 @@
     "name": "Thamaskene Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2412,
-    "weight": 2.15,
-    "rank": 3,
-    "tier": 5.19473362,
-=======
     "price": 7097,
     "weight": 1.87,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 9.697372,
->>>>>>> 9954479 (2154)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -141091,17 +138444,10 @@
     "name": "Thamaskene Steel Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 4900,
-    "weight": 2.27,
-    "rank": 1,
-    "tier": 7.86966944,
-=======
     "price": 7326,
     "weight": 2.18,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.870982,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -141133,17 +138479,10 @@
     "name": "Thamaskene Steel Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3623,
-    "weight": 2.27,
-    "rank": 2,
-    "tier": 6.612708,
-=======
     "price": 6810,
     "weight": 2.18,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.476922,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -141175,17 +138514,10 @@
     "name": "Thamaskene Steel Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2761,
-    "weight": 2.27,
-    "rank": 3,
-    "tier": 5.63449669,
-=======
     "price": 8043,
     "weight": 2.13,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.3960152,
->>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -141252,17 +138584,10 @@
     "name": "Thamaskene Steel Spathion +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5304,
-    "weight": 2.52,
-    "rank": 1,
-    "tier": 8.232752,
-=======
     "price": 7757,
     "weight": 2.43,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 10.189249,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -141294,17 +138619,10 @@
     "name": "Thamaskene Steel Spathion +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3915,
-    "weight": 2.52,
-    "rank": 2,
-    "tier": 6.91779566,
-=======
     "price": 7391,
     "weight": 2.43,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.91914749,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -141336,17 +138654,10 @@
     "name": "Thamaskene Steel Spathion +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2979,
-    "weight": 2.52,
-    "rank": 3,
-    "tier": 5.89445448,
-=======
     "price": 8816,
     "weight": 2.38,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.9363909,
->>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -146066,13 +143377,8 @@
     "type": "OneHandedWeapon",
     "price": 6662,
     "weight": 1.43,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 8.894467,
-=======
-    "heirloomLevel": 2,
     "tier": 9.361227,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -146106,17 +143412,10 @@
     "name": "Tyrhung +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 6810,
-    "weight": 1.43,
-    "rank": 3,
-    "tier": 9.476263,
-=======
     "price": 8411,
     "weight": 1.34,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6564846,
->>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -149453,24 +146752,10 @@
     "name": "Warhammer +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 4866,
-    "weight": 1.91,
-    "rank": 1,
-    "tier": 7.838435,
-=======
-    "price": 7269,
-    "weight": 1.85,
-    "heirloomLevel": 1,
-    "tier": 9.827833,
->>>>>>> 825a77b (startedonmaces)
-=======
     "price": 6544,
     "weight": 1.91,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.267763,
->>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -149502,24 +146787,10 @@
     "name": "Warhammer +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 3598,
-    "weight": 1.91,
-    "rank": 2,
-    "tier": 6.586463,
-=======
-    "price": 7082,
-    "weight": 1.85,
-    "heirloomLevel": 2,
-    "tier": 9.686204,
->>>>>>> 825a77b (startedonmaces)
-=======
     "price": 6405,
     "weight": 1.91,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.156638,
->>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -149551,24 +146822,10 @@
     "name": "Warhammer +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "price": 2743,
-    "weight": 1.91,
-    "rank": 3,
-    "tier": 5.612134,
-=======
-    "price": 8728,
-    "weight": 1.79,
-    "heirloomLevel": 3,
-    "tier": 10.8765373,
->>>>>>> 825a77b (startedonmaces)
-=======
     "price": 7963,
     "weight": 1.87,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.33864,
->>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151299,17 +148556,10 @@
     "name": "Winds Fury +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 5102,
-    "weight": 1.69,
-    "rank": 1,
-    "tier": 8.052679,
-=======
     "price": 7215,
     "weight": 1.55,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 9.78695,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151341,17 +148591,10 @@
     "name": "Winds Fury +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 3769,
-    "weight": 1.69,
-    "rank": 2,
-    "tier": 6.76648331,
-=======
     "price": 7388,
     "weight": 1.46,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 9.91673851,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151383,17 +148626,10 @@
     "name": "Winds Fury +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 2870,
-    "weight": 1.69,
-    "rank": 3,
-    "tier": 5.76552629,
-=======
     "price": 8381,
     "weight": 1.46,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 10.6353617,
->>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -152279,17 +149515,10 @@
     "name": "Wooden Hammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 360,
-    "weight": 2.48,
-    "rank": 1,
-    "tier": 1.38300467,
-=======
     "price": 485,
     "weight": 2.33,
-    "heirloomLevel": 1,
+    "rank": 1,
     "tier": 1.75959659,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -152324,17 +149553,10 @@
     "name": "Wooden Hammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 295,
-    "weight": 2.48,
-    "rank": 2,
-    "tier": 1.16210806,
-=======
     "price": 555,
     "weight": 2.33,
-    "heirloomLevel": 2,
+    "rank": 2,
     "tier": 1.95145833,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -152369,17 +149591,10 @@
     "name": "Wooden Hammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-<<<<<<< HEAD
-    "price": 248,
-    "weight": 2.48,
-    "rank": 3,
-    "tier": 0.9901986,
-=======
     "price": 898,
     "weight": 2.33,
-    "heirloomLevel": 3,
+    "rank": 3,
     "tier": 2.7592504,
->>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -152452,13 +149667,8 @@
     "type": "OneHandedWeapon",
     "price": 216,
     "weight": 1.42,
-<<<<<<< HEAD
     "rank": 1,
-    "tier": 0.8467218,
-=======
-    "heirloomLevel": 1,
     "tier": 0.8614832,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -152493,13 +149703,8 @@
     "type": "OneHandedWeapon",
     "price": 276,
     "weight": 1.42,
-<<<<<<< HEAD
     "rank": 2,
-    "tier": 0.711481452,
-=======
-    "heirloomLevel": 2,
     "tier": 1.0956769,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -152534,13 +149739,8 @@
     "type": "OneHandedWeapon",
     "price": 533,
     "weight": 1.42,
-<<<<<<< HEAD
     "rank": 3,
-    "tier": 0.606233,
-=======
-    "heirloomLevel": 3,
     "tier": 1.89384115,
->>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [

--- a/items.json
+++ b/items.json
@@ -123870,6 +123870,7 @@
     "culture": "Aserai",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 5140,
     "weight": 2.4,
     "rank": 1,
@@ -123880,6 +123881,12 @@
     "heirloomLevel": 1,
     "tier": 9.135182,
 >>>>>>> a1592ae (1433)
+=======
+    "price": 7917,
+    "weight": 2.32,
+    "heirloomLevel": 1,
+    "tier": 10.30562,
+>>>>>>> 1559a20 (1543)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -123890,8 +123897,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.63,
-        "handling": 90,
+        "balance": 0.66,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -123901,7 +123908,7 @@
         "thrustSpeed": 84,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 89
       }
     ]
   },
@@ -123911,6 +123918,7 @@
     "name": "Slightly Ridged Flyssa +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 3797,
     "weight": 2.4,
@@ -123922,6 +123930,12 @@
     "heirloomLevel": 2,
     "tier": 10.8876095,
 >>>>>>> a1592ae (1433)
+=======
+    "price": 7328,
+    "weight": 2.32,
+    "heirloomLevel": 2,
+    "tier": 9.872506,
+>>>>>>> 1559a20 (1543)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -123932,7 +123946,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.67,
+        "balance": 0.66,
         "handling": 91,
         "bodyArmor": 5,
         "flags": [
@@ -123940,10 +123954,10 @@
         ],
         "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 84,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -44757,6 +44757,7 @@
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 4242,
     "weight": 1.37,
     "rank": 1,
@@ -44767,6 +44768,12 @@
     "heirloomLevel": 1,
     "tier": 9.359575,
 >>>>>>> 617d082 (1507)
+=======
+    "price": 5771,
+    "weight": 1.37,
+    "heirloomLevel": 1,
+    "tier": 8.635548,
+>>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44777,18 +44784,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.53,
-        "handling": 87,
+        "balance": 0.44,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 93,
-        "swingDamage": 24,
+        "thrustSpeed": 92,
+        "swingDamage": 25,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 83
       }
     ]
   },
@@ -44798,6 +44805,7 @@
     "name": "Fine Steel Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 3146,
     "weight": 1.37,
@@ -44809,6 +44817,12 @@
     "heirloomLevel": 2,
     "tier": 9.373738,
 >>>>>>> 617d082 (1507)
+=======
+    "price": 5717,
+    "weight": 1.37,
+    "heirloomLevel": 2,
+    "tier": 8.589266,
+>>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44819,18 +44833,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.53,
-        "handling": 87,
+        "balance": 0.44,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 93,
-        "swingDamage": 25,
+        "thrustSpeed": 92,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 83
       }
     ]
   },
@@ -44840,6 +44854,7 @@
     "name": "Fine Steel Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2406,
     "weight": 1.37,
@@ -44851,6 +44866,12 @@
     "heirloomLevel": 3,
     "tier": 10.7215729,
 >>>>>>> 617d082 (1507)
+=======
+    "price": 7221,
+    "weight": 1.32,
+    "heirloomLevel": 3,
+    "tier": 9.7913,
+>>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44861,8 +44882,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 91,
-        "balance": 0.55,
-        "handling": 88,
+        "balance": 0.48,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -44870,9 +44891,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 93,
-        "swingDamage": 26,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 84
       }
     ]
   },
@@ -87326,6 +87347,7 @@
     "culture": "Neutral",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 1669,
     "weight": 2.58,
     "rank": 3,
@@ -87336,6 +87358,12 @@
     "heirloomLevel": 3,
     "tier": 8.314444,
 >>>>>>> 617d082 (1507)
+=======
+    "price": 4821,
+    "weight": 2.55,
+    "heirloomLevel": 3,
+    "tier": 7.79715443,
+>>>>>>> 67bc12d (a few brought closer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -87346,18 +87374,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 73,
-        "balance": 0.57,
-        "handling": 92,
+        "balance": 0.5,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 26,
+        "thrustSpeed": 82,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 87
+        "swingSpeed": 85
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -41104,10 +41104,17 @@
     "name": "Engraved Backsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5094,
     "weight": 2.03,
     "rank": 1,
     "tier": 8.045635,
+=======
+    "price": 7580,
+    "weight": 1.93,
+    "heirloomLevel": 1,
+    "tier": 10.0598507,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41120,18 +41127,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.46,
-        "handling": 82,
+        "balance": 0.53,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -41141,10 +41148,17 @@
     "name": "Engraved Backsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3763,
     "weight": 2.03,
     "rank": 2,
     "tier": 6.76056576,
+=======
+    "price": 8153,
+    "weight": 1.89,
+    "heirloomLevel": 2,
+    "tier": 10.4744015,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41157,18 +41171,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.46,
-        "handling": 82,
+        "balance": 0.55,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -41178,10 +41192,17 @@
     "name": "Engraved Backsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2866,
     "weight": 2.03,
     "rank": 3,
     "tier": 5.760485,
+=======
+    "price": 9197,
+    "weight": 1.89,
+    "heirloomLevel": 3,
+    "tier": 11.1944332,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41194,18 +41215,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.46,
-        "handling": 82,
+        "balance": 0.55,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -41326,10 +41347,15 @@
     "name": "Engraved Pointed Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 8098,
+    "price": 8791,
     "weight": 1.6,
+<<<<<<< HEAD
     "rank": 3,
     "tier": 10.4352427,
+=======
+    "heirloomLevel": 3,
+    "tier": 10.9196434,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41348,7 +41374,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 31,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
         "swingDamage": 32,
@@ -71460,10 +71486,15 @@
     "name": "Knightly Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5888,
+    "price": 7699,
     "weight": 1.66,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 8.733721,
+=======
+    "heirloomLevel": 2,
+    "tier": 10.14724,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -71482,7 +71513,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 30,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
         "swingDamage": 35,
@@ -71497,10 +71528,15 @@
     "name": "Knightly Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 7494,
+    "price": 8199,
     "weight": 1.59,
+<<<<<<< HEAD
     "rank": 3,
     "tier": 9.99612,
+=======
+    "heirloomLevel": 3,
+    "tier": 10.5068913,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -71519,7 +71555,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 30,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
         "swingDamage": 37,
@@ -116864,10 +116900,17 @@
     "name": "Scalpel +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5125,
     "weight": 1.74,
     "rank": 1,
     "tier": 8.073632,
+=======
+    "price": 7631,
+    "weight": 1.64,
+    "heirloomLevel": 1,
+    "tier": 10.0973539,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -116878,18 +116921,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.48,
-        "handling": 76,
+        "balance": 0.53,
+        "handling": 77,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -116899,10 +116942,17 @@
     "name": "Scalpel +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3786,
     "weight": 1.74,
     "rank": 2,
     "tier": 6.78409338,
+=======
+    "price": 6857,
+    "weight": 1.64,
+    "heirloomLevel": 2,
+    "tier": 9.513441,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -116913,18 +116963,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.48,
-        "handling": 76,
+        "balance": 0.53,
+        "handling": 77,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 35,
+        "thrustSpeed": 89,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -116934,10 +116984,17 @@
     "name": "Scalpel +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2883,
     "weight": 1.74,
     "rank": 3,
     "tier": 5.7805295,
+=======
+    "price": 7508,
+    "weight": 1.57,
+    "heirloomLevel": 3,
+    "tier": 10.0059519,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -116948,18 +117005,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.48,
-        "handling": 76,
+        "balance": 0.59,
+        "handling": 77,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 35,
+        "thrustSpeed": 90,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -118798,10 +118855,17 @@
     "name": "Short Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3208,
     "weight": 1.97,
     "rank": 1,
     "tier": 6.15762472,
+=======
+    "price": 4581,
+    "weight": 1.83,
+    "heirloomLevel": 1,
+    "tier": 7.572674,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -118814,18 +118878,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.67,
-        "handling": 89,
+        "balance": 0.74,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -118835,10 +118899,17 @@
     "name": "Short Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2396,
     "weight": 1.97,
     "rank": 2,
     "tier": 5.1741147,
+=======
+    "price": 5053,
+    "weight": 1.73,
+    "heirloomLevel": 2,
+    "tier": 8.008871,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -118851,18 +118922,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.67,
-        "handling": 89,
+        "balance": 0.8,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 89,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -118872,10 +118943,17 @@
     "name": "Short Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1845,
     "weight": 1.97,
     "rank": 3,
     "tier": 4.40871429,
+=======
+    "price": 5670,
+    "weight": 1.65,
+    "heirloomLevel": 3,
+    "tier": 8.549845,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -118888,18 +118966,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.67,
-        "handling": 89,
+        "balance": 0.83,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 94
       }
     ]
   },
@@ -143543,10 +143621,15 @@
     "name": "Tyrhung +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 6082,
+    "price": 6662,
     "weight": 1.43,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 8.894467,
+=======
+    "heirloomLevel": 2,
+    "tier": 9.361227,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -143565,7 +143648,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 31,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
         "swingDamage": 31,
@@ -143580,10 +143663,17 @@
     "name": "Tyrhung +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 6810,
     "weight": 1.43,
     "rank": 3,
     "tier": 9.476263,
+=======
+    "price": 8411,
+    "weight": 1.34,
+    "heirloomLevel": 3,
+    "tier": 10.6564846,
+>>>>>>> e19d1a9 (fixes)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -143596,18 +143686,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.61,
-        "handling": 78,
+        "balance": 0.65,
+        "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 31,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 92,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -41294,6 +41294,7 @@
     "culture": "Battania",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 5094,
     "weight": 2.03,
     "rank": 1,
@@ -41304,6 +41305,48 @@
     "heirloomLevel": 1,
     "tier": 10.0598507,
 >>>>>>> e19d1a9 (fixes)
+=======
+    "price": 6364,
+    "weight": 1.98,
+    "heirloomLevel": 1,
+    "tier": 9.124187,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 107,
+        "balance": 0.49,
+        "handling": 82,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 25,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 34,
+        "swingDamageType": "Cut",
+        "swingSpeed": 84
+      }
+    ]
+  },
+  {
+    "id": "crpg_engraved_backsword_h2",
+    "name": "Engraved Backsword +2",
+    "culture": "Battania",
+    "type": "OneHandedWeapon",
+    "price": 7440,
+    "weight": 1.93,
+    "heirloomLevel": 2,
+    "tier": 9.955603,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41322,6 +41365,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
@@ -41367,11 +41411,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 24,
+=======
+        "thrustDamage": 26,
+>>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 85
       }
     ]
   },
@@ -41381,6 +41428,7 @@
     "name": "Engraved Backsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2866,
     "weight": 2.03,
@@ -41392,6 +41440,12 @@
     "heirloomLevel": 3,
     "tier": 11.1944332,
 >>>>>>> e19d1a9 (fixes)
+=======
+    "price": 8471,
+    "weight": 1.89,
+    "heirloomLevel": 3,
+    "tier": 10.6980534,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41410,10 +41464,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 27,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
         "swingSpeed": 86
       }
@@ -42849,6 +42903,7 @@
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3256,
     "weight": 2.11,
     "rank": 2,
@@ -42859,6 +42914,48 @@
     "heirloomLevel": 2,
     "tier": 9.709291,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 6156,
+    "weight": 2.01,
+    "heirloomLevel": 2,
+    "tier": 8.95559,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 105,
+        "balance": 0.54,
+        "handling": 84,
+        "bodyArmor": 5,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 23,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 34,
+        "swingDamageType": "Cut",
+        "swingSpeed": 86
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_steel_arming_sword_h3",
+    "name": "Fine Steel Arming Sword +3",
+    "culture": "Vlandia",
+    "type": "OneHandedWeapon",
+    "price": 7268,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 9.827183,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42877,6 +42974,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
@@ -42922,11 +43020,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
+=======
+        "thrustDamage": 25,
+>>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -43141,6 +43242,7 @@
     "culture": "Battania",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3646,
     "weight": 2.33,
     "rank": 1,
@@ -43151,6 +43253,12 @@
     "heirloomLevel": 1,
     "tier": 8.687544,
 >>>>>>> 8c8f0e2 (1723)
+=======
+    "price": 6089,
+    "weight": 2.23,
+    "heirloomLevel": 1,
+    "tier": 8.900615,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43167,7 +43275,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 38,
@@ -43183,6 +43291,7 @@
     "culture": "Battania",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2714,
     "weight": 2.33,
     "rank": 2,
@@ -43193,6 +43302,12 @@
     "heirloomLevel": 2,
     "tier": 9.025386,
 >>>>>>> 8c8f0e2 (1723)
+=======
+    "price": 5377,
+    "weight": 2.23,
+    "heirloomLevel": 2,
+    "tier": 8.297085,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43203,18 +43318,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.28,
+        "balance": 0.25,
         "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 77
       }
     ]
   },
@@ -43224,6 +43339,7 @@
     "name": "Fine Steel Cavalry Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2083,
     "weight": 2.33,
@@ -43235,6 +43351,12 @@
     "heirloomLevel": 3,
     "tier": 9.428659,
 >>>>>>> 8c8f0e2 (1723)
+=======
+    "price": 6027,
+    "weight": 2.23,
+    "heirloomLevel": 3,
+    "tier": 8.849361,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43245,18 +43367,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.28,
+        "balance": 0.25,
         "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 78
+        "swingSpeed": 77
       }
     ]
   },
@@ -43513,6 +43635,7 @@
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2755,
     "weight": 2.04,
     "rank": 2,
@@ -43523,6 +43646,12 @@
     "heirloomLevel": 2,
     "tier": 8.93003,
 >>>>>>> 050a4f8 (0130)
+=======
+    "price": 5873,
+    "weight": 1.93,
+    "heirloomLevel": 2,
+    "tier": 8.721147,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43533,8 +43662,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.32,
-        "handling": 85,
+        "balance": 0.3,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -43555,6 +43684,7 @@
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2114,
     "weight": 2.04,
     "rank": 3,
@@ -43565,6 +43695,12 @@
     "heirloomLevel": 3,
     "tier": 9.556135,
 >>>>>>> 050a4f8 (0130)
+=======
+    "price": 6629,
+    "weight": 1.89,
+    "heirloomLevel": 3,
+    "tier": 9.335194,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43575,8 +43711,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.36,
-        "handling": 86,
+        "balance": 0.34,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -108087,6 +108223,7 @@
     "culture": "Neutral",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2681,
     "weight": 1.96,
     "rank": 2,
@@ -108097,6 +108234,46 @@
     "heirloomLevel": 2,
     "tier": 8.839773,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 5043,
+    "weight": 1.86,
+    "heirloomLevel": 2,
+    "tier": 8.000357,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 108,
+        "balance": 0.55,
+        "handling": 86,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 24,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 32,
+        "swingDamageType": "Cut",
+        "swingSpeed": 86
+      }
+    ]
+  },
+  {
+    "id": "crpg_pointed_falchion_h3",
+    "name": "Pointed Falchion +3",
+    "culture": "Neutral",
+    "type": "OneHandedWeapon",
+    "price": 6105,
+    "weight": 1.82,
+    "heirloomLevel": 3,
+    "tier": 8.91323948,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -108113,6 +108290,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
@@ -108156,11 +108334,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
+=======
+        "thrustDamage": 25,
+>>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -127553,6 +127734,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2532,
     "weight": 1.98,
     "rank": 2,
@@ -127563,6 +127745,48 @@
     "heirloomLevel": 2,
     "tier": 8.575342,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 4730,
+    "weight": 1.88,
+    "heirloomLevel": 2,
+    "tier": 7.71264124,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 105,
+        "balance": 0.48,
+        "handling": 86,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 23,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 34,
+        "swingDamageType": "Cut",
+        "swingSpeed": 84
+      }
+    ]
+  },
+  {
+    "id": "crpg_steel_long_warsword_h3",
+    "name": "Steel Long Warsword +3",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 5659,
+    "weight": 1.83,
+    "heirloomLevel": 3,
+    "tier": 8.540301,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127581,6 +127805,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
@@ -127626,11 +127851,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
+=======
+        "thrustDamage": 24,
+>>>>>>> 3b551c9 (bringingsomedownintier)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 85
       }
     ]
   },
@@ -131176,6 +131404,7 @@
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3003,
     "weight": 1.41,
     "rank": 1,
@@ -131186,6 +131415,48 @@
     "heirloomLevel": 1,
     "tier": 7.310702,
 >>>>>>> 050a4f8 (0130)
+=======
+    "price": 3892,
+    "weight": 1.36,
+    "heirloomLevel": 1,
+    "tier": 6.89428425,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 104,
+        "balance": 0.55,
+        "handling": 89,
+        "bodyArmor": 2,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 26,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 92,
+        "swingDamage": 29,
+        "swingDamageType": "Cut",
+        "swingSpeed": 86
+      }
+    ]
+  },
+  {
+    "id": "crpg_straight_saber_h2",
+    "name": "Straight Saber +2",
+    "culture": "Khuzait",
+    "type": "OneHandedWeapon",
+    "price": 4245,
+    "weight": 1.31,
+    "heirloomLevel": 2,
+    "tier": 7.24904871,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -131204,16 +131475,17 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
-        "swingDamage": 29,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 87
       }
     ]
   },
   {
+<<<<<<< HEAD
     "id": "crpg_straight_saber_h2",
     "baseId": "crpg_straight_saber",
     "name": "Straight Saber +2",
@@ -131230,6 +131502,16 @@
     "heirloomLevel": 2,
     "tier": 7.85113525,
 >>>>>>> 050a4f8 (0130)
+=======
+    "id": "crpg_straight_saber_h3",
+    "name": "Straight Saber +3",
+    "culture": "Khuzait",
+    "type": "OneHandedWeapon",
+    "price": 5171,
+    "weight": 1.26,
+    "heirloomLevel": 3,
+    "tier": 8.11458,
+>>>>>>> 3b551c9 (bringingsomedownintier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -131248,9 +131530,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 25,
+        "thrustDamage": 27,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
+<<<<<<< HEAD
         "swingDamage": 30,
         "swingDamageType": "Cut",
         "swingSpeed": 88
@@ -131295,9 +131578,11 @@
         "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 94,
+=======
+>>>>>>> 3b551c9 (bringingsomedownintier)
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 88
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -21958,10 +21958,17 @@
     "name": "Broad Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3532,
     "weight": 1.99,
     "rank": 1,
     "tier": 6.514932,
+=======
+    "price": 5222,
+    "weight": 1.89,
+    "heirloomLevel": 1,
+    "tier": 8.160145,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -21972,8 +21979,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.55,
-        "handling": 87,
+        "balance": 0.61,
+        "handling": 88,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -21983,7 +21990,7 @@
         "thrustSpeed": 87,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -21993,10 +22000,17 @@
     "name": "Broad Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2631,
     "weight": 1.99,
     "rank": 2,
     "tier": 5.474352,
+=======
+    "price": 4889,
+    "weight": 1.89,
+    "heirloomLevel": 2,
+    "tier": 7.859778,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22007,8 +22021,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.55,
-        "handling": 87,
+        "balance": 0.61,
+        "handling": 88,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -22016,9 +22030,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 31,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -22028,10 +22042,17 @@
     "name": "Broad Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2021,
     "weight": 1.99,
     "rank": 3,
     "tier": 4.66453648,
+=======
+    "price": 5838,
+    "weight": 1.89,
+    "heirloomLevel": 3,
+    "tier": 8.691618,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -22042,8 +22063,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.55,
-        "handling": 87,
+        "balance": 0.61,
+        "handling": 88,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -22051,9 +22072,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 31,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -31464,10 +31485,17 @@
     "name": "Decorated Elite Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5308,
     "weight": 2.35,
     "rank": 1,
     "tier": 8.236036,
+=======
+    "price": 7840,
+    "weight": 2.25,
+    "heirloomLevel": 1,
+    "tier": 10.24925,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31480,18 +31508,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.66,
-        "handling": 86,
+        "balance": 0.72,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -31501,10 +31529,17 @@
     "name": "Decorated Elite Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3918,
     "weight": 2.35,
     "rank": 2,
     "tier": 6.920559,
+=======
+    "price": 7328,
+    "weight": 2.25,
+    "heirloomLevel": 2,
+    "tier": 9.871988,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31517,18 +31552,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.66,
-        "handling": 86,
+        "balance": 0.72,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 31,
+        "thrustSpeed": 85,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -31538,10 +31573,17 @@
     "name": "Decorated Elite Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2981,
     "weight": 2.35,
     "rank": 3,
     "tier": 5.896807,
+=======
+    "price": 8787,
+    "weight": 2.25,
+    "heirloomLevel": 3,
+    "tier": 10.9167919,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -31554,18 +31596,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.66,
-        "handling": 86,
+        "balance": 0.72,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 31,
+        "thrustSpeed": 85,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -32020,10 +32062,17 @@
     "name": "Decorated Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5323,
     "weight": 1.9,
     "rank": 1,
     "tier": 8.249861,
+=======
+    "price": 8139,
+    "weight": 1.77,
+    "heirloomLevel": 1,
+    "tier": 10.4640341,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32036,18 +32085,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 87,
+        "balance": 0.75,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -32057,10 +32106,17 @@
     "name": "Decorated Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3929,
     "weight": 1.9,
     "rank": 2,
     "tier": 6.932177,
+=======
+    "price": 7593,
+    "weight": 1.77,
+    "heirloomLevel": 2,
+    "tier": 10.0691195,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32073,18 +32129,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 87,
+        "balance": 0.75,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -32094,10 +32150,17 @@
     "name": "Decorated Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2990,
     "weight": 1.9,
     "rank": 3,
     "tier": 5.90670824,
+=======
+    "price": 8557,
+    "weight": 1.74,
+    "heirloomLevel": 3,
+    "tier": 10.75799,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32110,18 +32173,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 87,
+        "balance": 0.78,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -45172,10 +45235,17 @@
     "name": "Fine Steel Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4208,
     "weight": 1.5,
     "rank": 1,
     "tier": 7.2121377,
+=======
+    "price": 6148,
+    "weight": 1.42,
+    "heirloomLevel": 1,
+    "tier": 8.948861,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45186,18 +45256,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.7,
-        "handling": 89,
+        "balance": 0.76,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
+        "thrustSpeed": 92,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -45207,10 +45277,17 @@
     "name": "Fine Steel Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3122,
     "weight": 1.5,
     "rank": 2,
     "tier": 6.06019974,
+=======
+    "price": 5798,
+    "weight": 1.42,
+    "heirloomLevel": 2,
+    "tier": 8.65814,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45221,18 +45298,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.7,
-        "handling": 89,
+        "balance": 0.76,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 30,
+        "thrustSpeed": 92,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -45242,10 +45319,17 @@
     "name": "Fine Steel Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2388,
     "weight": 1.5,
     "rank": 3,
     "tier": 5.163722,
+=======
+    "price": 7038,
+    "weight": 1.42,
+    "heirloomLevel": 3,
+    "tier": 9.652838,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -45256,18 +45340,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.7,
-        "handling": 89,
+        "balance": 0.76,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 90,
-        "swingDamage": 30,
+        "thrustSpeed": 92,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -64806,10 +64890,17 @@
     "name": "Iron Cavalry Scimitar +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3074,
     "weight": 1.85,
     "rank": 1,
     "tier": 6.00507832,
+=======
+    "price": 4676,
+    "weight": 1.74,
+    "heirloomLevel": 1,
+    "tier": 7.662101,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64822,18 +64913,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 112,
-        "balance": 0.31,
-        "handling": 84,
+        "balance": 0.39,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
+        "thrustSpeed": 89,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -64843,10 +64934,17 @@
     "name": "Iron Cavalry Scimitar +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2299,
     "weight": 1.85,
     "rank": 2,
     "tier": 5.04593372,
+=======
+    "price": 4264,
+    "weight": 1.74,
+    "heirloomLevel": 2,
+    "tier": 7.267396,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64859,18 +64957,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 112,
-        "balance": 0.31,
-        "handling": 84,
+        "balance": 0.39,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 35,
+        "thrustSpeed": 89,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -64880,10 +64978,17 @@
     "name": "Iron Cavalry Scimitar +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1772,
     "weight": 1.85,
     "rank": 3,
     "tier": 4.299495,
+=======
+    "price": 4982,
+    "weight": 1.68,
+    "heirloomLevel": 3,
+    "tier": 7.94463825,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64896,18 +65001,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 112,
-        "balance": 0.31,
-        "handling": 84,
+        "balance": 0.43,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 35,
+        "thrustSpeed": 89,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -65121,10 +65226,17 @@
     "name": "Iron Cleaver +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2710,
     "weight": 2.14,
     "rank": 1,
     "tier": 5.571284,
+=======
+    "price": 4088,
+    "weight": 2.0,
+    "heirloomLevel": 1,
+    "tier": 7.093058,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65135,8 +65247,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.37,
-        "handling": 74,
+        "balance": 0.44,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -65146,7 +65258,7 @@
         "thrustSpeed": 85,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -65156,10 +65268,17 @@
     "name": "Iron Cleaver +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2033,
     "weight": 2.14,
     "rank": 2,
     "tier": 4.68142557,
+=======
+    "price": 4429,
+    "weight": 1.95,
+    "heirloomLevel": 2,
+    "tier": 7.427265,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65170,18 +65289,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.37,
-        "handling": 74,
+        "balance": 0.47,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 37,
+        "thrustSpeed": 87,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 84
       }
     ]
   },
@@ -65191,10 +65310,17 @@
     "name": "Iron Cleaver +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1573,
     "weight": 2.14,
     "rank": 3,
     "tier": 3.98890734,
+=======
+    "price": 4882,
+    "weight": 1.86,
+    "heirloomLevel": 3,
+    "tier": 7.8531127,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65205,18 +65331,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.37,
-        "handling": 74,
+        "balance": 0.51,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 37,
+        "thrustSpeed": 87,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 81
+        "swingSpeed": 85
       }
     ]
   },
@@ -65432,10 +65558,17 @@
     "name": "Iron Flyssa +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2743,
     "weight": 1.56,
     "rank": 1,
     "tier": 5.61180973,
+=======
+    "price": 4199,
+    "weight": 1.48,
+    "heirloomLevel": 1,
+    "tier": 7.20373,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65448,8 +65581,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.53,
-        "handling": 86,
+        "balance": 0.6,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -65459,7 +65592,7 @@
         "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -65469,10 +65602,17 @@
     "name": "Iron Flyssa +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2057,
     "weight": 1.56,
     "rank": 2,
     "tier": 4.715478,
+=======
+    "price": 3962,
+    "weight": 1.48,
+    "heirloomLevel": 2,
+    "tier": 6.96567774,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65485,8 +65625,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.53,
-        "handling": 86,
+        "balance": 0.6,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -65494,9 +65634,9 @@
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 30,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -65506,10 +65646,17 @@
     "name": "Iron Flyssa +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1591,
     "weight": 1.56,
     "rank": 3,
     "tier": 4.017924,
+=======
+    "price": 4706,
+    "weight": 1.43,
+    "heirloomLevel": 3,
+    "tier": 7.69085932,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65522,18 +65669,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.53,
-        "handling": 86,
+        "balance": 0.62,
+        "handling": 89,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 30,
+        "thrustSpeed": 92,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -66583,10 +66730,17 @@
     "name": "Iron Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2456,
     "weight": 1.99,
     "rank": 1,
     "tier": 5.2521925,
+=======
+    "price": 3588,
+    "weight": 1.91,
+    "heirloomLevel": 1,
+    "tier": 6.575177,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66599,18 +66753,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 89,
+        "balance": 0.7,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -66620,10 +66774,17 @@
     "name": "Iron Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1848,
     "weight": 1.99,
     "rank": 2,
     "tier": 4.413302,
+=======
+    "price": 3452,
+    "weight": 1.91,
+    "heirloomLevel": 2,
+    "tier": 6.428775,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66636,18 +66797,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 89,
+        "balance": 0.7,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 29,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -66657,10 +66818,17 @@
     "name": "Iron Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1434,
     "weight": 1.99,
     "rank": 3,
     "tier": 3.76044536,
+=======
+    "price": 4133,
+    "weight": 1.88,
+    "heirloomLevel": 3,
+    "tier": 7.13725042,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66673,18 +66841,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 89,
+        "balance": 0.72,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 29,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 91
       }
     ]
   },
@@ -122670,10 +122838,17 @@
     "name": "Simple Scimitar +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2097,
     "weight": 2.12,
     "rank": 1,
     "tier": 4.77104855,
+=======
+    "price": 3030,
+    "weight": 2.02,
+    "heirloomLevel": 1,
+    "tier": 5.95360041,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122686,18 +122861,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.61,
-        "handling": 84,
+        "balance": 0.67,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -122707,10 +122882,17 @@
     "name": "Simple Scimitar +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1585,
     "weight": 2.12,
     "rank": 2,
     "tier": 4.009005,
+=======
+    "price": 2889,
+    "weight": 2.02,
+    "heirloomLevel": 2,
+    "tier": 5.787786,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122723,18 +122905,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.61,
-        "handling": 84,
+        "balance": 0.67,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -122744,10 +122926,17 @@
     "name": "Simple Scimitar +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1236,
     "weight": 2.12,
     "rank": 3,
     "tier": 3.415958,
+=======
+    "price": 3526,
+    "weight": 2.02,
+    "heirloomLevel": 3,
+    "tier": 6.50896549,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122760,18 +122949,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.61,
-        "handling": 84,
+        "balance": 0.67,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -124616,10 +124805,17 @@
     "name": "Soldier's Cleaver +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5193,
     "weight": 2.2,
     "rank": 1,
     "tier": 8.134172,
+=======
+    "price": 7540,
+    "weight": 2.06,
+    "heirloomLevel": 1,
+    "tier": 10.0302715,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124630,7 +124826,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.44,
+        "balance": 0.51,
         "handling": 75,
         "bodyArmor": 2,
         "flags": [
@@ -124641,7 +124837,7 @@
         "thrustSpeed": 85,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -124651,10 +124847,17 @@
     "name": "Soldier's Cleaver +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3835,
     "weight": 2.2,
     "rank": 2,
     "tier": 6.83496475,
+=======
+    "price": 8113,
+    "weight": 2.01,
+    "heirloomLevel": 2,
+    "tier": 10.44585,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124665,7 +124868,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.44,
+        "balance": 0.53,
         "handling": 75,
         "bodyArmor": 2,
         "flags": [
@@ -124674,9 +124877,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 85,
-        "swingDamage": 38,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -124686,10 +124889,17 @@
     "name": "Soldier's Cleaver +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2919,
     "weight": 2.2,
     "rank": 3,
     "tier": 5.82387447,
+=======
+    "price": 8890,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 10.987093,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -124700,7 +124910,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.44,
+        "balance": 0.58,
         "handling": 75,
         "bodyArmor": 2,
         "flags": [
@@ -124708,10 +124918,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 38,
+        "thrustSpeed": 87,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 87
       }
     ]
   },
@@ -127639,10 +127849,17 @@
     "name": "Star Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3215,
     "weight": 2.06,
     "rank": 1,
     "tier": 6.166212,
+=======
+    "price": 4874,
+    "weight": 1.97,
+    "heirloomLevel": 1,
+    "tier": 7.846354,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127653,18 +127870,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.36,
-        "handling": 84,
+        "balance": 0.42,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -127674,10 +127891,17 @@
     "name": "Star Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2401,
     "weight": 2.06,
     "rank": 2,
     "tier": 5.1813283,
+=======
+    "price": 4444,
+    "weight": 1.97,
+    "heirloomLevel": 2,
+    "tier": 7.44216061,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127688,18 +127912,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.36,
-        "handling": 84,
+        "balance": 0.42,
+        "handling": 85,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -127709,10 +127933,17 @@
     "name": "Star Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1849,
     "weight": 2.06,
     "rank": 3,
     "tier": 4.41486263,
+=======
+    "price": 5182,
+    "weight": 1.93,
+    "heirloomLevel": 3,
+    "tier": 8.125046,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127723,18 +127954,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.36,
-        "handling": 84,
+        "balance": 0.45,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 35,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -151386,10 +151617,15 @@
     "name": "Wooden Sword +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 212,
+    "price": 216,
     "weight": 1.42,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 0.8467218,
+=======
+    "heirloomLevel": 1,
+    "tier": 0.8614832,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151407,7 +151643,7 @@
           "MeleeWeapon",
           "NoBlood"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 12,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 92,
         "swingDamage": 10,
@@ -151422,10 +151658,15 @@
     "name": "Wooden Sword +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 180,
+    "price": 276,
     "weight": 1.42,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 0.711481452,
+=======
+    "heirloomLevel": 2,
+    "tier": 1.0956769,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151443,10 +151684,10 @@
           "MeleeWeapon",
           "NoBlood"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 13,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 92,
-        "swingDamage": 10,
+        "swingDamage": 11,
         "swingDamageType": "Blunt",
         "swingSpeed": 92
       }
@@ -151458,10 +151699,15 @@
     "name": "Wooden Sword +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 157,
+    "price": 533,
     "weight": 1.42,
+<<<<<<< HEAD
     "rank": 3,
     "tier": 0.606233,
+=======
+    "heirloomLevel": 3,
+    "tier": 1.89384115,
+>>>>>>> a01ffc9 (2332)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -151479,10 +151725,10 @@
           "MeleeWeapon",
           "NoBlood"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 13,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 92,
-        "swingDamage": 10,
+        "swingDamage": 13,
         "swingDamageType": "Blunt",
         "swingSpeed": 92
       }

--- a/items.json
+++ b/items.json
@@ -41252,10 +41252,10 @@
     "name": "Engraved Pointed Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5215,
-    "weight": 1.77,
+    "price": 7710,
+    "weight": 1.65,
     "rank": 1,
-    "tier": 8.154159,
+    "tier": 10.1551456,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41268,18 +41268,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.55,
-        "handling": 90,
+        "balance": 0.62,
+        "handling": 92,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -41289,10 +41289,10 @@
     "name": "Engraved Pointed Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 3851,
-    "weight": 1.77,
+    "price": 8121,
+    "weight": 1.6,
     "rank": 2,
-    "tier": 6.851758,
+    "tier": 10.4515219,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41305,18 +41305,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.55,
-        "handling": 90,
+        "balance": 0.66,
+        "handling": 92,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -41326,10 +41326,10 @@
     "name": "Engraved Pointed Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 2931,
-    "weight": 1.77,
+    "price": 8098,
+    "weight": 1.6,
     "rank": 3,
-    "tier": 5.83818626,
+    "tier": 10.4352427,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41342,18 +41342,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.55,
-        "handling": 90,
+        "balance": 0.66,
+        "handling": 92,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 30,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -71318,10 +71318,10 @@
     "name": "Knightly Cavalry Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5163,
-    "weight": 1.78,
+    "price": 6194,
+    "weight": 1.68,
     "rank": 1,
-    "tier": 8.107614,
+    "tier": 8.986552,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -71334,18 +71334,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.3,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 78
       }
     ]
   },
@@ -71355,10 +71355,10 @@
     "name": "Knightly Cavalry Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 3813,
-    "weight": 1.78,
+    "price": 5888,
+    "weight": 1.66,
     "rank": 2,
-    "tier": 6.812648,
+    "tier": 8.733721,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -71371,18 +71371,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.31,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 34,
+        "thrustSpeed": 89,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 79
       }
     ]
   },
@@ -71392,10 +71392,10 @@
     "name": "Knightly Cavalry Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 2903,
-    "weight": 1.78,
+    "price": 7494,
+    "weight": 1.59,
     "rank": 3,
-    "tier": 5.80486,
+    "tier": 9.99612,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -71408,18 +71408,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.23,
-        "handling": 83,
+        "balance": 0.36,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 34,
+        "thrustSpeed": 90,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 80
       }
     ]
   },
@@ -107962,10 +107962,10 @@
     "name": "Pointed Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3094,
-    "weight": 2.0,
+    "price": 4121,
+    "weight": 1.89,
     "rank": 1,
-    "tier": 6.02778053,
+    "tier": 7.125473,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -107978,7 +107978,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.61,
+        "balance": 0.67,
         "handling": 86,
         "bodyArmor": 0,
         "flags": [
@@ -107989,7 +107989,7 @@
         "thrustSpeed": 87,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -107999,10 +107999,10 @@
     "name": "Pointed Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 2313,
-    "weight": 2.0,
+    "price": 4425,
+    "weight": 1.81,
     "rank": 2,
-    "tier": 5.06500959,
+    "tier": 7.42408133,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -108015,7 +108015,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.61,
+        "balance": 0.71,
         "handling": 86,
         "bodyArmor": 0,
         "flags": [
@@ -108023,10 +108023,10 @@
         ],
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 88,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 91
       }
     ]
   },
@@ -108036,10 +108036,10 @@
     "name": "Pointed Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1783,
-    "weight": 2.0,
+    "price": 5389,
+    "weight": 1.74,
     "rank": 3,
-    "tier": 4.31574869,
+    "tier": 8.307131,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -108052,18 +108052,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.61,
-        "handling": 86,
+        "balance": 0.75,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 30,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 89,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 92
       }
     ]
   },
@@ -137866,10 +137866,10 @@
     "name": "Thamaskene Pointed Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4171,
-    "weight": 1.87,
+    "price": 5852,
+    "weight": 1.76,
     "rank": 1,
-    "tier": 7.175756,
+    "tier": 8.703283,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -137882,18 +137882,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.66,
-        "handling": 84,
+        "balance": 0.71,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 91
       }
     ]
   },
@@ -137903,10 +137903,10 @@
     "name": "Thamaskene Pointed Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3095,
-    "weight": 1.87,
+    "price": 6192,
+    "weight": 1.71,
     "rank": 2,
-    "tier": 6.02962971,
+    "tier": 8.984796,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -137919,18 +137919,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.66,
-        "handling": 84,
+        "balance": 0.75,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 92
       }
     ]
   },
@@ -137940,10 +137940,10 @@
     "name": "Thamaskene Pointed Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 2368,
-    "weight": 1.87,
+    "price": 7099,
+    "weight": 1.66,
     "rank": 3,
-    "tier": 5.137673,
+    "tier": 9.698905,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -137956,18 +137956,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.66,
-        "handling": 84,
+        "balance": 0.77,
+        "handling": 85,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 32,
+        "thrustDamage": 33,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 93
       }
     ]
   },
@@ -138304,10 +138304,10 @@
     "name": "Thamaskene Steel Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 5248,
-    "weight": 1.6,
+    "price": 7441,
+    "weight": 1.52,
     "rank": 1,
-    "tier": 8.183401,
+    "tier": 9.95623,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138318,8 +138318,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.52,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -138329,7 +138329,7 @@
         "thrustSpeed": 90,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -138339,10 +138339,10 @@
     "name": "Thamaskene Steel Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 3875,
-    "weight": 1.6,
+    "price": 8093,
+    "weight": 1.47,
     "rank": 2,
-    "tier": 6.87633038,
+    "tier": 10.4313831,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138353,8 +138353,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -138362,9 +138362,9 @@
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 32,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -138374,10 +138374,10 @@
     "name": "Thamaskene Steel Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 2949,
-    "weight": 1.6,
+    "price": 8958,
+    "weight": 1.47,
     "rank": 3,
-    "tier": 5.85912228,
+    "tier": 11.033041,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138388,8 +138388,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -138397,9 +138397,9 @@
         "thrustDamage": 30,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 32,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -143338,10 +143338,10 @@
     "name": "Tyrhung +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 4899,
-    "weight": 1.64,
+    "price": 5846,
+    "weight": 1.48,
     "rank": 1,
-    "tier": 7.869052,
+    "tier": 8.69873,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -143354,7 +143354,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.5,
+        "balance": 0.59,
         "handling": 78,
         "bodyArmor": 3,
         "flags": [
@@ -143362,10 +143362,10 @@
         ],
         "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -143375,10 +143375,10 @@
     "name": "Tyrhung +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 3622,
-    "weight": 1.64,
+    "price": 6082,
+    "weight": 1.43,
     "rank": 2,
-    "tier": 6.61219025,
+    "tier": 8.894467,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -143391,7 +143391,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.5,
+        "balance": 0.61,
         "handling": 78,
         "bodyArmor": 3,
         "flags": [
@@ -143399,10 +143399,10 @@
         ],
         "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -143412,10 +143412,10 @@
     "name": "Tyrhung +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 2761,
-    "weight": 1.64,
+    "price": 6810,
+    "weight": 1.43,
     "rank": 3,
-    "tier": 5.634056,
+    "tier": 9.476263,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -143428,7 +143428,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 107,
-        "balance": 0.5,
+        "balance": 0.61,
         "handling": 78,
         "bodyArmor": 3,
         "flags": [
@@ -143436,10 +143436,10 @@
         ],
         "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -73988,10 +73988,17 @@
     "name": "Knobbed Club +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 859,
     "weight": 2.44,
     "rank": 1,
     "tier": 2.67501688,
+=======
+    "price": 1232,
+    "weight": 2.34,
+    "heirloomLevel": 1,
+    "tier": 3.40950155,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74002,18 +74009,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 54,
-        "balance": 0.33,
-        "handling": 88,
+        "balance": 0.38,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -74023,10 +74030,17 @@
     "name": "Knobbed Club +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 672,
     "weight": 2.44,
     "rank": 2,
     "tier": 2.24775743,
+=======
+    "price": 1481,
+    "weight": 2.26,
+    "heirloomLevel": 2,
+    "tier": 3.83876228,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74037,18 +74051,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 54,
-        "balance": 0.33,
-        "handling": 88,
+        "balance": 0.43,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 26,
+        "thrustSpeed": 85,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -74058,10 +74072,17 @@
     "name": "Knobbed Club +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 541,
     "weight": 2.44,
     "rank": 3,
     "tier": 1.91524887,
+=======
+    "price": 1871,
+    "weight": 2.26,
+    "heirloomLevel": 3,
+    "tier": 4.44748259,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -74072,18 +74093,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 54,
-        "balance": 0.33,
-        "handling": 88,
+        "balance": 0.43,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 26,
+        "thrustSpeed": 85,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -85821,10 +85842,15 @@
     "name": "Medium Goedendag +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4795,
+    "price": 6378,
     "weight": 1.76,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 7.773378,
+=======
+    "heirloomLevel": 1,
+    "tier": 9.135416,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -85844,7 +85870,7 @@
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 25,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
         "swingSpeed": 85
       }
@@ -85856,10 +85882,15 @@
     "name": "Medium Goedendag +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3547,
+    "price": 6336,
     "weight": 1.76,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.53179646,
+=======
+    "heirloomLevel": 2,
+    "tier": 9.10117149,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -85876,10 +85907,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 25,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
         "swingSpeed": 85
       }
@@ -85891,10 +85922,17 @@
     "name": "Medium Goedendag +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2705,
     "weight": 1.76,
     "rank": 3,
     "tier": 5.56555557,
+=======
+    "price": 7928,
+    "weight": 1.73,
+    "heirloomLevel": 3,
+    "tier": 10.3131495,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -85905,18 +85943,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.52,
-        "handling": 89,
+        "balance": 0.55,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 25,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -86543,10 +86581,15 @@
     "name": "Military Hammer +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 5189,
+    "price": 7001,
     "weight": 1.45,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 8.130808,
+=======
+    "heirloomLevel": 1,
+    "tier": 9.624474,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -86568,7 +86611,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 91,
-        "swingDamage": 25,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
         "swingSpeed": 85
       }
@@ -86580,10 +86623,15 @@
     "name": "Military Hammer +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3832,
+    "price": 6856,
     "weight": 1.45,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 6.83213568,
+=======
+    "heirloomLevel": 2,
+    "tier": 9.512148,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -86605,7 +86653,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 91,
-        "swingDamage": 25,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
         "swingSpeed": 85
       }
@@ -86617,10 +86665,17 @@
     "name": "Military Hammer +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2917,
     "weight": 1.45,
     "rank": 3,
     "tier": 5.821466,
+=======
+    "price": 8195,
+    "weight": 1.42,
+    "heirloomLevel": 3,
+    "tier": 10.5043592,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -86633,7 +86688,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 78,
-        "balance": 0.52,
+        "balance": 0.55,
         "handling": 87,
         "bodyArmor": 0,
         "flags": [
@@ -86641,10 +86696,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 91,
-        "swingDamage": 25,
+        "thrustSpeed": 92,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -128732,10 +128787,17 @@
     "name": "Steel Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4272,
     "weight": 2.31,
     "rank": 1,
     "tier": 7.275543,
+=======
+    "price": 6522,
+    "weight": 2.25,
+    "heirloomLevel": 1,
+    "tier": 9.250165,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128746,8 +128808,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.39,
-        "handling": 78,
+        "balance": 0.45,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -128757,7 +128819,7 @@
         "thrustSpeed": 84,
         "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -128767,10 +128829,17 @@
     "name": "Steel Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3169,
     "weight": 2.31,
     "rank": 2,
     "tier": 6.113476,
+=======
+    "price": 6387,
+    "weight": 2.25,
+    "heirloomLevel": 2,
+    "tier": 9.142207,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128781,8 +128850,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.39,
-        "handling": 78,
+        "balance": 0.45,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -128790,9 +128859,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 84,
-        "swingDamage": 26,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 83
       }
     ]
   },
@@ -128802,10 +128871,17 @@
     "name": "Steel Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2423,
     "weight": 2.31,
     "rank": 3,
     "tier": 5.209118,
+=======
+    "price": 7663,
+    "weight": 2.22,
+    "heirloomLevel": 3,
+    "tier": 10.1207523,
+>>>>>>> 1597247 (0046)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -128816,18 +128892,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.39,
-        "handling": 78,
+        "balance": 0.48,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 26,
+        "thrustSpeed": 85,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 84
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -45252,6 +45252,7 @@
     "culture": "Empire",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2110,
     "weight": 1.91,
     "rank": 1,
@@ -45262,6 +45263,12 @@
     "heirloomLevel": 1,
     "tier": 5.995843,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 3174,
+    "weight": 1.84,
+    "heirloomLevel": 1,
+    "tier": 6.119334,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45280,7 +45287,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 30,
@@ -45296,6 +45303,7 @@
     "culture": "Empire",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 1595,
     "weight": 1.91,
     "rank": 2,
@@ -45306,6 +45314,12 @@
     "heirloomLevel": 2,
     "tier": 6.508357,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 3770,
+    "weight": 1.8,
+    "heirloomLevel": 2,
+    "tier": 6.76727057,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45324,7 +45338,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
         "swingDamage": 31,
@@ -45340,6 +45354,7 @@
     "culture": "Empire",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 1243,
     "weight": 1.91,
     "rank": 3,
@@ -45350,6 +45365,12 @@
     "heirloomLevel": 3,
     "tier": 7.143512,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 3710,
+    "weight": 1.8,
+    "heirloomLevel": 3,
+    "tier": 6.705321,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45362,18 +45383,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.57,
-        "handling": 89,
+        "balance": 0.54,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 88,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 86
       }
     ]
   },
@@ -65593,6 +65614,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2793,
     "weight": 2.11,
     "rank": 1,
@@ -65603,6 +65625,12 @@
     "heirloomLevel": 1,
     "tier": 7.2975297,
 >>>>>>> 9e69aca (0231)
+=======
+    "price": 4427,
+    "weight": 1.98,
+    "heirloomLevel": 1,
+    "tier": 7.42545557,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65621,7 +65649,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 32,
@@ -65637,6 +65665,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2094,
     "weight": 2.11,
     "rank": 2,
@@ -65647,6 +65676,48 @@
     "heirloomLevel": 2,
     "tier": 7.6900177,
 >>>>>>> 9e69aca (0231)
+=======
+    "price": 4208,
+    "weight": 1.98,
+    "heirloomLevel": 2,
+    "tier": 7.21247,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 103,
+        "balance": 0.53,
+        "handling": 86,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 23,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 33,
+        "swingDamageType": "Cut",
+        "swingSpeed": 85
+      }
+    ]
+  },
+  {
+    "id": "crpg_iron_long_warsword_h3",
+    "name": "Iron Long Warsword +3",
+    "culture": "Sturgia",
+    "type": "OneHandedWeapon",
+    "price": 4826,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 7.802027,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65665,6 +65736,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
@@ -65710,11 +65782,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
+=======
+        "thrustDamage": 24,
+>>>>>>> d2d2909 (afewmorebroughtdown)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 86
       }
     ]
   },
@@ -66167,6 +66242,7 @@
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2564,
     "weight": 2.12,
     "rank": 1,
@@ -66177,6 +66253,12 @@
     "heirloomLevel": 1,
     "tier": 6.70851231,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 3826,
+    "weight": 1.99,
+    "heirloomLevel": 1,
+    "tier": 6.82574749,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66195,7 +66277,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 29,
@@ -66211,6 +66293,7 @@
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 1927,
     "weight": 2.12,
     "rank": 2,
@@ -66221,6 +66304,48 @@
     "heirloomLevel": 2,
     "tier": 7.13018656,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 3719,
+    "weight": 1.99,
+    "heirloomLevel": 2,
+    "tier": 6.714681,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 99,
+        "balance": 0.66,
+        "handling": 87,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 23,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 30,
+        "swingDamageType": "Cut",
+        "swingSpeed": 89
+      }
+    ]
+  },
+  {
+    "id": "crpg_iron_saber_h3",
+    "name": "Iron Saber +3",
+    "culture": "Khuzait",
+    "type": "OneHandedWeapon",
+    "price": 4316,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 7.318255,
+>>>>>>> d2d2909 (afewmorebroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -66239,6 +66364,7 @@
         "flags": [
           "MeleeWeapon"
         ],
+<<<<<<< HEAD
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
@@ -66284,11 +66410,14 @@
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
+=======
+        "thrustDamage": 24,
+>>>>>>> d2d2909 (afewmorebroughtdown)
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 91
+        "swingSpeed": 90
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -32593,6 +32593,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 5191,
     "weight": 1.86,
     "rank": 1,
@@ -32603,6 +32604,12 @@
     "heirloomLevel": 1,
     "tier": 9.801615,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 7464,
+    "weight": 1.76,
+    "heirloomLevel": 1,
+    "tier": 9.973673,
+>>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32621,7 +32628,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
         "swingDamage": 31,
@@ -32637,6 +32644,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3833,
     "weight": 1.86,
     "rank": 2,
@@ -32647,6 +32655,12 @@
     "heirloomLevel": 2,
     "tier": 10.2837458,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 7125,
+    "weight": 1.76,
+    "heirloomLevel": 2,
+    "tier": 9.718939,
+>>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32659,18 +32673,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.8,
+        "balance": 0.75,
         "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 93
+        "swingSpeed": 92
       }
     ]
   },
@@ -32680,6 +32694,7 @@
     "name": "Decorated Northern Backsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2918,
     "weight": 1.86,
@@ -32691,6 +32706,12 @@
     "heirloomLevel": 3,
     "tier": 11.161087,
 >>>>>>> 150f2d5 (0203)
+=======
+    "price": 8609,
+    "weight": 1.76,
+    "heirloomLevel": 3,
+    "tier": 10.7944517,
+>>>>>>> f87d5c5 (DNBbroughtdown)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32703,18 +32724,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.83,
-        "handling": 90,
+        "balance": 0.75,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 33,
+        "thrustSpeed": 89,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 92
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -32042,10 +32042,17 @@
     "name": "Decorated Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4879,
     "weight": 2.08,
     "rank": 1,
     "tier": 7.85095835,
+=======
+    "price": 7572,
+    "weight": 1.95,
+    "heirloomLevel": 1,
+    "tier": 10.0533495,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32058,18 +32065,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.42,
-        "handling": 89,
+        "balance": 0.49,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -32079,10 +32086,17 @@
     "name": "Decorated Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3608,
     "weight": 2.08,
     "rank": 2,
     "tier": 6.59698248,
+=======
+    "price": 7099,
+    "weight": 1.95,
+    "heirloomLevel": 2,
+    "tier": 9.699401,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32095,18 +32109,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.42,
-        "handling": 89,
+        "balance": 0.49,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -32116,10 +32130,17 @@
     "name": "Decorated Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2750,
     "weight": 2.08,
     "rank": 3,
     "tier": 5.6211,
+=======
+    "price": 8093,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 10.4318752,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32132,18 +32153,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 104,
-        "balance": 0.42,
-        "handling": 89,
+        "balance": 0.52,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -42909,10 +42930,17 @@
     "name": "Fine Steel Cavalry Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3646,
     "weight": 2.33,
     "rank": 1,
     "tier": 6.63714838,
+=======
+    "price": 5833,
+    "weight": 2.23,
+    "heirloomLevel": 1,
+    "tier": 8.687544,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -42923,18 +42951,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.19,
-        "handling": 80,
+        "balance": 0.25,
+        "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 77
       }
     ]
   },
@@ -42944,10 +42972,17 @@
     "name": "Fine Steel Cavalry Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2714,
     "weight": 2.33,
     "rank": 2,
     "tier": 5.57705,
+=======
+    "price": 6242,
+    "weight": 2.19,
+    "heirloomLevel": 2,
+    "tier": 9.025386,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -42958,18 +42993,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.19,
-        "handling": 80,
+        "balance": 0.28,
+        "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 38,
+        "thrustSpeed": 85,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 78
       }
     ]
   },
@@ -42979,10 +43014,17 @@
     "name": "Fine Steel Cavalry Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2083,
     "weight": 2.33,
     "rank": 3,
     "tier": 4.75204372,
+=======
+    "price": 6748,
+    "weight": 2.19,
+    "heirloomLevel": 3,
+    "tier": 9.428659,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -42993,18 +43035,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.19,
-        "handling": 80,
+        "balance": 0.28,
+        "handling": 82,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 38,
+        "thrustSpeed": 85,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 78
       }
     ]
   },
@@ -93964,6 +94006,7 @@
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2671,
     "weight": 1.41,
     "rank": 2,
@@ -93974,6 +94017,12 @@
     "heirloomLevel": 2,
     "tier": 8.664381,
 >>>>>>> 4dd0778 (0105)
+=======
+    "price": 5227,
+    "weight": 1.32,
+    "heirloomLevel": 2,
+    "tier": 8.164885,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -93984,18 +94033,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.66,
-        "handling": 90,
+        "balance": 0.63,
+        "handling": 89,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 29,
+        "thrustDamage": 30,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 89
+        "swingSpeed": 88
       }
     ]
   },
@@ -94005,6 +94054,7 @@
     "name": "Narrow Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2051,
     "weight": 1.41,
@@ -94016,6 +94066,12 @@
     "heirloomLevel": 3,
     "tier": 8.69514751,
 >>>>>>> 4dd0778 (0105)
+=======
+    "price": 6348,
+    "weight": 1.29,
+    "heirloomLevel": 3,
+    "tier": 9.110932,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -94032,7 +94088,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 30,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 93,
         "swingDamage": 31,
@@ -94082,10 +94138,17 @@
     "name": "Narrow Fine Steel Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5238,
     "weight": 2.22,
     "rank": 1,
     "tier": 8.174032,
+=======
+    "price": 7717,
+    "weight": 2.13,
+    "heirloomLevel": 1,
+    "tier": 10.1603336,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -94096,8 +94159,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.53,
-        "handling": 87,
+        "balance": 0.6,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -94107,7 +94170,7 @@
         "thrustSpeed": 85,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -94117,10 +94180,17 @@
     "name": "Narrow Fine Steel Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3867,
     "weight": 2.22,
     "rank": 2,
     "tier": 6.868459,
+=======
+    "price": 7258,
+    "weight": 2.13,
+    "heirloomLevel": 2,
+    "tier": 9.819742,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -94131,18 +94201,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.53,
-        "handling": 87,
+        "balance": 0.6,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 33,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -94152,10 +94222,17 @@
     "name": "Narrow Fine Steel Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2943,
     "weight": 2.22,
     "rank": 3,
     "tier": 5.85241365,
+=======
+    "price": 8645,
+    "weight": 2.07,
+    "heirloomLevel": 3,
+    "tier": 10.819356,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -94166,18 +94243,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.53,
-        "handling": 87,
+        "balance": 0.63,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 86,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -148814,10 +148891,17 @@
     "name": "Winds Fury +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5102,
     "weight": 1.69,
     "rank": 1,
     "tier": 8.052679,
+=======
+    "price": 7215,
+    "weight": 1.55,
+    "heirloomLevel": 1,
+    "tier": 9.78695,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148828,7 +148912,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.59,
+        "balance": 0.66,
         "handling": 76,
         "bodyArmor": 2,
         "flags": [
@@ -148836,10 +148920,10 @@
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 90,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -148849,10 +148933,17 @@
     "name": "Winds Fury +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3769,
     "weight": 1.69,
     "rank": 2,
     "tier": 6.76648331,
+=======
+    "price": 7388,
+    "weight": 1.46,
+    "heirloomLevel": 2,
+    "tier": 9.91673851,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148863,18 +148954,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.59,
-        "handling": 76,
+        "balance": 0.7,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 34,
+        "thrustSpeed": 90,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -148884,10 +148975,17 @@
     "name": "Winds Fury +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2870,
     "weight": 1.69,
     "rank": 3,
     "tier": 5.76552629,
+=======
+    "price": 8381,
+    "weight": 1.46,
+    "heirloomLevel": 3,
+    "tier": 10.6353617,
+>>>>>>> 8c8f0e2 (1723)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148898,18 +148996,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.59,
-        "handling": 76,
+        "balance": 0.7,
+        "handling": 75,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 34,
+        "thrustSpeed": 90,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -30582,10 +30582,17 @@
     "name": "Decorated Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5136,
     "weight": 2.03,
     "rank": 1,
     "tier": 8.08350849,
+=======
+    "price": 6584,
+    "weight": 1.91,
+    "heirloomLevel": 1,
+    "tier": 9.299291,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30598,18 +30605,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.51,
-        "handling": 85,
+        "balance": 0.56,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -30619,10 +30626,17 @@
     "name": "Decorated Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3794,
     "weight": 2.03,
     "rank": 2,
     "tier": 6.7923913,
+=======
+    "price": 7324,
+    "weight": 1.88,
+    "heirloomLevel": 2,
+    "tier": 9.868801,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30635,18 +30649,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.51,
-        "handling": 85,
+        "balance": 0.6,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 34,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -30656,10 +30670,17 @@
     "name": "Decorated Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2889,
     "weight": 2.03,
     "rank": 3,
     "tier": 5.78759861,
+=======
+    "price": 8330,
+    "weight": 1.84,
+    "heirloomLevel": 3,
+    "tier": 10.5998373,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30672,18 +30693,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.51,
-        "handling": 85,
+        "balance": 0.61,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 34,
+        "thrustSpeed": 88,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -30876,10 +30897,17 @@
     "name": "Decorated Cavalry Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4697,
     "weight": 2.37,
     "rank": 1,
     "tier": 7.682463,
+=======
+    "price": 7171,
+    "weight": 2.27,
+    "heirloomLevel": 1,
+    "tier": 9.753942,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30890,18 +30918,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 119,
-        "balance": 0.25,
-        "handling": 88,
+        "balance": 0.32,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 79
       }
     ]
   },
@@ -30911,10 +30939,17 @@
     "name": "Decorated Cavalry Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3477,
     "weight": 2.37,
     "rank": 2,
     "tier": 6.45540142,
+=======
+    "price": 6652,
+    "weight": 2.27,
+    "heirloomLevel": 2,
+    "tier": 9.353273,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30925,18 +30960,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 119,
-        "balance": 0.25,
-        "handling": 88,
+        "balance": 0.32,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 36,
+        "thrustSpeed": 85,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 79
       }
     ]
   },
@@ -30946,10 +30981,17 @@
     "name": "Decorated Cavalry Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2652,
     "weight": 2.37,
     "rank": 3,
     "tier": 5.50046253,
+=======
+    "price": 7902,
+    "weight": 2.22,
+    "heirloomLevel": 3,
+    "tier": 10.2945747,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -30960,18 +31002,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 119,
-        "balance": 0.25,
-        "handling": 88,
+        "balance": 0.35,
+        "handling": 90,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 36,
+        "thrustSpeed": 85,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 80
       }
     ]
   },
@@ -32403,10 +32445,17 @@
     "name": "Decorated Northern Backsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5191,
     "weight": 1.86,
     "rank": 1,
     "tier": 8.13249,
+=======
+    "price": 7234,
+    "weight": 1.76,
+    "heirloomLevel": 1,
+    "tier": 9.801615,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32419,7 +32468,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.7,
+        "balance": 0.75,
         "handling": 89,
         "bodyArmor": 3,
         "flags": [
@@ -32427,10 +32476,10 @@
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -32440,10 +32489,17 @@
     "name": "Decorated Northern Backsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3833,
     "weight": 1.86,
     "rank": 2,
     "tier": 6.833552,
+=======
+    "price": 7887,
+    "weight": 1.68,
+    "heirloomLevel": 2,
+    "tier": 10.2837458,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32456,7 +32512,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.7,
+        "balance": 0.8,
         "handling": 89,
         "bodyArmor": 3,
         "flags": [
@@ -32464,10 +32520,10 @@
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -32477,10 +32533,17 @@
     "name": "Decorated Northern Backsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2918,
     "weight": 1.86,
     "rank": 3,
     "tier": 5.82267332,
+=======
+    "price": 9147,
+    "weight": 1.6,
+    "heirloomLevel": 3,
+    "tier": 11.161087,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32493,18 +32556,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.7,
-        "handling": 89,
+        "balance": 0.83,
+        "handling": 90,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 90,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 94
       }
     ]
   },
@@ -42636,10 +42699,17 @@
     "name": "Fine Steel Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4392,
     "weight": 2.11,
     "rank": 1,
     "tier": 7.39236736,
+=======
+    "price": 6543,
+    "weight": 2.01,
+    "heirloomLevel": 1,
+    "tier": 9.266528,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42652,18 +42722,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.48,
-        "handling": 83,
+        "balance": 0.54,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -42673,10 +42743,17 @@
     "name": "Fine Steel Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3256,
     "weight": 2.11,
     "rank": 2,
     "tier": 6.21164227,
+=======
+    "price": 7112,
+    "weight": 1.92,
+    "heirloomLevel": 2,
+    "tier": 9.709291,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42689,18 +42766,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.48,
-        "handling": 83,
+        "balance": 0.6,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -42710,10 +42787,17 @@
     "name": "Fine Steel Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2488,
     "weight": 2.11,
     "rank": 3,
     "tier": 5.29276037,
+=======
+    "price": 7879,
+    "weight": 1.88,
+    "heirloomLevel": 3,
+    "tier": 10.2775841,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42726,18 +42810,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.48,
-        "handling": 83,
+        "balance": 0.61,
+        "handling": 84,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
@@ -43093,10 +43177,17 @@
     "name": "Fine Steel Cavalry Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3740,
     "weight": 2.23,
     "rank": 1,
     "tier": 6.736767,
+=======
+    "price": 5898,
+    "weight": 2.14,
+    "heirloomLevel": 1,
+    "tier": 8.742244,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43109,8 +43200,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.25,
-        "handling": 84,
+        "balance": 0.32,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
@@ -43120,7 +43211,7 @@
         "thrustSpeed": 85,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 79
       }
     ]
   },
@@ -43130,10 +43221,17 @@
     "name": "Fine Steel Cavalry Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2783,
     "weight": 2.23,
     "rank": 2,
     "tier": 5.660756,
+=======
+    "price": 5476,
+    "weight": 2.14,
+    "heirloomLevel": 2,
+    "tier": 8.38256,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43146,18 +43244,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.25,
-        "handling": 84,
+        "balance": 0.32,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 36,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 79
       }
     ]
   },
@@ -43167,10 +43265,17 @@
     "name": "Fine Steel Cavalry Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2135,
     "weight": 2.23,
     "rank": 3,
     "tier": 4.823366,
+=======
+    "price": 6238,
+    "weight": 2.11,
+    "heirloomLevel": 3,
+    "tier": 9.021925,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -43183,18 +43288,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 117,
-        "balance": 0.25,
-        "handling": 84,
+        "balance": 0.35,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 36,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 77
+        "swingSpeed": 80
       }
     ]
   },
@@ -43980,10 +44085,17 @@
     "name": "Fine Steel Long Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1679,
     "weight": 1.8,
     "rank": 1,
     "tier": 4.157275,
+=======
+    "price": 2409,
+    "weight": 1.72,
+    "heirloomLevel": 1,
+    "tier": 5.191718,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -43994,18 +44106,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 109,
-        "balance": 0.41,
-        "handling": 84,
+        "balance": 0.48,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -44015,10 +44127,17 @@
     "name": "Fine Steel Long Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1279,
     "weight": 1.8,
     "rank": 2,
     "tier": 3.49326754,
+=======
+    "price": 2757,
+    "weight": 1.66,
+    "heirloomLevel": 2,
+    "tier": 5.62910938,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44029,18 +44148,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 109,
-        "balance": 0.41,
-        "handling": 84,
+        "balance": 0.52,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 29,
+        "thrustSpeed": 89,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -44050,10 +44169,17 @@
     "name": "Fine Steel Long Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1004,
     "weight": 1.8,
     "rank": 3,
     "tier": 2.976512,
+=======
+    "price": 3230,
+    "weight": 1.6,
+    "heirloomLevel": 3,
+    "tier": 6.18233347,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44064,18 +44190,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 109,
-        "balance": 0.41,
-        "handling": 84,
+        "balance": 0.56,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 29,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 86
       }
     ]
   },
@@ -107603,10 +107729,17 @@
     "name": "Pointed Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3600,
     "weight": 1.96,
     "rank": 1,
     "tier": 6.58784246,
+=======
+    "price": 5255,
+    "weight": 1.86,
+    "heirloomLevel": 1,
+    "tier": 8.189134,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -107617,8 +107750,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.48,
-        "handling": 85,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -107628,7 +107761,7 @@
         "thrustSpeed": 87,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -107638,10 +107771,17 @@
     "name": "Pointed Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2681,
     "weight": 1.96,
     "rank": 2,
     "tier": 5.53561831,
+=======
+    "price": 6016,
+    "weight": 1.82,
+    "heirloomLevel": 2,
+    "tier": 8.839773,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -107652,18 +107792,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.48,
-        "handling": 85,
+        "balance": 0.59,
+        "handling": 87,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -107673,10 +107813,17 @@
     "name": "Pointed Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2058,
     "weight": 1.96,
     "rank": 3,
     "tier": 4.71674061,
+=======
+    "price": 6705,
+    "weight": 1.77,
+    "heirloomLevel": 3,
+    "tier": 9.39467049,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -107687,18 +107834,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 108,
-        "balance": 0.48,
-        "handling": 85,
+        "balance": 0.62,
+        "handling": 87,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
@@ -117020,6 +117167,7 @@
     "culture": "Neutral",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3786,
     "weight": 1.74,
     "rank": 2,
@@ -117072,6 +117220,12 @@
     "heirloomLevel": 3,
     "tier": 10.0059519,
 >>>>>>> e19d1a9 (fixes)
+=======
+    "price": 8190,
+    "weight": 1.57,
+    "heirloomLevel": 2,
+    "tier": 10.5005264,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -117091,9 +117245,43 @@
         "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 37,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
         "swingSpeed": 87
+      }
+    ]
+  },
+  {
+    "id": "crpg_scalpel_h3",
+    "name": "Scalpel +3",
+    "culture": "Neutral",
+    "type": "OneHandedWeapon",
+    "price": 8925,
+    "weight": 1.52,
+    "heirloomLevel": 3,
+    "tier": 11.0111637,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "OneHandedSword",
+        "itemUsage": "onehanded_block_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 104,
+        "balance": 0.61,
+        "handling": 77,
+        "bodyArmor": 5,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 24,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 37,
+        "swingDamageType": "Cut",
+        "swingSpeed": 88
       }
     ]
   },
@@ -126984,10 +127172,17 @@
     "name": "Steel Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3395,
     "weight": 1.98,
     "rank": 1,
     "tier": 6.36605549,
+=======
+    "price": 5011,
+    "weight": 1.88,
+    "heirloomLevel": 1,
+    "tier": 7.9709053,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127000,8 +127195,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.42,
-        "handling": 85,
+        "balance": 0.48,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -127011,7 +127206,7 @@
         "thrustSpeed": 87,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -127021,10 +127216,17 @@
     "name": "Steel Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2532,
     "weight": 1.98,
     "rank": 2,
     "tier": 5.34925461,
+=======
+    "price": 5700,
+    "weight": 1.83,
+    "heirloomLevel": 2,
+    "tier": 8.575342,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127037,18 +127239,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.42,
-        "handling": 85,
+        "balance": 0.53,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 33,
+        "thrustSpeed": 88,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -127058,10 +127260,17 @@
     "name": "Steel Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1947,
     "weight": 1.98,
     "rank": 3,
     "tier": 4.55794525,
+=======
+    "price": 6320,
+    "weight": 1.77,
+    "heirloomLevel": 3,
+    "tier": 9.088213,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -127074,18 +127283,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.42,
-        "handling": 85,
+        "balance": 0.56,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 33,
+        "thrustSpeed": 88,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 82
+        "swingSpeed": 86
       }
     ]
   },
@@ -138907,10 +139116,17 @@
     "name": "Thamaskene Steel Spathion +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5304,
     "weight": 2.52,
     "rank": 1,
     "tier": 8.232752,
+=======
+    "price": 7757,
+    "weight": 2.43,
+    "heirloomLevel": 1,
+    "tier": 10.189249,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138921,18 +139137,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 89,
+        "balance": 0.67,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -138942,10 +139158,17 @@
     "name": "Thamaskene Steel Spathion +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3915,
     "weight": 2.52,
     "rank": 2,
     "tier": 6.91779566,
+=======
+    "price": 7391,
+    "weight": 2.43,
+    "heirloomLevel": 2,
+    "tier": 9.91914749,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138956,18 +139179,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 89,
+        "balance": 0.67,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 31,
+        "thrustSpeed": 84,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -138977,10 +139200,17 @@
     "name": "Thamaskene Steel Spathion +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2979,
     "weight": 2.52,
     "rank": 3,
     "tier": 5.89445448,
+=======
+    "price": 8816,
+    "weight": 2.38,
+    "heirloomLevel": 3,
+    "tier": 10.9363909,
+>>>>>>> 150f2d5 (0203)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -138991,18 +139221,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 89,
+        "balance": 0.72,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 31,
+        "thrustSpeed": 84,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 91
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -50377,6 +50377,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 5208,
     "weight": 2.13,
     "rank": 1,
@@ -50387,6 +50388,12 @@
     "heirloomLevel": 1,
     "tier": 10.1876535,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 7889,
+    "weight": 2.02,
+    "heirloomLevel": 1,
+    "tier": 10.2847309,
+>>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50405,7 +50412,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 36,
@@ -50421,6 +50428,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3846,
     "weight": 2.13,
     "rank": 2,
@@ -50431,6 +50439,12 @@
     "heirloomLevel": 2,
     "tier": 10.5928211,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 8995,
+    "weight": 1.94,
+    "heirloomLevel": 2,
+    "tier": 11.0583,
+>>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50449,7 +50463,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 37,
@@ -50465,6 +50479,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 2928,
     "weight": 2.13,
     "rank": 3,
@@ -50475,6 +50490,12 @@
     "heirloomLevel": 3,
     "tier": 11.1268253,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 8432,
+    "weight": 1.94,
+    "heirloomLevel": 3,
+    "tier": 10.6707478,
+>>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50487,18 +50508,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.67,
+        "balance": 0.66,
         "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 89
       }
     ]
   },
@@ -57567,6 +57588,7 @@
     "culture": "Battania",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 3118,
     "weight": 2.1,
     "rank": 2,
@@ -57577,6 +57599,12 @@
     "heirloomLevel": 2,
     "tier": 9.554945,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 6043,
+    "weight": 2.01,
+    "heirloomLevel": 2,
+    "tier": 8.862477,
+>>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57589,18 +57617,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.44,
+        "balance": 0.41,
         "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 82
       }
     ]
   },
@@ -57610,6 +57638,7 @@
     "name": "Highland Broad Blade +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2385,
     "weight": 2.1,
@@ -57621,6 +57650,12 @@
     "heirloomLevel": 3,
     "tier": 10.1506023,
 >>>>>>> cbed0ab (1808)
+=======
+    "price": 7049,
+    "weight": 1.95,
+    "heirloomLevel": 3,
+    "tier": 9.661266,
+>>>>>>> 609634a (2xbroughtdowntier)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57639,10 +57674,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 39,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
         "swingSpeed": 83
       }

--- a/items.json
+++ b/items.json
@@ -27602,10 +27602,17 @@
     "name": "Crescent Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3537,
     "weight": 2.2,
     "rank": 1,
     "tier": 6.52059174,
+=======
+    "price": 4988,
+    "weight": 2.05,
+    "heirloomLevel": 1,
+    "tier": 7.950447,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27618,7 +27625,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.51,
+        "balance": 0.59,
         "handling": 83,
         "bodyArmor": 5,
         "flags": [
@@ -27626,10 +27633,10 @@
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 86,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -27639,10 +27646,17 @@
     "name": "Crescent Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2635,
     "weight": 2.2,
     "rank": 2,
     "tier": 5.47910833,
+=======
+    "price": 5429,
+    "weight": 1.99,
+    "heirloomLevel": 2,
+    "tier": 8.342169,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27655,7 +27669,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.51,
+        "balance": 0.62,
         "handling": 83,
         "bodyArmor": 5,
         "flags": [
@@ -27663,10 +27677,10 @@
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -27676,10 +27690,17 @@
     "name": "Crescent Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2024,
     "weight": 2.2,
     "rank": 3,
     "tier": 4.668589,
+=======
+    "price": 5999,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 8.826276,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -27692,7 +27713,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.51,
+        "balance": 0.66,
         "handling": 83,
         "bodyArmor": 5,
         "flags": [
@@ -27700,10 +27721,10 @@
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 89
       }
     ]
   },
@@ -32614,10 +32635,17 @@
     "name": "Decorated Scimitar with Wide Grip +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5299,
     "weight": 2.06,
     "rank": 1,
     "tier": 8.22874,
+=======
+    "price": 7857,
+    "weight": 1.95,
+    "heirloomLevel": 1,
+    "tier": 10.26215,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32630,18 +32658,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 101,
-        "balance": 0.51,
-        "handling": 87,
+        "balance": 0.58,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -32651,10 +32679,17 @@
     "name": "Decorated Scimitar with Wide Grip +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3912,
     "weight": 2.06,
     "rank": 2,
     "tier": 6.91442776,
+=======
+    "price": 7380,
+    "weight": 1.95,
+    "heirloomLevel": 2,
+    "tier": 9.911118,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32667,18 +32702,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 101,
-        "balance": 0.51,
-        "handling": 87,
+        "balance": 0.58,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -32688,10 +32723,17 @@
     "name": "Decorated Scimitar with Wide Grip +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2977,
     "weight": 2.06,
     "rank": 3,
     "tier": 5.89158535,
+=======
+    "price": 8749,
+    "weight": 1.91,
+    "heirloomLevel": 3,
+    "tier": 10.8910208,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -32704,18 +32746,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 101,
-        "balance": 0.51,
-        "handling": 87,
+        "balance": 0.61,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -32760,10 +32802,17 @@
     "name": "Decorated Short Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5292,
     "weight": 1.8,
     "rank": 1,
     "tier": 8.22242451,
+=======
+    "price": 7965,
+    "weight": 1.71,
+    "heirloomLevel": 1,
+    "tier": 10.3397827,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32774,18 +32823,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.7,
+        "handling": 92,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -32795,10 +32844,17 @@
     "name": "Decorated Short Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3907,
     "weight": 1.8,
     "rank": 2,
     "tier": 6.90912,
+=======
+    "price": 7588,
+    "weight": 1.71,
+    "heirloomLevel": 2,
+    "tier": 10.0655518,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32809,18 +32865,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.7,
+        "handling": 92,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -32830,10 +32886,17 @@
     "name": "Decorated Short Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2973,
     "weight": 1.8,
     "rank": 3,
     "tier": 5.887063,
+=======
+    "price": 8703,
+    "weight": 1.68,
+    "heirloomLevel": 3,
+    "tier": 10.8589611,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32844,18 +32907,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 96,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.72,
+        "handling": 92,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 91
       }
     ]
   },
@@ -42868,10 +42931,17 @@
     "name": "Fine Steel Broad Shortsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3907,
     "weight": 2.22,
     "rank": 1,
     "tier": 6.90941525,
+=======
+    "price": 5717,
+    "weight": 2.07,
+    "heirloomLevel": 1,
+    "tier": 8.589457,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42884,8 +42954,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.58,
-        "handling": 82,
+        "balance": 0.65,
+        "handling": 83,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
@@ -42895,7 +42965,7 @@
         "thrustSpeed": 85,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -42905,10 +42975,17 @@
     "name": "Fine Steel Broad Shortsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2904,
     "weight": 2.22,
     "rank": 2,
     "tier": 5.805825,
+=======
+    "price": 6192,
+    "weight": 2.01,
+    "heirloomLevel": 2,
+    "tier": 8.984725,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42921,18 +42998,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.58,
-        "handling": 82,
+        "balance": 0.68,
+        "handling": 83,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -42942,10 +43019,17 @@
     "name": "Fine Steel Broad Shortsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2225,
     "weight": 2.22,
     "rank": 3,
     "tier": 4.94697857,
+=======
+    "price": 6796,
+    "weight": 1.92,
+    "heirloomLevel": 3,
+    "tier": 9.465937,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -42958,18 +43042,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 85,
-        "balance": 0.58,
-        "handling": 82,
+        "balance": 0.72,
+        "handling": 83,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 34,
+        "thrustSpeed": 87,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 91
       }
     ]
   },
@@ -44680,10 +44764,17 @@
     "name": "Fine Steel Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4079,
     "weight": 1.97,
     "rank": 1,
     "tier": 7.08412457,
+=======
+    "price": 5939,
+    "weight": 1.89,
+    "heirloomLevel": 1,
+    "tier": 8.775941,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44696,8 +44787,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.6,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -44707,7 +44798,7 @@
         "thrustSpeed": 87,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -44717,10 +44808,17 @@
     "name": "Fine Steel Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3029,
     "weight": 1.97,
     "rank": 2,
     "tier": 5.952631,
+=======
+    "price": 5663,
+    "weight": 1.89,
+    "heirloomLevel": 2,
+    "tier": 8.543802,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44733,18 +44831,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.6,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 31,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -44754,10 +44852,17 @@
     "name": "Fine Steel Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2318,
     "weight": 1.97,
     "rank": 3,
     "tier": 5.07206631,
+=======
+    "price": 6788,
+    "weight": 1.86,
+    "heirloomLevel": 3,
+    "tier": 9.45975,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44770,18 +44875,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.6,
-        "handling": 87,
+        "balance": 0.67,
+        "handling": 89,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 88,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -63961,10 +64066,17 @@
     "name": "Iron Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2879,
     "weight": 2.02,
     "rank": 1,
     "tier": 5.77565861,
+=======
+    "price": 4239,
+    "weight": 1.88,
+    "heirloomLevel": 1,
+    "tier": 7.242883,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -63977,18 +64089,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.48,
-        "handling": 79,
+        "balance": 0.55,
+        "handling": 80,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -63998,10 +64110,17 @@
     "name": "Iron Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2156,
     "weight": 2.02,
     "rank": 2,
     "tier": 4.85315657,
+=======
+    "price": 4612,
+    "weight": 1.83,
+    "heirloomLevel": 2,
+    "tier": 7.60243845,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64014,18 +64133,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.48,
-        "handling": 79,
+        "balance": 0.58,
+        "handling": 80,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 33,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -64035,10 +64154,17 @@
     "name": "Iron Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1665,
     "weight": 2.02,
     "rank": 3,
     "tier": 4.135235,
+=======
+    "price": 5121,
+    "weight": 1.77,
+    "heirloomLevel": 3,
+    "tier": 8.070484,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -64051,18 +64177,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.48,
-        "handling": 79,
+        "balance": 0.61,
+        "handling": 80,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 33,
+        "thrustSpeed": 88,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
@@ -65204,10 +65330,17 @@
     "name": "Iron Long Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2793,
     "weight": 2.11,
     "rank": 1,
     "tier": 5.67289925,
+=======
+    "price": 4295,
+    "weight": 1.98,
+    "heirloomLevel": 1,
+    "tier": 7.2975297,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65220,18 +65353,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.53,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -65241,10 +65374,17 @@
     "name": "Iron Long Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2094,
     "weight": 2.11,
     "rank": 2,
     "tier": 4.766809,
+=======
+    "price": 4706,
+    "weight": 1.92,
+    "heirloomLevel": 2,
+    "tier": 7.6900177,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65257,18 +65397,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -65278,10 +65418,17 @@
     "name": "Iron Long Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1618,
     "weight": 2.11,
     "rank": 3,
     "tier": 4.061661,
+=======
+    "price": 5249,
+    "weight": 1.88,
+    "heirloomLevel": 3,
+    "tier": 8.184298,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65294,18 +65441,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.44,
-        "handling": 84,
+        "balance": 0.59,
+        "handling": 86,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 87
       }
     ]
   },
@@ -78453,10 +78600,17 @@
     "name": "Lion Imprinted Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5384,
     "weight": 2.05,
     "rank": 1,
     "tier": 8.303297,
+=======
+    "price": 7818,
+    "weight": 1.96,
+    "heirloomLevel": 1,
+    "tier": 10.2332878,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78467,18 +78621,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.6,
+        "balance": 0.66,
         "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -78488,10 +78642,17 @@
     "name": "Lion Imprinted Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3973,
     "weight": 2.05,
     "rank": 2,
     "tier": 6.977075,
+=======
+    "price": 7387,
+    "weight": 1.96,
+    "heirloomLevel": 2,
+    "tier": 9.916577,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78502,18 +78663,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.6,
+        "balance": 0.66,
         "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -78523,10 +78684,17 @@
     "name": "Lion Imprinted Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3022,
     "weight": 2.05,
     "rank": 3,
     "tier": 5.94496441,
+=======
+    "price": 8781,
+    "weight": 1.91,
+    "heirloomLevel": 3,
+    "tier": 10.9123325,
+>>>>>>> 9e69aca (0231)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78537,18 +78705,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.6,
-        "handling": 87,
+        "balance": 0.68,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -24172,10 +24172,17 @@
     "name": "Cataphract Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2236,
     "weight": 2.07,
     "rank": 1,
     "tier": 4.961576,
+=======
+    "price": 3495,
+    "weight": 2.01,
+    "heirloomLevel": 1,
+    "tier": 6.475282,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24186,18 +24193,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.09,
-        "handling": 79,
+        "balance": 0.14,
+        "handling": 80,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
+        "thrustSpeed": 86,
         "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 72
+        "swingSpeed": 74
       }
     ]
   },
@@ -24207,10 +24214,17 @@
     "name": "Cataphract Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1687,
     "weight": 2.07,
     "rank": 2,
     "tier": 4.16910172,
+=======
+    "price": 3330,
+    "weight": 2.01,
+    "heirloomLevel": 2,
+    "tier": 6.29493952,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24221,18 +24235,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.09,
-        "handling": 79,
+        "balance": 0.14,
+        "handling": 80,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 86,
+        "swingDamage": 30,
         "swingDamageType": "Blunt",
-        "swingSpeed": 72
+        "swingSpeed": 74
       }
     ]
   },
@@ -24242,10 +24256,17 @@
     "name": "Cataphract Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1312,
     "weight": 2.07,
     "rank": 3,
     "tier": 3.5523715,
+=======
+    "price": 4120,
+    "weight": 1.96,
+    "heirloomLevel": 3,
+    "tier": 7.125106,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -24256,18 +24277,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.09,
-        "handling": 79,
+        "balance": 0.19,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Blunt",
-        "swingSpeed": 72
+        "swingSpeed": 75
       }
     ]
   },
@@ -69447,10 +69468,17 @@
     "name": "Judgement +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3579,
     "weight": 2.36,
     "rank": 1,
     "tier": 6.565557,
+=======
+    "price": 5684,
+    "weight": 2.28,
+    "heirloomLevel": 1,
+    "tier": 8.561754,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -69461,18 +69489,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.33,
-        "handling": 87,
+        "balance": 0.38,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -69482,10 +69510,17 @@
     "name": "Judgement +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2666,
     "weight": 2.36,
     "rank": 2,
     "tier": 5.516889,
+=======
+    "price": 5407,
+    "weight": 2.28,
+    "heirloomLevel": 2,
+    "tier": 8.323303,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -69496,18 +69531,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.33,
-        "handling": 87,
+        "balance": 0.38,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 29,
+        "thrustSpeed": 85,
+        "swingDamage": 30,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -69517,10 +69552,17 @@
     "name": "Judgement +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2047,
     "weight": 2.36,
     "rank": 3,
     "tier": 4.70078373,
+=======
+    "price": 6331,
+    "weight": 2.24,
+    "heirloomLevel": 3,
+    "tier": 9.097019,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -69531,18 +69573,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.33,
-        "handling": 87,
+        "balance": 0.41,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 29,
+        "thrustSpeed": 85,
+        "swingDamage": 31,
         "swingDamageType": "Blunt",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -72983,10 +73025,17 @@
     "name": "Knightly Spiked Battle Axe +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3894,
     "weight": 0.91,
     "rank": 1,
     "tier": 6.89577961,
+=======
+    "price": 6069,
+    "weight": 0.87,
+    "heirloomLevel": 1,
+    "tier": 8.884193,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -72999,18 +73048,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 85,
+        "balance": 0.69,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 97,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -73020,10 +73069,17 @@
     "name": "Knightly Spiked Battle Axe +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2894,
     "weight": 0.91,
     "rank": 2,
     "tier": 5.794369,
+=======
+    "price": 5690,
+    "weight": 0.87,
+    "heirloomLevel": 2,
+    "tier": 8.566359,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -73036,18 +73092,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 85,
+        "balance": 0.69,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 97,
-        "swingDamage": 34,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -73057,10 +73113,17 @@
     "name": "Knightly Spiked Battle Axe +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2218,
     "weight": 0.91,
     "rank": 3,
     "tier": 4.93721437,
+=======
+    "price": 6627,
+    "weight": 0.87,
+    "heirloomLevel": 3,
+    "tier": 9.333597,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -73073,18 +73136,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.63,
-        "handling": 85,
+        "balance": 0.69,
+        "handling": 87,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 97,
-        "swingDamage": 34,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -87009,10 +87072,17 @@
     "name": "Morningstar +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4875,
     "weight": 1.94,
     "rank": 1,
     "tier": 7.847093,
+=======
+    "price": 7008,
+    "weight": 1.85,
+    "heirloomLevel": 1,
+    "tier": 9.629232,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87025,7 +87095,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 79,
-        "balance": 0.52,
+        "balance": 0.58,
         "handling": 82,
         "bodyArmor": 0,
         "flags": [
@@ -87037,7 +87107,7 @@
         "thrustSpeed": 87,
         "swingDamage": 28,
         "swingDamageType": "Pierce",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -87047,10 +87117,17 @@
     "name": "Morningstar +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3605,
     "weight": 1.94,
     "rank": 2,
     "tier": 6.593737,
+=======
+    "price": 6723,
+    "weight": 1.85,
+    "heirloomLevel": 2,
+    "tier": 9.40906048,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87063,7 +87140,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 79,
-        "balance": 0.52,
+        "balance": 0.58,
         "handling": 82,
         "bodyArmor": 0,
         "flags": [
@@ -87073,9 +87150,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 28,
+        "swingDamage": 29,
         "swingDamageType": "Pierce",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -87085,10 +87162,17 @@
     "name": "Morningstar +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2748,
     "weight": 1.94,
     "rank": 3,
     "tier": 5.618334,
+=======
+    "price": 8445,
+    "weight": 1.85,
+    "heirloomLevel": 3,
+    "tier": 10.6798763,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87101,7 +87185,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 79,
-        "balance": 0.52,
+        "balance": 0.58,
         "handling": 82,
         "bodyArmor": 0,
         "flags": [
@@ -87111,9 +87195,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 28,
+        "swingDamage": 31,
         "swingDamageType": "Pierce",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -106491,10 +106575,17 @@
     "name": "Pernach +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4839,
     "weight": 2.12,
     "rank": 1,
     "tier": 7.814022,
+=======
+    "price": 7048,
+    "weight": 2.06,
+    "heirloomLevel": 1,
+    "tier": 9.659853,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -106505,7 +106596,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 89,
-        "balance": 0.43,
+        "balance": 0.47,
         "handling": 74,
         "bodyArmor": 0,
         "flags": [
@@ -106516,7 +106607,7 @@
         "thrustSpeed": 85,
         "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -106526,10 +106617,17 @@
     "name": "Pernach +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3579,
     "weight": 2.12,
     "rank": 2,
     "tier": 6.565947,
+=======
+    "price": 6828,
+    "weight": 2.06,
+    "heirloomLevel": 2,
+    "tier": 9.490931,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -106540,7 +106638,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 89,
-        "balance": 0.43,
+        "balance": 0.47,
         "handling": 74,
         "bodyArmor": 0,
         "flags": [
@@ -106549,9 +106647,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 85,
-        "swingDamage": 27,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 84
       }
     ]
   },
@@ -106561,10 +106659,17 @@
     "name": "Pernach +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2729,
     "weight": 2.12,
     "rank": 3,
     "tier": 5.59465647,
+=======
+    "price": 8100,
+    "weight": 1.98,
+    "heirloomLevel": 3,
+    "tier": 10.4362659,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -106575,7 +106680,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 89,
-        "balance": 0.43,
+        "balance": 0.51,
         "handling": 74,
         "bodyArmor": 0,
         "flags": [
@@ -106583,10 +106688,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 27,
+        "thrustSpeed": 86,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 85
       }
     ]
   },
@@ -127202,10 +127307,17 @@
     "name": "Spiked Mace +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1236,
     "weight": 1.83,
     "rank": 1,
     "tier": 3.416224,
+=======
+    "price": 1844,
+    "weight": 1.73,
+    "heirloomLevel": 1,
+    "tier": 4.40779972,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127216,18 +127328,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.44,
-        "handling": 87,
+        "balance": 0.51,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 9,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 26,
         "swingDamageType": "Pierce",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -127237,10 +127349,17 @@
     "name": "Spiked Mace +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 952,
     "weight": 1.83,
     "rank": 2,
     "tier": 2.870578,
+=======
+    "price": 1809,
+    "weight": 1.73,
+    "heirloomLevel": 2,
+    "tier": 4.35576,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127251,18 +127370,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.44,
-        "handling": 87,
+        "balance": 0.51,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 9,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 26,
+        "thrustSpeed": 89,
+        "swingDamage": 27,
         "swingDamageType": "Pierce",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -127272,10 +127391,17 @@
     "name": "Spiked Mace +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 756,
     "weight": 1.83,
     "rank": 3,
     "tier": 2.445936,
+=======
+    "price": 2298,
+    "weight": 1.73,
+    "heirloomLevel": 3,
+    "tier": 5.04529762,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127286,18 +127412,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.44,
-        "handling": 87,
+        "balance": 0.51,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 9,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 26,
+        "thrustSpeed": 89,
+        "swingDamage": 29,
         "swingDamageType": "Pierce",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -148704,10 +148830,17 @@
     "name": "Warhammer +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4866,
     "weight": 1.91,
     "rank": 1,
     "tier": 7.838435,
+=======
+    "price": 7269,
+    "weight": 1.85,
+    "heirloomLevel": 1,
+    "tier": 9.827833,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148718,18 +148851,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.48,
-        "handling": 90,
+        "balance": 0.53,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -148739,10 +148872,17 @@
     "name": "Warhammer +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3598,
     "weight": 1.91,
     "rank": 2,
     "tier": 6.586463,
+=======
+    "price": 7082,
+    "weight": 1.85,
+    "heirloomLevel": 2,
+    "tier": 9.686204,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148753,18 +148893,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.48,
-        "handling": 90,
+        "balance": 0.53,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 26,
+        "thrustSpeed": 88,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -148774,10 +148914,17 @@
     "name": "Warhammer +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2743,
     "weight": 1.91,
     "rank": 3,
     "tier": 5.612134,
+=======
+    "price": 8728,
+    "weight": 1.79,
+    "heirloomLevel": 3,
+    "tier": 10.8765373,
+>>>>>>> 825a77b (startedonmaces)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -148788,18 +148935,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.48,
-        "handling": 90,
+        "balance": 0.59,
+        "handling": 92,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 26,
+        "thrustSpeed": 88,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -58206,10 +58206,17 @@
     "name": "Highland Pointed Blade +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3785,
     "weight": 1.88,
     "rank": 1,
     "tier": 6.78317928,
+=======
+    "price": 5452,
+    "weight": 1.78,
+    "heirloomLevel": 1,
+    "tier": 8.362564,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -58222,18 +58229,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.48,
-        "handling": 84,
+        "balance": 0.54,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -58243,10 +58250,17 @@
     "name": "Highland Pointed Blade +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2815,
     "weight": 1.88,
     "rank": 2,
     "tier": 5.699755,
+=======
+    "price": 5858,
+    "weight": 1.73,
+    "heirloomLevel": 2,
+    "tier": 8.708277,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -58259,18 +58273,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.48,
-        "handling": 84,
+        "balance": 0.57,
+        "handling": 85,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -58280,10 +58294,17 @@
     "name": "Highland Pointed Blade +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2159,
     "weight": 1.88,
     "rank": 3,
     "tier": 4.85659742,
+=======
+    "price": 6637,
+    "weight": 1.66,
+    "heirloomLevel": 3,
+    "tier": 9.341043,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -58296,18 +58317,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.48,
-        "handling": 84,
+        "balance": 0.61,
+        "handling": 86,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 31,
+        "thrustSpeed": 89,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
@@ -65316,10 +65337,17 @@
     "name": "Iron Pointed Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2326,
     "weight": 1.6,
     "rank": 1,
     "tier": 5.081744,
+=======
+    "price": 3217,
+    "weight": 1.54,
+    "heirloomLevel": 1,
+    "tier": 6.16824436,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65330,8 +65358,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.54,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -65341,7 +65369,7 @@
         "thrustSpeed": 90,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -65351,10 +65379,17 @@
     "name": "Iron Pointed Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1753,
     "weight": 1.6,
     "rank": 2,
     "tier": 4.270076,
+=======
+    "price": 3544,
+    "weight": 1.49,
+    "heirloomLevel": 2,
+    "tier": 6.52847672,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65365,8 +65400,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.58,
+        "handling": 89,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -65374,9 +65409,9 @@
         "thrustDamage": 29,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 29,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -65386,10 +65421,17 @@
     "name": "Iron Pointed Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1362,
     "weight": 1.6,
     "rank": 3,
     "tier": 3.63840818,
+=======
+    "price": 4053,
+    "weight": 1.49,
+    "heirloomLevel": 3,
+    "tier": 7.05796528,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -65400,8 +65442,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 95,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.58,
+        "handling": 89,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
@@ -65409,9 +65451,9 @@
         "thrustDamage": 29,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 29,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 87
       }
     ]
   },
@@ -93780,10 +93822,17 @@
     "name": "Narrow Arming Sword +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3586,
     "weight": 1.41,
     "rank": 1,
     "tier": 6.57317257,
+=======
+    "price": 5264,
+    "weight": 1.32,
+    "heirloomLevel": 1,
+    "tier": 8.197535,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -93794,18 +93843,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.63,
+        "handling": 89,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 29,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
+        "thrustSpeed": 93,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -93815,10 +93864,17 @@
     "name": "Narrow Arming Sword +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2671,
     "weight": 1.41,
     "rank": 2,
     "tier": 5.523289,
+=======
+    "price": 5805,
+    "weight": 1.29,
+    "heirloomLevel": 2,
+    "tier": 8.664381,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -93829,18 +93885,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 90,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 29,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 29,
+        "thrustSpeed": 93,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -93850,10 +93906,17 @@
     "name": "Narrow Arming Sword +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2051,
     "weight": 1.41,
     "rank": 3,
     "tier": 4.70623541,
+=======
+    "price": 5842,
+    "weight": 1.29,
+    "heirloomLevel": 3,
+    "tier": 8.69514751,
+>>>>>>> 4dd0778 (0105)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -93864,18 +93927,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 90,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 29,
+        "thrustDamage": 30,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 29,
+        "thrustSpeed": 93,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -123869,10 +123869,17 @@
     "name": "Slightly Ridged Flyssa +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5140,
     "weight": 2.4,
     "rank": 1,
     "tier": 8.08698,
+=======
+    "price": 6378,
+    "weight": 2.34,
+    "heirloomLevel": 1,
+    "tier": 9.135182,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -123883,8 +123890,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.6,
-        "handling": 89,
+        "balance": 0.63,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -123894,7 +123901,7 @@
         "thrustSpeed": 84,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 88
       }
     ]
   },
@@ -123904,10 +123911,17 @@
     "name": "Slightly Ridged Flyssa +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3797,
     "weight": 2.4,
     "rank": 2,
     "tier": 6.795307,
+=======
+    "price": 8745,
+    "weight": 2.29,
+    "heirloomLevel": 2,
+    "tier": 10.8876095,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -123918,18 +123932,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.6,
-        "handling": 89,
+        "balance": 0.67,
+        "handling": 91,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 32,
+        "thrustSpeed": 85,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -123939,10 +123953,17 @@
     "name": "Slightly Ridged Flyssa +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2891,
     "weight": 2.4,
     "rank": 3,
     "tier": 5.7900877,
+=======
+    "price": 8573,
+    "weight": 2.26,
+    "heirloomLevel": 3,
+    "tier": 10.7690277,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -123953,18 +123974,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 98,
-        "balance": 0.6,
-        "handling": 89,
+        "balance": 0.7,
+        "handling": 92,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 84,
-        "swingDamage": 32,
+        "thrustSpeed": 85,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -126024,10 +126045,17 @@
     "name": "Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1577,
     "weight": 1.65,
     "rank": 1,
     "tier": 3.9958005,
+=======
+    "price": 2390,
+    "weight": 1.56,
+    "heirloomLevel": 1,
+    "tier": 5.16677,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126040,18 +126068,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.54,
-        "handling": 88,
+        "balance": 0.61,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 27,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -126061,10 +126089,17 @@
     "name": "Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1204,
     "weight": 1.65,
     "rank": 2,
     "tier": 3.35758138,
+=======
+    "price": 2362,
+    "weight": 1.56,
+    "heirloomLevel": 2,
+    "tier": 5.129491,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126077,18 +126112,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.54,
-        "handling": 88,
+        "balance": 0.61,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 27,
+        "thrustSpeed": 90,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -126098,10 +126133,17 @@
     "name": "Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 947,
     "weight": 1.65,
     "rank": 3,
     "tier": 2.860899,
+=======
+    "price": 2776,
+    "weight": 1.51,
+    "heirloomLevel": 3,
+    "tier": 5.652436,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126114,18 +126156,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.54,
-        "handling": 88,
+        "balance": 0.65,
+        "handling": 90,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 27,
+        "thrustSpeed": 90,
+        "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -126172,10 +126214,17 @@
     "name": "Spatha With Narrow Fuller +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2190,
     "weight": 1.78,
     "rank": 1,
     "tier": 4.899188,
+=======
+    "price": 3198,
+    "weight": 1.68,
+    "heirloomLevel": 1,
+    "tier": 6.146165,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126188,18 +126237,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.56,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -126209,10 +126258,17 @@
     "name": "Spatha With Narrow Fuller +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1653,
     "weight": 1.78,
     "rank": 2,
     "tier": 4.116679,
+=======
+    "price": 3060,
+    "weight": 1.68,
+    "heirloomLevel": 2,
+    "tier": 5.98894453,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126225,18 +126281,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.56,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },
@@ -126246,10 +126302,17 @@
     "name": "Spatha With Narrow Fuller +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1287,
     "weight": 1.78,
     "rank": 3,
     "tier": 3.507703,
+=======
+    "price": 3712,
+    "weight": 1.68,
+    "heirloomLevel": 3,
+    "tier": 6.70715332,
+>>>>>>> a1592ae (1433)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -126262,18 +126325,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.49,
-        "handling": 87,
+        "balance": 0.56,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 86
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -22100,10 +22100,17 @@
     "name": "Broad Ild +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3529,
     "weight": 2.21,
     "rank": 1,
     "tier": 6.51216364,
+=======
+    "price": 5060,
+    "weight": 2.15,
+    "heirloomLevel": 1,
+    "tier": 8.014909,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22116,8 +22123,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.76,
-        "handling": 90,
+        "balance": 0.82,
+        "handling": 91,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -22127,7 +22134,7 @@
         "thrustSpeed": 85,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -22137,10 +22144,17 @@
     "name": "Broad Ild +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2629,
     "weight": 2.21,
     "rank": 2,
     "tier": 5.472026,
+=======
+    "price": 4793,
+    "weight": 2.15,
+    "heirloomLevel": 2,
+    "tier": 7.771138,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22153,8 +22167,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.76,
-        "handling": 90,
+        "balance": 0.82,
+        "handling": 91,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -22162,9 +22176,9 @@
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 29,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -22174,10 +22188,17 @@
     "name": "Broad Ild +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2020,
     "weight": 2.21,
     "rank": 3,
     "tier": 4.66255569,
+=======
+    "price": 5848,
+    "weight": 2.15,
+    "heirloomLevel": 3,
+    "tier": 8.699919,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -22190,8 +22211,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.76,
-        "handling": 90,
+        "balance": 0.82,
+        "handling": 91,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -22199,9 +22220,9 @@
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 29,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -41145,10 +41166,17 @@
     "name": "Engraved Angular Kaskara +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5231,
     "weight": 2.14,
     "rank": 1,
     "tier": 8.168509,
+=======
+    "price": 7913,
+    "weight": 2.04,
+    "heirloomLevel": 1,
+    "tier": 10.3023968,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41161,18 +41189,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 92,
+        "balance": 0.74,
+        "handling": 93,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -41182,10 +41210,17 @@
     "name": "Engraved Angular Kaskara +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3863,
     "weight": 2.14,
     "rank": 2,
     "tier": 6.863819,
+=======
+    "price": 7559,
+    "weight": 2.04,
+    "heirloomLevel": 2,
+    "tier": 10.0437679,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41198,18 +41233,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 92,
+        "balance": 0.74,
+        "handling": 93,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 30,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -41219,10 +41254,17 @@
     "name": "Engraved Angular Kaskara +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2940,
     "weight": 2.14,
     "rank": 3,
     "tier": 5.84846,
+=======
+    "price": 8681,
+    "weight": 1.98,
+    "heirloomLevel": 3,
+    "tier": 10.843915,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -41235,18 +41277,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.67,
-        "handling": 92,
+        "balance": 0.77,
+        "handling": 93,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 30,
+        "thrustSpeed": 87,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -65221,10 +65263,17 @@
     "name": "Iron Falchion +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2627,
     "weight": 1.97,
     "rank": 1,
     "tier": 5.469384,
+=======
+    "price": 3801,
+    "weight": 1.85,
+    "heirloomLevel": 1,
+    "tier": 6.79953527,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65237,18 +65286,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 86,
+        "balance": 0.68,
+        "handling": 87,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -65258,10 +65307,17 @@
     "name": "Iron Falchion +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1973,
     "weight": 1.97,
     "rank": 2,
     "tier": 4.595802,
+=======
+    "price": 4248,
+    "weight": 1.78,
+    "heirloomLevel": 2,
+    "tier": 7.251519,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65274,18 +65330,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 86,
+        "balance": 0.72,
+        "handling": 87,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 88,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 91
       }
     ]
   },
@@ -65295,10 +65351,17 @@
     "name": "Iron Falchion +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1528,
     "weight": 1.97,
     "rank": 3,
     "tier": 3.91594887,
+=======
+    "price": 4831,
+    "weight": 1.72,
+    "heirloomLevel": 3,
+    "tier": 7.80689,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65311,18 +65374,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.61,
-        "handling": 86,
+        "balance": 0.75,
+        "handling": 87,
         "bodyArmor": 2,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 29,
+        "thrustSpeed": 89,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 92
       }
     ]
   },
@@ -99960,10 +100023,17 @@
     "name": "Northern Backsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4167,
     "weight": 1.74,
     "rank": 1,
     "tier": 7.171772,
+=======
+    "price": 5783,
+    "weight": 1.59,
+    "heirloomLevel": 1,
+    "tier": 8.645561,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -99976,7 +100046,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.74,
+        "balance": 0.81,
         "handling": 85,
         "bodyArmor": 0,
         "flags": [
@@ -99984,10 +100054,10 @@
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -99997,10 +100067,17 @@
     "name": "Northern Backsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3093,
     "weight": 1.74,
     "rank": 2,
     "tier": 6.02628136,
+=======
+    "price": 6395,
+    "weight": 1.51,
+    "heirloomLevel": 2,
+    "tier": 9.149115,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -100013,7 +100090,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.74,
+        "balance": 0.84,
         "handling": 85,
         "bodyArmor": 0,
         "flags": [
@@ -100021,10 +100098,10 @@
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 95
       }
     ]
   },
@@ -100034,10 +100111,17 @@
     "name": "Northern Backsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2366,
     "weight": 1.74,
     "rank": 3,
     "tier": 5.13482046,
+=======
+    "price": 6892,
+    "weight": 1.46,
+    "heirloomLevel": 3,
+    "tier": 9.540372,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -100050,18 +100134,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.74,
-        "handling": 85,
+        "balance": 0.87,
+        "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 30,
+        "thrustSpeed": 90,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 96
       }
     ]
   },
@@ -122417,10 +122501,17 @@
     "name": "Simple Saber  +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2003,
     "weight": 2.17,
     "rank": 1,
     "tier": 4.63824368,
+=======
+    "price": 2880,
+    "weight": 2.08,
+    "heirloomLevel": 1,
+    "tier": 5.77739143,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122433,8 +122524,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.62,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
@@ -122444,7 +122535,7 @@
         "thrustSpeed": 85,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -122454,10 +122545,17 @@
     "name": "Simple Saber  +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1516,
     "weight": 2.17,
     "rank": 2,
     "tier": 3.89741325,
+=======
+    "price": 3228,
+    "weight": 2.03,
+    "heirloomLevel": 2,
+    "tier": 6.1799736,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122470,18 +122568,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 88,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -122491,10 +122589,17 @@
     "name": "Simple Saber  +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1184,
     "weight": 2.17,
     "rank": 3,
     "tier": 3.32087278,
+=======
+    "price": 3806,
+    "weight": 1.96,
+    "heirloomLevel": 3,
+    "tier": 6.80512476,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122507,18 +122612,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 97,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.7,
+        "handling": 89,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 90
       }
     ]
   },
@@ -123041,10 +123146,17 @@
     "name": "Simple Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1887,
     "weight": 1.73,
     "rank": 1,
     "tier": 4.47138834,
+=======
+    "price": 2606,
+    "weight": 1.63,
+    "heirloomLevel": 1,
+    "tier": 5.44288445,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123057,7 +123169,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.6,
+        "balance": 0.64,
         "handling": 77,
         "bodyArmor": 3,
         "flags": [
@@ -123065,10 +123177,10 @@
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -123078,10 +123190,17 @@
     "name": "Simple Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1432,
     "weight": 1.73,
     "rank": 2,
     "tier": 3.75720859,
+=======
+    "price": 2974,
+    "weight": 1.57,
+    "heirloomLevel": 2,
+    "tier": 5.88837957,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123094,18 +123213,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.6,
-        "handling": 77,
+        "balance": 0.68,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 32,
+        "thrustSpeed": 90,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -123115,10 +123234,17 @@
     "name": "Simple Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1120,
     "weight": 1.73,
     "rank": 3,
     "tier": 3.201408,
+=======
+    "price": 3300,
+    "weight": 1.51,
+    "heirloomLevel": 3,
+    "tier": 6.261262,
+>>>>>>> 6a16bda (1054)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -123131,18 +123257,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.6,
-        "handling": 77,
+        "balance": 0.71,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 32,
+        "thrustSpeed": 90,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 91
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -30455,10 +30455,17 @@
     "name": "Dawnbreaker +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4863,
     "weight": 2.39,
     "rank": 1,
     "tier": 7.835578,
+=======
+    "price": 7099,
+    "weight": 2.23,
+    "heirloomLevel": 1,
+    "tier": 9.699391,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30471,7 +30478,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.33,
+        "balance": 0.42,
         "handling": 74,
         "bodyArmor": 4,
         "flags": [
@@ -30479,10 +30486,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
+        "thrustSpeed": 84,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -30492,10 +30499,17 @@
     "name": "Dawnbreaker +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3596,
     "weight": 2.39,
     "rank": 2,
     "tier": 6.58406353,
+=======
+    "price": 7564,
+    "weight": 2.18,
+    "heirloomLevel": 2,
+    "tier": 10.0479565,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30508,7 +30522,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.33,
+        "balance": 0.44,
         "handling": 74,
         "bodyArmor": 4,
         "flags": [
@@ -30516,10 +30530,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 40,
+        "thrustSpeed": 85,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -30529,10 +30543,17 @@
     "name": "Dawnbreaker +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2741,
     "weight": 2.39,
     "rank": 3,
     "tier": 5.610091,
+=======
+    "price": 8202,
+    "weight": 2.07,
+    "heirloomLevel": 3,
+    "tier": 10.5090961,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30545,7 +30566,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 102,
-        "balance": 0.33,
+        "balance": 0.49,
         "handling": 74,
         "bodyArmor": 4,
         "flags": [
@@ -30553,10 +30574,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 83,
-        "swingDamage": 40,
+        "thrustSpeed": 85,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 84
       }
     ]
   },
@@ -30772,10 +30793,17 @@
     "name": "Decorated Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5173,
     "weight": 2.25,
     "rank": 1,
     "tier": 8.117065,
+=======
+    "price": 8086,
+    "weight": 2.15,
+    "heirloomLevel": 1,
+    "tier": 10.4265194,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30788,18 +30816,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.3,
-        "handling": 81,
+        "balance": 0.37,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -30809,10 +30837,17 @@
     "name": "Decorated Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3821,
     "weight": 2.25,
     "rank": 2,
     "tier": 6.8205924,
+=======
+    "price": 7316,
+    "weight": 2.15,
+    "heirloomLevel": 2,
+    "tier": 9.863284,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30825,18 +30860,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.3,
-        "handling": 81,
+        "balance": 0.37,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 39,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -30846,10 +30881,17 @@
     "name": "Decorated Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2909,
     "weight": 2.25,
     "rank": 3,
     "tier": 5.811629,
+=======
+    "price": 8520,
+    "weight": 2.09,
+    "heirloomLevel": 3,
+    "tier": 10.7326221,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -30862,18 +30904,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.3,
-        "handling": 81,
+        "balance": 0.41,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 39,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 82
       }
     ]
   },
@@ -45073,10 +45115,17 @@
     "name": "Fine Steel Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2110,
     "weight": 1.91,
     "rank": 1,
     "tier": 4.78916025,
+=======
+    "price": 3066,
+    "weight": 1.84,
+    "heirloomLevel": 1,
+    "tier": 5.995843,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45089,18 +45138,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.46,
-        "handling": 86,
+        "balance": 0.51,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -45110,10 +45159,17 @@
     "name": "Fine Steel Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1595,
     "weight": 1.91,
     "rank": 2,
     "tier": 4.024225,
+=======
+    "price": 3526,
+    "weight": 1.8,
+    "heirloomLevel": 2,
+    "tier": 6.508357,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45126,18 +45182,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.46,
-        "handling": 86,
+        "balance": 0.54,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
+        "thrustSpeed": 88,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },
@@ -45147,10 +45203,17 @@
     "name": "Fine Steel Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1243,
     "weight": 1.91,
     "rank": 3,
     "tier": 3.428925,
+=======
+    "price": 4139,
+    "weight": 1.75,
+    "heirloomLevel": 3,
+    "tier": 7.143512,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -45163,18 +45226,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.46,
-        "handling": 86,
+        "balance": 0.57,
+        "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 30,
+        "thrustSpeed": 89,
+        "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 87
       }
     ]
   },
@@ -50135,10 +50198,17 @@
     "name": "Gold Bound Short Warsword +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5208,
     "weight": 2.13,
     "rank": 1,
     "tier": 8.148066,
+=======
+    "price": 7755,
+    "weight": 2.02,
+    "heirloomLevel": 1,
+    "tier": 10.1876535,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50151,18 +50221,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.55,
-        "handling": 85,
+        "balance": 0.61,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -50172,10 +50242,17 @@
     "name": "Gold Bound Short Warsword +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3846,
     "weight": 2.13,
     "rank": 2,
     "tier": 6.846637,
+=======
+    "price": 8320,
+    "weight": 1.94,
+    "heirloomLevel": 2,
+    "tier": 10.5928211,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50188,18 +50265,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.55,
-        "handling": 85,
+        "balance": 0.66,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -50209,10 +50286,17 @@
     "name": "Gold Bound Short Warsword +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2928,
     "weight": 2.13,
     "rank": 3,
     "tier": 5.83382225,
+=======
+    "price": 9096,
+    "weight": 1.9,
+    "heirloomLevel": 3,
+    "tier": 11.1268253,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -50225,18 +50309,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 84,
-        "balance": 0.55,
-        "handling": 85,
+        "balance": 0.67,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 90
       }
     ]
   },
@@ -56579,10 +56663,17 @@
     "name": "Heavy Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3838,
     "weight": 2.2,
     "rank": 1,
     "tier": 6.83820868,
+=======
+    "price": 5791,
+    "weight": 2.08,
+    "heirloomLevel": 1,
+    "tier": 8.651993,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -56595,18 +56686,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.5,
-        "handling": 84,
+        "balance": 0.59,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -56616,10 +56707,17 @@
     "name": "Heavy Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2854,
     "weight": 2.2,
     "rank": 2,
     "tier": 5.74599552,
+=======
+    "price": 5472,
+    "weight": 2.08,
+    "heirloomLevel": 2,
+    "tier": 8.379686,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -56632,18 +56730,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.5,
-        "handling": 84,
+        "balance": 0.59,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 32,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 87
       }
     ]
   },
@@ -56653,10 +56751,17 @@
     "name": "Heavy Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2188,
     "weight": 2.2,
     "rank": 3,
     "tier": 4.895997,
+=======
+    "price": 6295,
+    "weight": 2.03,
+    "heirloomLevel": 3,
+    "tier": 9.068188,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -56669,18 +56774,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 103,
-        "balance": 0.5,
-        "handling": 84,
+        "balance": 0.61,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 85
+        "swingSpeed": 88
       }
     ]
   },
@@ -57239,10 +57344,17 @@
     "name": "Highland Broad Blade +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4203,
     "weight": 2.1,
     "rank": 1,
     "tier": 7.20706558,
+=======
+    "price": 6388,
+    "weight": 2.01,
+    "heirloomLevel": 1,
+    "tier": 9.14334,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57255,18 +57367,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.36,
-        "handling": 81,
+        "balance": 0.41,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -57276,10 +57388,17 @@
     "name": "Highland Broad Blade +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3118,
     "weight": 2.1,
     "rank": 2,
     "tier": 6.05593538,
+=======
+    "price": 6911,
+    "weight": 1.95,
+    "heirloomLevel": 2,
+    "tier": 9.554945,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57292,18 +57411,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.36,
-        "handling": 81,
+        "balance": 0.44,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -57313,10 +57432,17 @@
     "name": "Highland Broad Blade +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2385,
     "weight": 2.1,
     "rank": 3,
     "tier": 5.16008854,
+=======
+    "price": 7704,
+    "weight": 1.95,
+    "heirloomLevel": 3,
+    "tier": 10.1506023,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -57329,18 +57455,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.36,
-        "handling": 81,
+        "balance": 0.44,
+        "handling": 82,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 36,
+        "thrustSpeed": 87,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },
@@ -65904,10 +66030,17 @@
     "name": "Iron Saber +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2564,
     "weight": 2.12,
     "rank": 1,
     "tier": 5.390258,
+=======
+    "price": 3714,
+    "weight": 1.99,
+    "heirloomLevel": 1,
+    "tier": 6.70851231,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65920,18 +66053,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.58,
-        "handling": 86,
+        "balance": 0.66,
+        "handling": 87,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 29,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -65941,10 +66074,17 @@
     "name": "Iron Saber +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1927,
     "weight": 2.12,
     "rank": 2,
     "tier": 4.52931356,
+=======
+    "price": 4125,
+    "weight": 1.92,
+    "heirloomLevel": 2,
+    "tier": 7.13018656,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65957,18 +66097,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.58,
-        "handling": 86,
+        "balance": 0.7,
+        "handling": 87,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 30,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 90
       }
     ]
   },
@@ -65978,10 +66118,17 @@
     "name": "Iron Saber +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1493,
     "weight": 2.12,
     "rank": 3,
     "tier": 3.85929728,
+=======
+    "price": 4852,
+    "weight": 1.88,
+    "heirloomLevel": 3,
+    "tier": 7.82577372,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -65994,18 +66141,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 99,
-        "balance": 0.58,
-        "handling": 86,
+        "balance": 0.73,
+        "handling": 88,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 29,
+        "thrustSpeed": 87,
+        "swingDamage": 31,
         "swingDamageType": "Cut",
-        "swingSpeed": 87
+        "swingSpeed": 91
       }
     ]
   },
@@ -112640,10 +112787,17 @@
     "name": "Ridged Saber  +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4591,
     "weight": 2.14,
     "rank": 1,
     "tier": 7.582545,
+=======
+    "price": 6799,
+    "weight": 2.05,
+    "heirloomLevel": 1,
+    "tier": 9.467809,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -112654,18 +112808,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.63,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
+        "thrustSpeed": 87,
         "swingDamage": 32,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -112675,10 +112829,17 @@
     "name": "Ridged Saber  +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3400,
     "weight": 2.14,
     "rank": 2,
     "tier": 6.37144327,
+=======
+    "price": 6271,
+    "weight": 2.05,
+    "heirloomLevel": 2,
+    "tier": 9.048825,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -112689,18 +112850,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.63,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -112710,10 +112871,17 @@
     "name": "Ridged Saber  +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2595,
     "weight": 2.14,
     "rank": 3,
     "tier": 5.42892361,
+=======
+    "price": 7497,
+    "weight": 2.02,
+    "heirloomLevel": 3,
+    "tier": 9.998306,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -112724,18 +112892,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.56,
-        "handling": 87,
+        "balance": 0.66,
+        "handling": 88,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 85,
-        "swingDamage": 32,
+        "thrustSpeed": 87,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 86
+        "swingSpeed": 89
       }
     ]
   },
@@ -139144,10 +139312,17 @@
     "name": "Thamaskene Steel Spatha +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 4900,
     "weight": 2.27,
     "rank": 1,
     "tier": 7.86966944,
+=======
+    "price": 7326,
+    "weight": 2.18,
+    "heirloomLevel": 1,
+    "tier": 9.870982,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -139158,8 +139333,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.45,
-        "handling": 86,
+        "balance": 0.51,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
@@ -139169,7 +139344,7 @@
         "thrustSpeed": 85,
         "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -139179,10 +139354,17 @@
     "name": "Thamaskene Steel Spatha +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3623,
     "weight": 2.27,
     "rank": 2,
     "tier": 6.612708,
+=======
+    "price": 6810,
+    "weight": 2.18,
+    "heirloomLevel": 2,
+    "tier": 9.476922,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -139193,18 +139375,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.45,
-        "handling": 86,
+        "balance": 0.51,
+        "handling": 87,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 34,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 85
       }
     ]
   },
@@ -139214,10 +139396,17 @@
     "name": "Thamaskene Steel Spatha +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2761,
     "weight": 2.27,
     "rank": 3,
     "tier": 5.63449669,
+=======
+    "price": 8043,
+    "weight": 2.13,
+    "heirloomLevel": 3,
+    "tier": 10.3960152,
+>>>>>>> cbed0ab (1808)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -139228,18 +139417,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 105,
-        "balance": 0.45,
-        "handling": 86,
+        "balance": 0.55,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 34,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 86
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -16808,10 +16808,17 @@
     "name": "Blacksmith Hammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 458,
     "weight": 2.4,
     "rank": 1,
     "tier": 1.68400609,
+=======
+    "price": 622,
+    "weight": 2.25,
+    "heirloomLevel": 1,
+    "tier": 2.12674212,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16824,18 +16831,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 32,
-        "balance": 0.67,
-        "handling": 99,
+        "balance": 0.76,
+        "handling": 101,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
+        "thrustSpeed": 85,
         "swingDamage": 20,
         "swingDamageType": "Blunt",
-        "swingSpeed": 90
+        "swingSpeed": 92
       }
     ]
   },
@@ -16845,10 +16852,17 @@
     "name": "Blacksmith Hammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 370,
     "weight": 2.4,
     "rank": 2,
     "tier": 1.4150331,
+=======
+    "price": 746,
+    "weight": 2.2,
+    "heirloomLevel": 2,
+    "tier": 2.42420173,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16861,18 +16875,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 32,
-        "balance": 0.67,
-        "handling": 99,
+        "balance": 0.77,
+        "handling": 101,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 20,
+        "thrustSpeed": 85,
+        "swingDamage": 21,
         "swingDamageType": "Blunt",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -16882,10 +16896,17 @@
     "name": "Blacksmith Hammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 307,
     "weight": 2.4,
     "rank": 3,
     "tier": 1.20570874,
+=======
+    "price": 1044,
+    "weight": 2.2,
+    "heirloomLevel": 3,
+    "tier": 3.05443859,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -16898,18 +16919,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 32,
-        "balance": 0.67,
-        "handling": 99,
+        "balance": 0.77,
+        "handling": 101,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 84,
-        "swingDamage": 20,
+        "thrustSpeed": 85,
+        "swingDamage": 23,
         "swingDamageType": "Blunt",
-        "swingSpeed": 90
+        "swingSpeed": 93
       }
     ]
   },
@@ -19433,10 +19454,17 @@
     "name": "Bone Crusher +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5213,
     "weight": 1.75,
     "rank": 1,
     "tier": 8.152554,
+=======
+    "price": 7910,
+    "weight": 1.63,
+    "heirloomLevel": 1,
+    "tier": 10.3005533,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19447,18 +19475,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.71,
-        "handling": 93,
+        "balance": 0.8,
+        "handling": 95,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 22,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -19468,10 +19496,17 @@
     "name": "Bone Crusher +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3850,
     "weight": 1.75,
     "rank": 2,
     "tier": 6.850408,
+=======
+    "price": 8159,
+    "weight": 1.63,
+    "heirloomLevel": 2,
+    "tier": 10.4784174,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19482,18 +19517,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.71,
-        "handling": 93,
+        "balance": 0.8,
+        "handling": 95,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 22,
+        "thrustSpeed": 90,
+        "swingDamage": 23,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -19503,10 +19538,17 @@
     "name": "Bone Crusher +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2930,
     "weight": 1.75,
     "rank": 3,
     "tier": 5.837035,
+=======
+    "price": 8504,
+    "weight": 1.63,
+    "heirloomLevel": 3,
+    "tier": 10.7213669,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -19517,18 +19559,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 71,
-        "balance": 0.71,
-        "handling": 93,
+        "balance": 0.8,
+        "handling": 95,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 22,
+        "thrustSpeed": 90,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -23633,10 +23675,15 @@
     "name": "Calradic Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 2359,
+    "price": 3300,
     "weight": 1.79,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 5.125899,
+=======
+    "heirloomLevel": 1,
+    "tier": 6.261012,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23656,7 +23703,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 88,
-        "swingDamage": 21,
+        "swingDamage": 22,
         "swingDamageType": "Blunt",
         "swingSpeed": 88
       }
@@ -23668,10 +23715,15 @@
     "name": "Calradic Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1777,
+    "price": 3398,
     "weight": 1.79,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 4.307178,
+=======
+    "heirloomLevel": 2,
+    "tier": 6.36912251,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23691,7 +23743,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 88,
-        "swingDamage": 21,
+        "swingDamage": 23,
         "swingDamageType": "Blunt",
         "swingSpeed": 88
       }
@@ -23703,10 +23755,17 @@
     "name": "Calradic Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1380,
     "weight": 1.79,
     "rank": 3,
     "tier": 3.67002344,
+=======
+    "price": 4354,
+    "weight": 1.78,
+    "heirloomLevel": 3,
+    "tier": 7.355445,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -23717,18 +23776,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 73,
-        "balance": 0.63,
-        "handling": 92,
+        "balance": 0.64,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 88,
-        "swingDamage": 21,
+        "thrustSpeed": 89,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 88
+        "swingSpeed": 89
       }
     ]
   },
@@ -37146,10 +37205,17 @@
     "name": "Eastern Heavy Mace +1",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5199,
     "weight": 1.46,
     "rank": 1,
     "tier": 8.139377,
+=======
+    "price": 7586,
+    "weight": 1.39,
+    "heirloomLevel": 1,
+    "tier": 10.0640364,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37160,8 +37226,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.72,
-        "handling": 95,
+        "balance": 0.78,
+        "handling": 96,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -37171,7 +37237,7 @@
         "thrustSpeed": 92,
         "swingDamage": 21,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -37181,10 +37247,17 @@
     "name": "Eastern Heavy Mace +2",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3839,
     "weight": 1.46,
     "rank": 2,
     "tier": 6.839338,
+=======
+    "price": 7950,
+    "weight": 1.39,
+    "heirloomLevel": 2,
+    "tier": 10.3292694,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37195,8 +37268,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.72,
-        "handling": 95,
+        "balance": 0.78,
+        "handling": 96,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -37204,9 +37277,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 92,
-        "swingDamage": 21,
+        "swingDamage": 22,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -37216,10 +37289,17 @@
     "name": "Eastern Heavy Mace +3",
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2922,
     "weight": 1.46,
     "rank": 3,
     "tier": 5.82760143,
+=======
+    "price": 8409,
+    "weight": 1.39,
+    "heirloomLevel": 3,
+    "tier": 10.6551037,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -37230,8 +37310,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.72,
-        "handling": 95,
+        "balance": 0.78,
+        "handling": 96,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -37239,9 +37319,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 92,
-        "swingDamage": 21,
+        "swingDamage": 23,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 93
       }
     ]
   },
@@ -48396,10 +48476,17 @@
     "name": "Fullered Light Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 839,
     "weight": 1.72,
     "rank": 1,
     "tier": 2.632216,
+=======
+    "price": 1144,
+    "weight": 1.62,
+    "heirloomLevel": 1,
+    "tier": 3.246553,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48410,18 +48497,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 55,
-        "balance": 0.75,
-        "handling": 97,
+        "balance": 0.82,
+        "handling": 98,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 18,
         "swingDamageType": "Blunt",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -48431,10 +48518,17 @@
     "name": "Fullered Light Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 657,
     "weight": 1.72,
     "rank": 2,
     "tier": 2.21179271,
+=======
+    "price": 1250,
+    "weight": 1.62,
+    "heirloomLevel": 2,
+    "tier": 3.44202423,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48445,18 +48539,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 55,
-        "balance": 0.75,
-        "handling": 97,
+        "balance": 0.82,
+        "handling": 98,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 18,
+        "thrustSpeed": 90,
+        "swingDamage": 19,
         "swingDamageType": "Blunt",
-        "swingSpeed": 92
+        "swingSpeed": 94
       }
     ]
   },
@@ -48466,10 +48560,17 @@
     "name": "Fullered Light Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 530,
     "weight": 1.72,
     "rank": 3,
     "tier": 1.88460445,
+=======
+    "price": 1640,
+    "weight": 1.57,
+    "heirloomLevel": 3,
+    "tier": 4.095804,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -48480,18 +48581,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 55,
-        "balance": 0.75,
-        "handling": 97,
+        "balance": 0.84,
+        "handling": 99,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 18,
+        "thrustSpeed": 90,
+        "swingDamage": 20,
         "swingDamageType": "Blunt",
-        "swingSpeed": 92
+        "swingSpeed": 95
       }
     ]
   },
@@ -63420,10 +63521,15 @@
     "name": "Imperial Light Mace +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1909,
+    "price": 2745,
     "weight": 1.9,
+<<<<<<< HEAD
     "rank": 1,
     "tier": 4.50350475,
+=======
+    "heirloomLevel": 1,
+    "tier": 5.61486149,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63443,7 +63549,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 19,
+        "swingDamage": 20,
         "swingDamageType": "Blunt",
         "swingSpeed": 91
       }
@@ -63455,10 +63561,15 @@
     "name": "Imperial Light Mace +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1448,
+    "price": 2915,
     "weight": 1.9,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 3.78419423,
+=======
+    "heirloomLevel": 2,
+    "tier": 5.81936932,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63478,7 +63589,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 87,
-        "swingDamage": 19,
+        "swingDamage": 21,
         "swingDamageType": "Blunt",
         "swingSpeed": 91
       }
@@ -63490,10 +63601,17 @@
     "name": "Imperial Light Mace +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1132,
     "weight": 1.9,
     "rank": 3,
     "tier": 3.22440267,
+=======
+    "price": 3808,
+    "weight": 1.83,
+    "heirloomLevel": 3,
+    "tier": 6.80763149,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63504,18 +63622,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.71,
-        "handling": 96,
+        "balance": 0.76,
+        "handling": 97,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 19,
+        "thrustSpeed": 88,
+        "swingDamage": 22,
         "swingDamageType": "Blunt",
-        "swingSpeed": 91
+        "swingSpeed": 92
       }
     ]
   },
@@ -73336,10 +73454,15 @@
     "name": "Knight's Fall +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 2200,
+    "price": 2983,
     "weight": 1.68,
+<<<<<<< HEAD
     "rank": 2,
     "tier": 4.91268253,
+=======
+    "heirloomLevel": 2,
+    "tier": 5.89925766,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -73359,7 +73482,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 89,
-        "swingDamage": 23,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
         "swingSpeed": 85
       }
@@ -73371,10 +73494,17 @@
     "name": "Knight's Fall +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1698,
     "weight": 1.68,
     "rank": 3,
     "tier": 4.185955,
+=======
+    "price": 5095,
+    "weight": 1.64,
+    "heirloomLevel": 3,
+    "tier": 8.04654,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -73385,8 +73515,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 81,
-        "balance": 0.5,
-        "handling": 85,
+        "balance": 0.55,
+        "handling": 86,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -73394,9 +73524,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 89,
-        "swingDamage": 23,
+        "swingDamage": 26,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 86
       }
     ]
   },
@@ -78879,10 +79009,17 @@
     "name": "Light Mace +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 402,
     "weight": 1.8,
     "rank": 1,
     "tier": 1.51508188,
+=======
+    "price": 530,
+    "weight": 1.7,
+    "heirloomLevel": 1,
+    "tier": 1.88605559,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78893,18 +79030,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.97,
-        "handling": 92,
+        "balance": 1.0,
+        "handling": 94,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 15,
         "swingDamageType": "Blunt",
-        "swingSpeed": 99
+        "swingSpeed": 101
       }
     ]
   },
@@ -78914,10 +79051,17 @@
     "name": "Light Mace +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 327,
     "weight": 1.8,
     "rank": 2,
     "tier": 1.27308929,
+=======
+    "price": 609,
+    "weight": 1.7,
+    "heirloomLevel": 2,
+    "tier": 2.09170675,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78928,18 +79072,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.97,
-        "handling": 92,
+        "balance": 1.0,
+        "handling": 94,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 88,
-        "swingDamage": 15,
+        "thrustSpeed": 89,
+        "swingDamage": 16,
         "swingDamageType": "Blunt",
-        "swingSpeed": 99
+        "swingSpeed": 101
       }
     ]
   },
@@ -78949,10 +79093,17 @@
     "name": "Light Mace +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 273,
     "weight": 1.8,
     "rank": 3,
     "tier": 1.08476281,
+=======
+    "price": 995,
+    "weight": 1.7,
+    "heirloomLevel": 3,
+    "tier": 2.957553,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -78963,18 +79114,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.97,
-        "handling": 92,
+        "balance": 1.0,
+        "handling": 94,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 88,
-        "swingDamage": 15,
+        "thrustSpeed": 89,
+        "swingDamage": 18,
         "swingDamageType": "Blunt",
-        "swingSpeed": 99
+        "swingSpeed": 101
       }
     ]
   },
@@ -79349,10 +79500,17 @@
     "name": "Light Shishpar Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1087,
     "weight": 1.99,
     "rank": 1,
     "tier": 3.139505,
+=======
+    "price": 1485,
+    "weight": 1.91,
+    "heirloomLevel": 1,
+    "tier": 3.84629321,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79363,18 +79521,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 57,
-        "balance": 0.84,
-        "handling": 101,
+        "balance": 0.9,
+        "handling": 102,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
+        "thrustSpeed": 88,
         "swingDamage": 17,
         "swingDamageType": "Blunt",
-        "swingSpeed": 95
+        "swingSpeed": 97
       }
     ]
   },
@@ -79384,10 +79542,17 @@
     "name": "Light Shishpar Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 842,
     "weight": 1.99,
     "rank": 2,
     "tier": 2.638056,
+=======
+    "price": 1663,
+    "weight": 1.91,
+    "heirloomLevel": 2,
+    "tier": 4.13244152,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79398,18 +79563,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 57,
-        "balance": 0.84,
-        "handling": 101,
+        "balance": 0.9,
+        "handling": 102,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 17,
+        "thrustSpeed": 88,
+        "swingDamage": 18,
         "swingDamageType": "Blunt",
-        "swingSpeed": 95
+        "swingSpeed": 97
       }
     ]
   },
@@ -79419,10 +79584,17 @@
     "name": "Light Shishpar Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 672,
     "weight": 1.99,
     "rank": 3,
     "tier": 2.24781132,
+=======
+    "price": 2233,
+    "weight": 1.87,
+    "heirloomLevel": 3,
+    "tier": 4.958194,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79433,18 +79605,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 57,
-        "balance": 0.84,
-        "handling": 101,
+        "balance": 0.95,
+        "handling": 103,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 87,
-        "swingDamage": 17,
+        "thrustSpeed": 88,
+        "swingDamage": 19,
         "swingDamageType": "Blunt",
-        "swingSpeed": 95
+        "swingSpeed": 98
       }
     ]
   },
@@ -127068,10 +127240,17 @@
     "name": "Spiked Club +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1347,
     "weight": 1.78,
     "rank": 1,
     "tier": 3.61332941,
+=======
+    "price": 1988,
+    "weight": 1.69,
+    "heirloomLevel": 1,
+    "tier": 4.617814,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127082,18 +127261,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 78,
-        "balance": 0.53,
-        "handling": 89,
+        "balance": 0.62,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
+        "thrustSpeed": 89,
         "swingDamage": 23,
         "swingDamageType": "Pierce",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -127103,10 +127282,17 @@
     "name": "Spiked Club +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1034,
     "weight": 1.78,
     "rank": 2,
     "tier": 3.03619933,
+=======
+    "price": 2013,
+    "weight": 1.69,
+    "heirloomLevel": 2,
+    "tier": 4.65219831,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127117,18 +127303,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 78,
-        "balance": 0.53,
-        "handling": 89,
+        "balance": 0.62,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 23,
+        "thrustSpeed": 89,
+        "swingDamage": 24,
         "swingDamageType": "Pierce",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -127138,10 +127324,17 @@
     "name": "Spiked Club +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 818,
     "weight": 1.78,
     "rank": 3,
     "tier": 2.58705735,
+=======
+    "price": 2715,
+    "weight": 1.69,
+    "heirloomLevel": 3,
+    "tier": 5.57812357,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127152,18 +127345,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 78,
-        "balance": 0.53,
-        "handling": 89,
+        "balance": 0.62,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 23,
+        "thrustSpeed": 89,
+        "swingDamage": 26,
         "swingDamageType": "Pierce",
-        "swingSpeed": 86
+        "swingSpeed": 88
       }
     ]
   },
@@ -127889,10 +128082,17 @@
     "name": "Spiralled Mace +1",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 5189,
     "weight": 1.21,
     "rank": 1,
     "tier": 8.130823,
+=======
+    "price": 7999,
+    "weight": 1.12,
+    "heirloomLevel": 1,
+    "tier": 10.3643179,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127903,8 +128103,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.61,
-        "handling": 88,
+        "balance": 0.7,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -127914,7 +128114,7 @@
         "thrustSpeed": 94,
         "swingDamage": 22,
         "swingDamageType": "Blunt",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -127924,10 +128124,17 @@
     "name": "Spiralled Mace +2",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 3832,
     "weight": 1.21,
     "rank": 2,
     "tier": 6.83215046,
+=======
+    "price": 8250,
+    "weight": 1.12,
+    "heirloomLevel": 2,
+    "tier": 10.54328,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127938,8 +128145,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.61,
-        "handling": 88,
+        "balance": 0.7,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -127947,9 +128154,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 22,
+        "swingDamage": 23,
         "swingDamageType": "Blunt",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -127959,10 +128166,17 @@
     "name": "Spiralled Mace +3",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2917,
     "weight": 1.21,
     "rank": 3,
     "tier": 5.82147646,
+=======
+    "price": 8600,
+    "weight": 1.12,
+    "heirloomLevel": 3,
+    "tier": 10.7877369,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -127973,8 +128187,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 87,
-        "balance": 0.61,
-        "handling": 88,
+        "balance": 0.7,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -127982,9 +128196,9 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 22,
+        "swingDamage": 24,
         "swingDamageType": "Blunt",
-        "swingSpeed": 88
+        "swingSpeed": 90
       }
     ]
   },
@@ -151959,10 +152173,17 @@
     "name": "Wooden Hammer +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 360,
     "weight": 2.48,
     "rank": 1,
     "tier": 1.38300467,
+=======
+    "price": 485,
+    "weight": 2.33,
+    "heirloomLevel": 1,
+    "tier": 1.75959659,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -151975,8 +152196,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.59,
-        "handling": 97,
+        "balance": 0.66,
+        "handling": 99,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -151984,10 +152205,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
+        "thrustSpeed": 85,
         "swingDamage": 15,
         "swingDamageType": "Blunt",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -151997,10 +152218,17 @@
     "name": "Wooden Hammer +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 295,
     "weight": 2.48,
     "rank": 2,
     "tier": 1.16210806,
+=======
+    "price": 555,
+    "weight": 2.33,
+    "heirloomLevel": 2,
+    "tier": 1.95145833,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -152013,8 +152241,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.59,
-        "handling": 97,
+        "balance": 0.66,
+        "handling": 99,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -152022,10 +152250,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 15,
+        "thrustSpeed": 85,
+        "swingDamage": 16,
         "swingDamageType": "Blunt",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },
@@ -152035,10 +152263,17 @@
     "name": "Wooden Hammer +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 248,
     "weight": 2.48,
     "rank": 3,
     "tier": 0.9901986,
+=======
+    "price": 898,
+    "weight": 2.33,
+    "heirloomLevel": 3,
+    "tier": 2.7592504,
+>>>>>>> 016072a (macesdone)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -152051,8 +152286,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 45,
-        "balance": 0.59,
-        "handling": 97,
+        "balance": 0.66,
+        "handling": 99,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -152060,10 +152295,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 83,
-        "swingDamage": 15,
+        "thrustSpeed": 85,
+        "swingDamage": 18,
         "swingDamageType": "Blunt",
-        "swingSpeed": 87
+        "swingSpeed": 89
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -112593,10 +112593,17 @@
     "name": "Ridged Iron Broadsword +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 2525,
     "weight": 2.26,
     "rank": 1,
     "tier": 5.340885,
+=======
+    "price": 4000,
+    "weight": 2.13,
+    "heirloomLevel": 1,
+    "tier": 7.00439835,
+>>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -112609,18 +112616,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.33,
-        "handling": 83,
+        "balance": 0.42,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
         "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -112630,10 +112637,17 @@
     "name": "Ridged Iron Broadsword +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1899,
     "weight": 2.26,
     "rank": 2,
     "tier": 4.48782635,
+=======
+    "price": 3712,
+    "weight": 2.13,
+    "heirloomLevel": 2,
+    "tier": 6.70670033,
+>>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -112646,18 +112660,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.33,
-        "handling": 83,
+        "balance": 0.42,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 35,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 82
       }
     ]
   },
@@ -112667,10 +112681,17 @@
     "name": "Ridged Iron Broadsword +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
     "price": 1472,
     "weight": 2.26,
     "rank": 3,
     "tier": 3.82394743,
+=======
+    "price": 4193,
+    "weight": 2.09,
+    "heirloomLevel": 3,
+    "tier": 7.19720936,
+>>>>>>> 8655046 (2158)
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -112683,18 +112704,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 100,
-        "balance": 0.33,
-        "handling": 83,
+        "balance": 0.44,
+        "handling": 85,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 85,
-        "swingDamage": 35,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 80
+        "swingSpeed": 83
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -129236,6 +129236,7 @@
     "culture": "Khuzait",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 4272,
     "weight": 2.31,
     "rank": 1,
@@ -129246,6 +129247,12 @@
     "heirloomLevel": 1,
     "tier": 9.250165,
 >>>>>>> 1597247 (0046)
+=======
+    "price": 5679,
+    "weight": 2.31,
+    "heirloomLevel": 1,
+    "tier": 8.55744648,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129256,6 +129263,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
+<<<<<<< HEAD
         "balance": 0.45,
         "handling": 79,
         "bodyArmor": 0,
@@ -129300,6 +129308,10 @@
         "length": 93,
         "balance": 0.45,
         "handling": 79,
+=======
+        "balance": 0.39,
+        "handling": 78,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -129309,11 +129321,12 @@
         "thrustSpeed": 84,
         "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 81
       }
     ]
   },
   {
+<<<<<<< HEAD
     "id": "crpg_steel_mace_h3",
     "baseId": "crpg_steel_mace",
     "name": "Steel Mace +3",
@@ -129330,6 +129343,16 @@
     "heirloomLevel": 3,
     "tier": 10.1207523,
 >>>>>>> 1597247 (0046)
+=======
+    "id": "crpg_steel_mace_h2",
+    "name": "Steel Mace +2",
+    "culture": "Khuzait",
+    "type": "OneHandedWeapon",
+    "price": 5505,
+    "weight": 2.31,
+    "heirloomLevel": 2,
+    "tier": 8.407801,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -129340,7 +129363,41 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 93,
-        "balance": 0.48,
+        "balance": 0.39,
+        "handling": 78,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 84,
+        "swingDamage": 28,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 81
+      }
+    ]
+  },
+  {
+    "id": "crpg_steel_mace_h3",
+    "name": "Steel Mace +3",
+    "culture": "Khuzait",
+    "type": "OneHandedWeapon",
+    "price": 6866,
+    "weight": 2.27,
+    "heirloomLevel": 3,
+    "tier": 9.520258,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 93,
+        "balance": 0.43,
         "handling": 79,
         "bodyArmor": 0,
         "flags": [
@@ -129348,10 +129405,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 85,
-        "swingDamage": 28,
+        "thrustSpeed": 84,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 82
       }
     ]
   },
@@ -149397,6 +149454,7 @@
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "price": 4866,
     "weight": 1.91,
     "rank": 1,
@@ -149407,6 +149465,12 @@
     "heirloomLevel": 1,
     "tier": 9.827833,
 >>>>>>> 825a77b (startedonmaces)
+=======
+    "price": 6544,
+    "weight": 1.91,
+    "heirloomLevel": 1,
+    "tier": 9.267763,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -149417,18 +149481,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.53,
-        "handling": 91,
+        "balance": 0.48,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 26,
+        "thrustSpeed": 87,
+        "swingDamage": 27,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 84
       }
     ]
   },
@@ -149438,6 +149502,7 @@
     "name": "Warhammer +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 3598,
     "weight": 1.91,
@@ -149449,6 +149514,12 @@
     "heirloomLevel": 2,
     "tier": 9.686204,
 >>>>>>> 825a77b (startedonmaces)
+=======
+    "price": 6405,
+    "weight": 1.91,
+    "heirloomLevel": 2,
+    "tier": 9.156638,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -149459,18 +149530,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.53,
-        "handling": 91,
+        "balance": 0.48,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 27,
+        "thrustSpeed": 87,
+        "swingDamage": 28,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 84
       }
     ]
   },
@@ -149480,6 +149551,7 @@
     "name": "Warhammer +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
+<<<<<<< HEAD
 <<<<<<< HEAD
     "price": 2743,
     "weight": 1.91,
@@ -149491,6 +149563,12 @@
     "heirloomLevel": 3,
     "tier": 10.8765373,
 >>>>>>> 825a77b (startedonmaces)
+=======
+    "price": 7963,
+    "weight": 1.87,
+    "heirloomLevel": 3,
+    "tier": 10.33864,
+>>>>>>> 5ff5dd5 (sortedwarhammer)
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -149501,18 +149579,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 70,
-        "balance": 0.59,
-        "handling": 92,
+        "balance": 0.52,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 20,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 88,
-        "swingDamage": 28,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
-        "swingSpeed": 87
+        "swingSpeed": 85
       }
     ]
   },


### PR DESCRIPTION
A list with changes to tier, showing the increase/decrease at h3 from h0,  as well as the stat changes per heirloom level. Some I've flagged to see if I can get it closer to **1.0** tier difference i.e. **+/- 0.2**, such as **0.7** or **1.3**:
https://docs.google.com/spreadsheets/d/1G-nn5KeMVP84JMxMeu3wP8vUn3bEZKsYW65K6l3ha-E/edit?usp=sharing

Flagged swords are in bold - either due to their tier difference or due to the amount of damage points added (i.e. 5 Thrust and 2 Swing - Gold Bound Short Warsword, 3 Thrust and 3 Swing - Wooden Sword, 3 Thrust and 2 Swing - Spathas, etc) which I perhaps couldn't balance with just increases to speed & swing damage. 