### PR TITLE
Fixing a typo in the +2 loom state of the Hoe

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -9905,7 +9905,7 @@
   <CraftingPiece id="crpg_hoe_blade_h2" name="{=LSrJljDL}Adze Head" tier="1" piece_type="Blade" mesh="axe_craft_15_head" distance_to_next_piece="4.1" distance_to_previous_piece="3.2" weight="0.315" is_default="true">
     <BuildData piece_offset="-6.4" />
     <BladeData stack_amount="2" blade_length="4.552" blade_width="25.764" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -59967,10 +59967,10 @@
     "name": "Hoe +2",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 15303,
+    "price": 1698,
     "weight": 0.96,
     "rank": 2,
-    "tier": 10.5045223,
+    "tier": 2.8254416,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -59994,7 +59994,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 38,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       },
@@ -60017,7 +60017,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 102,
-        "swingDamage": 38,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 94
       },
@@ -60038,7 +60038,7 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 94,
-        "swingDamage": 38,
+        "swingDamage": 28,
         "swingDamageType": "Cut",
         "swingSpeed": 76
       }


### PR DESCRIPTION
Resolve a typo created when making the +2 heirloom state of the Hoe (intended to be 2.8 to fall in line with loom elevation per level but mistyped as 3.8)