### PR TITLE
7.10 swingpolarm adjustments

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -5116,37 +5116,37 @@
       <Flag name="NoBlood" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_polesword_blade_h0" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.5">
+  <CraftingPiece id="crpg_polesword_blade_h0" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.44">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_polesword_blade_h1" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.47">
+  <CraftingPiece id="crpg_polesword_blade_h1" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.41">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron5" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_polesword_blade_h2" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.41">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron5" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_polesword_blade_h3" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.41">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="4.9" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron5" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_polesword_blade_h2" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.47">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="5.0" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron5" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_polesword_blade_h3" name="{=kaikaikai}Exceptional Eastern Glaive" tier="4" piece_type="Blade" mesh="spear_blade_22" length="89" weight="0.47">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="5.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -6020,73 +6020,73 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warrazor_blade_h0" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.6" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_warrazor_blade_h0" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.56" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_warrazor_blade_h1" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.53" excluded_item_usage_features="">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warrazor_blade_h1" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.57" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_warrazor_blade_h2" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.5" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warrazor_blade_h2" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.54" excluded_item_usage_features="">
+  <CraftingPiece id="crpg_warrazor_blade_h3" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.46" excluded_item_usage_features="">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_warrazor_blade_h3" name="{=kaikaikai}Warrazor Head" tier="4" piece_type="Blade" mesh="spear_blade_43" length="64.4" weight="0.54" excluded_item_usage_features="">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_long_glaive_blade_h0" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.43">
+  <CraftingPiece id="crpg_long_glaive_blade_h0" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.4">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron5" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_long_glaive_blade_h1" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.37">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron5" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_long_glaive_blade_h2" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.37">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Cut" damage_factor="2.7" />
       <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_glaive_blade_h1" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.4">
+  <CraftingPiece id="crpg_long_glaive_blade_h3" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.34">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron5" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_long_glaive_blade_h2" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.4">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron5" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_long_glaive_blade_h3" name="{=kaikaikai}Long Glaive Head" tier="5" piece_type="Blade" mesh="spear_blade_24" length="68" weight="0.4">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Thrust damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="2" />
@@ -6128,10 +6128,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h0" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.6">
+  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h0" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6139,26 +6139,26 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_menavlion_blade_h1" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Cut" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Thrust damage_type="Cut" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h2" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
+  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h2" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.54">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h3" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.57">
+  <CraftingPiece id="crpg_fine_steel_menavlion_blade_h3" name="{=kaikaikai}Swordstaff Head" tier="5" piece_type="Blade" mesh="spear_blade_18" length="70" weight="0.51">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Cut" damage_factor="2.7" />
-      <Swing damage_type="Cut" damage_factor="5.1" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
@@ -6196,11 +6196,11 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_early_halberd_blade_h0" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.51">
+  <CraftingPiece id="crpg_early_halberd_blade_h0" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.48">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6210,11 +6210,11 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_early_halberd_blade_h1" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.51">
+  <CraftingPiece id="crpg_early_halberd_blade_h1" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.45">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -6224,25 +6224,25 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_early_halberd_blade_h2" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.51">
+  <CraftingPiece id="crpg_early_halberd_blade_h2" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.45">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
+    </Flags>
+    <Materials>
+      <Material id="Iron5" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_early_halberd_blade_h3" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.45">
+    <BuildData piece_offset="-8" />
+    <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Cut" damage_factor="4.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="BonusAgainstShield" />
-    </Flags>
-    <Materials>
-      <Material id="Iron5" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_early_halberd_blade_h3" name="{=kaikaikai}Voulge Head" tier="4" piece_type="Blade" mesh="axe_craft_10_head" distance_to_next_piece="23" distance_to_previous_piece="4" weight="0.51">
-    <BuildData piece_offset="-8" />
-    <BladeData stack_amount="2" blade_length="23.118" blade_width="18.371" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -7664,7 +7664,18 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.55" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h0" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Swing damage_type="Cut" damage_factor="4.4" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanHook" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_billhook_blade_h1" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.52" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
@@ -7675,9 +7686,9 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h1" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.55" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h2" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.48" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -7686,20 +7697,9 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h2" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.55" excluded_item_usage_features="shield:thrust">
+  <CraftingPiece id="crpg_billhook_blade_h3" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.45" excluded_item_usage_features="shield:thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanHook" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_billhook_blade_h3" name="{=kaikaikai}Bill Head" tier="2" piece_type="Blade" mesh="spear_blade_33" length="35.5" weight="0.51" excluded_item_usage_features="shield:thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Swing damage_type="Cut" damage_factor="5.0" />
+      <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanHook" />
@@ -26336,10 +26336,10 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade_h0" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.34">
+  <CraftingPiece id="crpg_burgundian_glaive_blade_h0" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.28">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26348,34 +26348,34 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade_h1" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.31">
+  <CraftingPiece id="crpg_burgundian_glaive_blade_h1" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.25">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_burgundian_glaive_blade_h2" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.25">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_burgundian_glaive_blade_h3" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.25">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Cut" damage_factor="4.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade_h2" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.31">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_burgundian_glaive_blade_h3" name="{=kaikaikai}Burgundian Glaive Blade" tier="3" piece_type="Blade" mesh="burgundian_glaive_head" culture="Culture.vlandia" length="56.8" weight="0.31">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26632,21 +26632,9 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.56">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.61">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Blunt" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.58">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Flags>
@@ -26656,22 +26644,34 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.53">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Blunt" damage_factor="3.1" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.52">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.61">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.4" />
       <Swing damage_type="Blunt" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.56">
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.555">
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -16306,8 +16306,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_billhook_v1_h0",
-    "baseId": "crpg_billhook_v1",
+    "id": "crpg_billhook_v2_h0",
+    "baseId": "crpg_billhook_v2",
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -16345,8 +16345,8 @@
     ]
   },
   {
-    "id": "crpg_billhook_v1_h1",
-    "baseId": "crpg_billhook_v1",
+    "id": "crpg_billhook_v2_h1",
+    "baseId": "crpg_billhook_v2",
     "name": "Billhook +1",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -16384,8 +16384,8 @@
     ]
   },
   {
-    "id": "crpg_billhook_v1_h2",
-    "baseId": "crpg_billhook_v1",
+    "id": "crpg_billhook_v2_h2",
+    "baseId": "crpg_billhook_v2",
     "name": "Billhook +2",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -16423,8 +16423,8 @@
     ]
   },
   {
-    "id": "crpg_billhook_v1_h3",
-    "baseId": "crpg_billhook_v1",
+    "id": "crpg_billhook_v2_h3",
+    "baseId": "crpg_billhook_v2",
     "name": "Billhook +3",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -22906,8 +22906,8 @@
     ]
   },
   {
-    "id": "crpg_burgundian_glaive_v1_h0",
-    "baseId": "crpg_burgundian_glaive_v1",
+    "id": "crpg_burgundian_glaive_v2_h0",
+    "baseId": "crpg_burgundian_glaive_v2",
     "name": "Burgundian Glaive",
     "culture": "Neutral",
     "type": "Polearm",
@@ -22946,8 +22946,8 @@
     ]
   },
   {
-    "id": "crpg_burgundian_glaive_v1_h1",
-    "baseId": "crpg_burgundian_glaive_v1",
+    "id": "crpg_burgundian_glaive_v2_h1",
+    "baseId": "crpg_burgundian_glaive_v2",
     "name": "Burgundian Glaive +1",
     "culture": "Neutral",
     "type": "Polearm",
@@ -22986,8 +22986,8 @@
     ]
   },
   {
-    "id": "crpg_burgundian_glaive_v1_h2",
-    "baseId": "crpg_burgundian_glaive_v1",
+    "id": "crpg_burgundian_glaive_v2_h2",
+    "baseId": "crpg_burgundian_glaive_v2",
     "name": "Burgundian Glaive +2",
     "culture": "Neutral",
     "type": "Polearm",
@@ -23026,8 +23026,8 @@
     ]
   },
   {
-    "id": "crpg_burgundian_glaive_v1_h3",
-    "baseId": "crpg_burgundian_glaive_v1",
+    "id": "crpg_burgundian_glaive_v2_h3",
+    "baseId": "crpg_burgundian_glaive_v2",
     "name": "Burgundian Glaive +3",
     "culture": "Neutral",
     "type": "Polearm",
@@ -36366,8 +36366,8 @@
     ]
   },
   {
-    "id": "crpg_early_halberd_v1_h0",
-    "baseId": "crpg_early_halberd_v1",
+    "id": "crpg_early_halberd_v2_h0",
+    "baseId": "crpg_early_halberd_v2",
     "name": "Early Halberd",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -36407,8 +36407,8 @@
     ]
   },
   {
-    "id": "crpg_early_halberd_v1_h1",
-    "baseId": "crpg_early_halberd_v1",
+    "id": "crpg_early_halberd_v2_h1",
+    "baseId": "crpg_early_halberd_v2",
     "name": "Early Halberd +1",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -36448,8 +36448,8 @@
     ]
   },
   {
-    "id": "crpg_early_halberd_v1_h2",
-    "baseId": "crpg_early_halberd_v1",
+    "id": "crpg_early_halberd_v2_h2",
+    "baseId": "crpg_early_halberd_v2",
     "name": "Early Halberd +2",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -36489,8 +36489,8 @@
     ]
   },
   {
-    "id": "crpg_early_halberd_v1_h3",
-    "baseId": "crpg_early_halberd_v1",
+    "id": "crpg_early_halberd_v2_h3",
+    "baseId": "crpg_early_halberd_v2",
     "name": "Early Halberd +3",
     "culture": "Vlandia",
     "type": "Polearm",
@@ -44110,8 +44110,8 @@
     ]
   },
   {
-    "id": "crpg_fine_steel_menavlion_v1_h0",
-    "baseId": "crpg_fine_steel_menavlion_v1",
+    "id": "crpg_fine_steel_menavlion_v2_h0",
+    "baseId": "crpg_fine_steel_menavlion_v2",
     "name": "Fine Steel Menavlion",
     "culture": "Empire",
     "type": "Polearm",
@@ -44148,8 +44148,8 @@
     ]
   },
   {
-    "id": "crpg_fine_steel_menavlion_v1_h1",
-    "baseId": "crpg_fine_steel_menavlion_v1",
+    "id": "crpg_fine_steel_menavlion_v2_h1",
+    "baseId": "crpg_fine_steel_menavlion_v2",
     "name": "Fine Steel Menavlion +1",
     "culture": "Empire",
     "type": "Polearm",
@@ -44186,8 +44186,8 @@
     ]
   },
   {
-    "id": "crpg_fine_steel_menavlion_v1_h2",
-    "baseId": "crpg_fine_steel_menavlion_v1",
+    "id": "crpg_fine_steel_menavlion_v2_h2",
+    "baseId": "crpg_fine_steel_menavlion_v2",
     "name": "Fine Steel Menavlion +2",
     "culture": "Empire",
     "type": "Polearm",
@@ -44224,8 +44224,8 @@
     ]
   },
   {
-    "id": "crpg_fine_steel_menavlion_v1_h3",
-    "baseId": "crpg_fine_steel_menavlion_v1",
+    "id": "crpg_fine_steel_menavlion_v2_h3",
+    "baseId": "crpg_fine_steel_menavlion_v2",
     "name": "Fine Steel Menavlion +3",
     "culture": "Empire",
     "type": "Polearm",
@@ -79430,8 +79430,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_long_glaive_v1_h0",
-    "baseId": "crpg_long_glaive_v1",
+    "id": "crpg_long_glaive_v2_h0",
+    "baseId": "crpg_long_glaive_v2",
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
@@ -79468,8 +79468,8 @@
     ]
   },
   {
-    "id": "crpg_long_glaive_v1_h1",
-    "baseId": "crpg_long_glaive_v1",
+    "id": "crpg_long_glaive_v2_h1",
+    "baseId": "crpg_long_glaive_v2",
     "name": "Long Glaive +1",
     "culture": "Khuzait",
     "type": "Polearm",
@@ -79506,8 +79506,8 @@
     ]
   },
   {
-    "id": "crpg_long_glaive_v1_h2",
-    "baseId": "crpg_long_glaive_v1",
+    "id": "crpg_long_glaive_v2_h2",
+    "baseId": "crpg_long_glaive_v2",
     "name": "Long Glaive +2",
     "culture": "Khuzait",
     "type": "Polearm",
@@ -79544,8 +79544,8 @@
     ]
   },
   {
-    "id": "crpg_long_glaive_v1_h3",
-    "baseId": "crpg_long_glaive_v1",
+    "id": "crpg_long_glaive_v2_h3",
+    "baseId": "crpg_long_glaive_v2",
     "name": "Long Glaive +3",
     "culture": "Khuzait",
     "type": "Polearm",
@@ -108156,8 +108156,8 @@
     ]
   },
   {
-    "id": "crpg_polesword_h0",
-    "baseId": "crpg_polesword",
+    "id": "crpg_polesword_v1_h0",
+    "baseId": "crpg_polesword_v1",
     "name": "Polesword",
     "culture": "Aserai",
     "type": "Polearm",
@@ -108194,8 +108194,8 @@
     ]
   },
   {
-    "id": "crpg_polesword_h1",
-    "baseId": "crpg_polesword",
+    "id": "crpg_polesword_v1_h1",
+    "baseId": "crpg_polesword_v1",
     "name": "Polesword +1",
     "culture": "Aserai",
     "type": "Polearm",
@@ -108232,8 +108232,8 @@
     ]
   },
   {
-    "id": "crpg_polesword_h2",
-    "baseId": "crpg_polesword",
+    "id": "crpg_polesword_v1_h2",
+    "baseId": "crpg_polesword_v1",
     "name": "Polesword +2",
     "culture": "Aserai",
     "type": "Polearm",
@@ -108270,8 +108270,8 @@
     ]
   },
   {
-    "id": "crpg_polesword_h3",
-    "baseId": "crpg_polesword",
+    "id": "crpg_polesword_v1_h3",
+    "baseId": "crpg_polesword_v1",
     "name": "Polesword +3",
     "culture": "Aserai",
     "type": "Polearm",
@@ -125722,8 +125722,8 @@
     ]
   },
   {
-    "id": "crpg_spiked_polehammer_v1_h0",
-    "baseId": "crpg_spiked_polehammer_v1",
+    "id": "crpg_spiked_polehammer_v2_h0",
+    "baseId": "crpg_spiked_polehammer_v2",
     "name": "Spiked Polehammer",
     "culture": "Neutral",
     "type": "Polearm",
@@ -125762,8 +125762,8 @@
     ]
   },
   {
-    "id": "crpg_spiked_polehammer_v1_h1",
-    "baseId": "crpg_spiked_polehammer_v1",
+    "id": "crpg_spiked_polehammer_v2_h1",
+    "baseId": "crpg_spiked_polehammer_v2",
     "name": "Spiked Polehammer +1",
     "culture": "Neutral",
     "type": "Polearm",
@@ -125802,8 +125802,8 @@
     ]
   },
   {
-    "id": "crpg_spiked_polehammer_v1_h2",
-    "baseId": "crpg_spiked_polehammer_v1",
+    "id": "crpg_spiked_polehammer_v2_h2",
+    "baseId": "crpg_spiked_polehammer_v2",
     "name": "Spiked Polehammer +2",
     "culture": "Neutral",
     "type": "Polearm",
@@ -125842,8 +125842,8 @@
     ]
   },
   {
-    "id": "crpg_spiked_polehammer_v1_h3",
-    "baseId": "crpg_spiked_polehammer_v1",
+    "id": "crpg_spiked_polehammer_v2_h3",
+    "baseId": "crpg_spiked_polehammer_v2",
     "name": "Spiked Polehammer +3",
     "culture": "Neutral",
     "type": "Polearm",
@@ -146936,8 +146936,8 @@
     ]
   },
   {
-    "id": "crpg_warrazor_v1_h0",
-    "baseId": "crpg_warrazor_v1",
+    "id": "crpg_warrazor_v2_h0",
+    "baseId": "crpg_warrazor_v2",
     "name": "Warrazor",
     "culture": "Sturgia",
     "type": "Polearm",
@@ -146997,8 +146997,8 @@
     ]
   },
   {
-    "id": "crpg_warrazor_v1_h1",
-    "baseId": "crpg_warrazor_v1",
+    "id": "crpg_warrazor_v2_h1",
+    "baseId": "crpg_warrazor_v2",
     "name": "Warrazor +1",
     "culture": "Sturgia",
     "type": "Polearm",
@@ -147058,8 +147058,8 @@
     ]
   },
   {
-    "id": "crpg_warrazor_v1_h2",
-    "baseId": "crpg_warrazor_v1",
+    "id": "crpg_warrazor_v2_h2",
+    "baseId": "crpg_warrazor_v2",
     "name": "Warrazor +2",
     "culture": "Sturgia",
     "type": "Polearm",
@@ -147119,8 +147119,8 @@
     ]
   },
   {
-    "id": "crpg_warrazor_v1_h3",
-    "baseId": "crpg_warrazor_v1",
+    "id": "crpg_warrazor_v2_h3",
+    "baseId": "crpg_warrazor_v2",
     "name": "Warrazor +3",
     "culture": "Sturgia",
     "type": "Polearm",

--- a/items.json
+++ b/items.json
@@ -16311,127 +16311,10 @@
     "name": "Billhook",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 13744,
-    "weight": 2.05,
+    "price": 12544,
+    "weight": 2.01,
     "rank": 0,
-    "tier": 9.898451,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 141,
-        "balance": 0.33,
-        "handling": 67,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount",
-          "MissileWithPhysics"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 46,
-        "swingDamageType": "Cut",
-        "swingSpeed": 79
-      }
-    ]
-  },
-  {
-    "id": "crpg_billhook_v1_h1",
-    "baseId": "crpg_billhook_v1",
-    "name": "Billhook +1",
-    "culture": "Vlandia",
-    "type": "Polearm",
-    "price": 13557,
-    "weight": 2.05,
-    "rank": 1,
-    "tier": 9.823371,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 141,
-        "balance": 0.33,
-        "handling": 67,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount",
-          "MissileWithPhysics"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 48,
-        "swingDamageType": "Cut",
-        "swingSpeed": 79
-      }
-    ]
-  },
-  {
-    "id": "crpg_billhook_v1_h2",
-    "baseId": "crpg_billhook_v1",
-    "name": "Billhook +2",
-    "culture": "Vlandia",
-    "type": "Polearm",
-    "price": 13594,
-    "weight": 2.05,
-    "rank": 2,
-    "tier": 9.838236,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 141,
-        "balance": 0.33,
-        "handling": 67,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount",
-          "MissileWithPhysics"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 92,
-        "swingDamage": 50,
-        "swingDamageType": "Cut",
-        "swingSpeed": 79
-      }
-    ]
-  },
-  {
-    "id": "crpg_billhook_v1_h3",
-    "baseId": "crpg_billhook_v1",
-    "name": "Billhook +3",
-    "culture": "Vlandia",
-    "type": "Polearm",
-    "price": 13119,
-    "weight": 1.99,
-    "rank": 3,
-    "tier": 9.645723,
+    "tier": 9.407991,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -16455,9 +16338,126 @@
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
         "thrustSpeed": 92,
-        "swingDamage": 50,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
         "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_billhook_v1_h1",
+    "baseId": "crpg_billhook_v1",
+    "name": "Billhook +1",
+    "culture": "Vlandia",
+    "type": "Polearm",
+    "price": 12555,
+    "weight": 2.01,
+    "rank": 1,
+    "tier": 9.412906,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 141,
+        "balance": 0.36,
+        "handling": 68,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount",
+          "MissileWithPhysics"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 92,
+        "swingDamage": 46,
+        "swingDamageType": "Cut",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_billhook_v1_h2",
+    "baseId": "crpg_billhook_v1",
+    "name": "Billhook +2",
+    "culture": "Vlandia",
+    "type": "Polearm",
+    "price": 13198,
+    "weight": 1.95,
+    "rank": 2,
+    "tier": 9.677983,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 141,
+        "balance": 0.39,
+        "handling": 68,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount",
+          "MissileWithPhysics"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 93,
+        "swingDamage": 47,
+        "swingDamageType": "Cut",
+        "swingSpeed": 81
+      }
+    ]
+  },
+  {
+    "id": "crpg_billhook_v1_h3",
+    "baseId": "crpg_billhook_v1",
+    "name": "Billhook +3",
+    "culture": "Vlandia",
+    "type": "Polearm",
+    "price": 12665,
+    "weight": 1.91,
+    "rank": 3,
+    "tier": 9.458773,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 141,
+        "balance": 0.42,
+        "handling": 69,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount",
+          "MissileWithPhysics"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 93,
+        "swingDamage": 47,
+        "swingDamageType": "Cut",
+        "swingSpeed": 82
       }
     ]
   },
@@ -22911,10 +22911,10 @@
     "name": "Burgundian Glaive",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 11749,
-    "weight": 1.84,
+    "price": 11287,
+    "weight": 1.78,
     "rank": 0,
-    "tier": 9.070358,
+    "tier": 8.868867,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -22927,8 +22927,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.14,
-        "handling": 63,
+        "balance": 0.21,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -22936,12 +22936,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 45,
+        "thrustSpeed": 93,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 76
       }
     ]
   },
@@ -22951,10 +22951,10 @@
     "name": "Burgundian Glaive +1",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12635,
-    "weight": 1.81,
+    "price": 11576,
+    "weight": 1.75,
     "rank": 1,
-    "tier": 9.446181,
+    "tier": 8.995415,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -22967,8 +22967,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.17,
-        "handling": 64,
+        "balance": 0.25,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -22976,12 +22976,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 46,
+        "thrustSpeed": 94,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 77
       }
     ]
   },
@@ -22991,10 +22991,10 @@
     "name": "Burgundian Glaive +2",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12133,
-    "weight": 1.81,
+    "price": 11140,
+    "weight": 1.75,
     "rank": 2,
-    "tier": 9.234841,
+    "tier": 8.803902,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23007,8 +23007,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.17,
-        "handling": 64,
+        "balance": 0.25,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -23016,12 +23016,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 47,
+        "thrustSpeed": 94,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 77
       }
     ]
   },
@@ -23031,10 +23031,10 @@
     "name": "Burgundian Glaive +3",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12173,
-    "weight": 1.81,
+    "price": 11441,
+    "weight": 1.75,
     "rank": 3,
-    "tier": 9.252068,
+    "tier": 8.936441,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -23047,8 +23047,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 189,
-        "balance": 0.17,
-        "handling": 64,
+        "balance": 0.25,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -23056,12 +23056,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 49,
+        "thrustSpeed": 94,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 77
       }
     ]
   },
@@ -36371,10 +36371,10 @@
     "name": "Early Halberd",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 13984,
-    "weight": 1.53,
+    "price": 13082,
+    "weight": 1.5,
     "rank": 0,
-    "tier": 9.994027,
+    "tier": 9.630879,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -36387,8 +36387,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.33,
-        "handling": 64,
+        "balance": 0.36,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -36397,12 +36397,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 43,
+        "thrustSpeed": 95,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 80
       }
     ]
   },
@@ -36412,10 +36412,10 @@
     "name": "Early Halberd +1",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 13689,
-    "weight": 1.53,
+    "price": 12947,
+    "weight": 1.47,
     "rank": 1,
-    "tier": 9.876236,
+    "tier": 9.575415,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -36428,8 +36428,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.33,
-        "handling": 64,
+        "balance": 0.38,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -36438,12 +36438,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 45,
+        "thrustSpeed": 96,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -36453,10 +36453,10 @@
     "name": "Early Halberd +2",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 13103,
-    "weight": 1.53,
+    "price": 13225,
+    "weight": 1.47,
     "rank": 2,
-    "tier": 9.639451,
+    "tier": 9.688914,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -36469,8 +36469,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.33,
-        "handling": 64,
+        "balance": 0.38,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -36479,12 +36479,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 46,
+        "thrustSpeed": 96,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -36494,10 +36494,10 @@
     "name": "Early Halberd +3",
     "culture": "Vlandia",
     "type": "Polearm",
-    "price": 13202,
-    "weight": 1.53,
+    "price": 13676,
+    "weight": 1.47,
     "rank": 3,
-    "tier": 9.679608,
+    "tier": 9.8712635,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -36510,8 +36510,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 142,
-        "balance": 0.33,
-        "handling": 64,
+        "balance": 0.38,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -36520,12 +36520,12 @@
           "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 26,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 48,
+        "thrustSpeed": 96,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -44115,48 +44115,10 @@
     "name": "Fine Steel Menavlion",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 10414,
-    "weight": 1.29,
-    "rank": 0,
-    "tier": 8.476524,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 201,
-        "balance": 0.06,
-        "handling": 62,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 25,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 96,
-        "swingDamage": 47,
-        "swingDamageType": "Cut",
-        "swingSpeed": 71
-      }
-    ]
-  },
-  {
-    "id": "crpg_fine_steel_menavlion_v1_h1",
-    "baseId": "crpg_fine_steel_menavlion_v1",
-    "name": "Fine Steel Menavlion +1",
-    "culture": "Empire",
-    "type": "Polearm",
-    "price": 11103,
+    "price": 9947,
     "weight": 1.26,
-    "rank": 1,
-    "tier": 8.787595,
+    "rank": 0,
+    "tier": 8.260043,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44179,7 +44141,45 @@
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
         "thrustSpeed": 96,
-        "swingDamage": 48,
+        "swingDamage": 45,
+        "swingDamageType": "Cut",
+        "swingSpeed": 72
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_steel_menavlion_v1_h1",
+    "baseId": "crpg_fine_steel_menavlion_v1",
+    "name": "Fine Steel Menavlion +1",
+    "culture": "Empire",
+    "type": "Polearm",
+    "price": 10143,
+    "weight": 1.26,
+    "rank": 1,
+    "tier": 8.351628,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 201,
+        "balance": 0.09,
+        "handling": 63,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 26,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 96,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
         "swingSpeed": 72
       }
@@ -44191,10 +44191,10 @@
     "name": "Fine Steel Menavlion +2",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 10515,
-    "weight": 1.26,
+    "price": 10235,
+    "weight": 1.22,
     "rank": 2,
-    "tier": 8.52296,
+    "tier": 8.39411,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44205,8 +44205,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 201,
-        "balance": 0.09,
-        "handling": 63,
+        "balance": 0.12,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -44216,10 +44216,10 @@
         ],
         "thrustDamage": 27,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 96,
-        "swingDamage": 49,
+        "thrustSpeed": 97,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 72
+        "swingSpeed": 73
       }
     ]
   },
@@ -44229,10 +44229,10 @@
     "name": "Fine Steel Menavlion +3",
     "culture": "Empire",
     "type": "Polearm",
-    "price": 10401,
-    "weight": 1.26,
+    "price": 9910,
+    "weight": 1.19,
     "rank": 3,
-    "tier": 8.470777,
+    "tier": 8.242941,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -44243,8 +44243,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 201,
-        "balance": 0.09,
-        "handling": 63,
+        "balance": 0.16,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -44254,10 +44254,10 @@
         ],
         "thrustDamage": 27,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 96,
-        "swingDamage": 51,
+        "thrustSpeed": 98,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 72
+        "swingSpeed": 74
       }
     ]
   },
@@ -79435,10 +79435,10 @@
     "name": "Long Glaive",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 11813,
-    "weight": 1.44,
+    "price": 10520,
+    "weight": 1.41,
     "rank": 0,
-    "tier": 9.098196,
+    "tier": 8.525251,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79449,7 +79449,7 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.12,
+        "balance": 0.15,
         "handling": 63,
         "bodyArmor": 0,
         "flags": [
@@ -79460,10 +79460,10 @@
         ],
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
-        "thrustSpeed": 95,
-        "swingDamage": 45,
+        "thrustSpeed": 96,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 73
+        "swingSpeed": 74
       }
     ]
   },
@@ -79473,10 +79473,10 @@
     "name": "Long Glaive +1",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 12004,
-    "weight": 1.41,
+    "price": 11267,
+    "weight": 1.38,
     "rank": 1,
-    "tier": 9.179739,
+    "tier": 8.86012,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79487,8 +79487,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.15,
-        "handling": 63,
+        "balance": 0.19,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -79499,9 +79499,9 @@
         "thrustDamage": 25,
         "thrustDamageType": "Cut",
         "thrustSpeed": 96,
-        "swingDamage": 46,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 75
       }
     ]
   },
@@ -79511,10 +79511,10 @@
     "name": "Long Glaive +2",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 11402,
-    "weight": 1.41,
+    "price": 10809,
+    "weight": 1.38,
     "rank": 2,
-    "tier": 8.919378,
+    "tier": 8.656079,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79525,8 +79525,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.15,
-        "handling": 63,
+        "balance": 0.19,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -79537,9 +79537,9 @@
         "thrustDamage": 27,
         "thrustDamageType": "Cut",
         "thrustSpeed": 96,
-        "swingDamage": 47,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 75
       }
     ]
   },
@@ -79549,10 +79549,10 @@
     "name": "Long Glaive +3",
     "culture": "Khuzait",
     "type": "Polearm",
-    "price": 11420,
-    "weight": 1.41,
+    "price": 10995,
+    "weight": 1.35,
     "rank": 3,
-    "tier": 8.927241,
+    "tier": 8.739561,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -79563,8 +79563,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 200,
-        "balance": 0.15,
-        "handling": 63,
+        "balance": 0.22,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -79572,12 +79572,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 27,
+        "thrustDamage": 28,
         "thrustDamageType": "Cut",
         "thrustSpeed": 96,
-        "swingDamage": 49,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 74
+        "swingSpeed": 76
       }
     ]
   },
@@ -108161,10 +108161,10 @@
     "name": "Polesword",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 6155,
-    "weight": 1.75,
+    "price": 6827,
+    "weight": 1.66,
     "rank": 0,
-    "tier": 6.2726984,
+    "tier": 6.6617074,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -108176,7 +108176,7 @@
         "stackAmount": 0,
         "length": 246,
         "balance": 0.0,
-        "handling": 61,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -108186,10 +108186,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 48,
+        "thrustSpeed": 94,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 65
+        "swingSpeed": 67
       }
     ]
   },
@@ -108199,10 +108199,10 @@
     "name": "Polesword +1",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 6589,
-    "weight": 1.7,
+    "price": 6326,
+    "weight": 1.62,
     "rank": 1,
-    "tier": 6.525843,
+    "tier": 6.37343073,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -108214,7 +108214,7 @@
         "stackAmount": 0,
         "length": 246,
         "balance": 0.0,
-        "handling": 62,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -108224,10 +108224,10 @@
         ],
         "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 49,
+        "thrustSpeed": 94,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 66
+        "swingSpeed": 68
       }
     ]
   },
@@ -108237,10 +108237,10 @@
     "name": "Polesword +2",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 6651,
-    "weight": 1.7,
+    "price": 6787,
+    "weight": 1.62,
     "rank": 2,
-    "tier": 6.561812,
+    "tier": 6.63922358,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -108252,7 +108252,7 @@
         "stackAmount": 0,
         "length": 246,
         "balance": 0.0,
-        "handling": 62,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -108260,12 +108260,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 50,
+        "thrustSpeed": 94,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 66
+        "swingSpeed": 68
       }
     ]
   },
@@ -108275,10 +108275,10 @@
     "name": "Polesword +3",
     "culture": "Aserai",
     "type": "Polearm",
-    "price": 6475,
-    "weight": 1.7,
+    "price": 6754,
+    "weight": 1.62,
     "rank": 3,
-    "tier": 6.46022558,
+    "tier": 6.62003565,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -108290,7 +108290,7 @@
         "stackAmount": 0,
         "length": 246,
         "balance": 0.0,
-        "handling": 62,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -108298,12 +108298,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 52,
+        "thrustSpeed": 94,
+        "swingDamage": 49,
         "swingDamageType": "Cut",
-        "swingSpeed": 66
+        "swingSpeed": 68
       }
     ]
   },
@@ -125727,10 +125727,90 @@
     "name": "Spiked Polehammer",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 12505,
-    "weight": 2.06,
+    "price": 12259,
+    "weight": 2.11,
     "rank": 0,
-    "tier": 9.391907,
+    "tier": 9.288145,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 148,
+        "balance": 0.1,
+        "handling": 64,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 22,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 31,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      }
+    ]
+  },
+  {
+    "id": "crpg_spiked_polehammer_v1_h1",
+    "baseId": "crpg_spiked_polehammer_v1",
+    "name": "Spiked Polehammer +1",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 12057,
+    "weight": 2.11,
+    "rank": 1,
+    "tier": 9.202384,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 148,
+        "balance": 0.1,
+        "handling": 64,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 24,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 32,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      }
+    ]
+  },
+  {
+    "id": "crpg_spiked_polehammer_v1_h2",
+    "baseId": "crpg_spiked_polehammer_v1",
+    "name": "Spiked Polehammer +2",
+    "culture": "Neutral",
+    "type": "Polearm",
+    "price": 11995,
+    "weight": 2.06,
+    "rank": 2,
+    "tier": 9.176242,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -125752,92 +125832,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 91,
-        "swingDamage": 30,
+        "swingDamage": 32,
         "swingDamageType": "Blunt",
         "swingSpeed": 74
-      }
-    ]
-  },
-  {
-    "id": "crpg_spiked_polehammer_v1_h1",
-    "baseId": "crpg_spiked_polehammer_v1",
-    "name": "Spiked Polehammer +1",
-    "culture": "Neutral",
-    "type": "Polearm",
-    "price": 12399,
-    "weight": 2.08,
-    "rank": 1,
-    "tier": 9.347505,
-    "requirement": 0,
-    "flags": [
-      "CanBePickedUpFromCorpse"
-    ],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 148,
-        "balance": 0.13,
-        "handling": 65,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 24,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 31,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 74
-      }
-    ]
-  },
-  {
-    "id": "crpg_spiked_polehammer_v1_h2",
-    "baseId": "crpg_spiked_polehammer_v1",
-    "name": "Spiked Polehammer +2",
-    "culture": "Neutral",
-    "type": "Polearm",
-    "price": 11717,
-    "weight": 2.03,
-    "rank": 2,
-    "tier": 9.056646,
-    "requirement": 0,
-    "flags": [
-      "CanBePickedUpFromCorpse"
-    ],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 148,
-        "balance": 0.19,
-        "handling": 66,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 24,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 31,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 75
       }
     ]
   },
@@ -125847,10 +125847,10 @@
     "name": "Spiked Polehammer +3",
     "culture": "Neutral",
     "type": "Polearm",
-    "price": 11625,
-    "weight": 2.02,
+    "price": 11797,
+    "weight": 2.06,
     "rank": 3,
-    "tier": 9.01680851,
+    "tier": 9.091233,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -125863,8 +125863,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 148,
-        "balance": 0.2,
-        "handling": 67,
+        "balance": 0.16,
+        "handling": 66,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -125872,12 +125872,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 32,
+        "thrustSpeed": 91,
+        "swingDamage": 33,
         "swingDamageType": "Blunt",
-        "swingSpeed": 75
+        "swingSpeed": 74
       }
     ]
   },
@@ -146941,10 +146941,10 @@
     "name": "Warrazor",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 11220,
-    "weight": 1.23,
+    "price": 11192,
+    "weight": 1.19,
     "rank": 0,
-    "tier": 8.839445,
+    "tier": 8.827055,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -146955,8 +146955,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.17,
-        "handling": 62,
+        "balance": 0.21,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -146964,12 +146964,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 45,
+        "thrustSpeed": 97,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 76
       },
       {
         "class": "TwoHandedPolearm",
@@ -146978,8 +146978,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.17,
-        "handling": 62,
+        "balance": 0.21,
+        "handling": 63,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -146987,12 +146987,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 45,
+        "thrustSpeed": 97,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 76
       }
     ]
   },
@@ -147002,10 +147002,10 @@
     "name": "Warrazor +1",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 11574,
-    "weight": 1.2,
+    "price": 11633,
+    "weight": 1.16,
     "rank": 1,
-    "tier": 8.994566,
+    "tier": 9.020154,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -147016,8 +147016,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.19,
-        "handling": 63,
+        "balance": 0.23,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147025,12 +147025,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 76
       },
       {
         "class": "TwoHandedPolearm",
@@ -147039,8 +147039,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.19,
-        "handling": 63,
+        "balance": 0.23,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147048,12 +147048,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 75
+        "swingSpeed": 76
       }
     ]
   },
@@ -147063,10 +147063,10 @@
     "name": "Warrazor +2",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 11548,
-    "weight": 1.17,
+    "price": 11796,
+    "weight": 1.13,
     "rank": 2,
-    "tier": 8.983329,
+    "tier": 9.09068,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -147077,8 +147077,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.22,
-        "handling": 63,
+        "balance": 0.25,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147086,12 +147086,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 77
       },
       {
         "class": "TwoHandedPolearm",
@@ -147100,8 +147100,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.22,
-        "handling": 63,
+        "balance": 0.25,
+        "handling": 64,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147109,12 +147109,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 47,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 77
       }
     ]
   },
@@ -147124,10 +147124,10 @@
     "name": "Warrazor +3",
     "culture": "Sturgia",
     "type": "Polearm",
-    "price": 11592,
-    "weight": 1.17,
+    "price": 11200,
+    "weight": 1.09,
     "rank": 3,
-    "tier": 9.002591,
+    "tier": 8.830637,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -147138,8 +147138,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.22,
-        "handling": 63,
+        "balance": 0.29,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147147,12 +147147,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 49,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 78
       },
       {
         "class": "TwoHandedPolearm",
@@ -147161,8 +147161,8 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 178,
-        "balance": 0.22,
-        "handling": 63,
+        "balance": 0.29,
+        "handling": 65,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -147170,12 +147170,12 @@
           "WideGrip",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 49,
+        "thrustSpeed": 98,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 76
+        "swingSpeed": 78
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -24,25 +24,25 @@
       <Piece id="crpg_french_voulge_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v1_h0" name="{=kaikaikai}Burgundian Glaive" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v2_h0" name="{=kaikaikai}Burgundian Glaive" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v1_h1" name="{=kaikaikai}Burgundian Glaive +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v2_h1" name="{=kaikaikai}Burgundian Glaive +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v1_h2" name="{=kaikaikai}Burgundian Glaive +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v2_h2" name="{=kaikaikai}Burgundian Glaive +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_burgundian_glaive_v1_h3" name="{=kaikaikai}Burgundian Glaive +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_burgundian_glaive_v2_h3" name="{=kaikaikai}Burgundian Glaive +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_burgundian_glaive_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_burgundian_glaive_handle_h3" Type="Handle" scale_factor="100" />
@@ -120,25 +120,25 @@
       <Piece id="crpg_bec_de_corbin_handle_h3" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v1_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v2_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v1_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v2_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v1_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v2_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v1_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v2_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h3" Type="Handle" scale_factor="100" />
@@ -8152,7 +8152,7 @@
       <Piece id="crpg_mamluke_lance_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v1_h0" name="{=kaikaikai}Long Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v2_h0" name="{=kaikaikai}Long Glaive" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h0" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h0" Type="Guard" scale_factor="97" />
@@ -8160,7 +8160,7 @@
       <Piece id="crpg_long_glaive_pommel_h0" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v1_h1" name="{=kaikaikai}Long Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v2_h1" name="{=kaikaikai}Long Glaive +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h1" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h1" Type="Guard" scale_factor="97" />
@@ -8168,7 +8168,7 @@
       <Piece id="crpg_long_glaive_pommel_h1" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v1_h2" name="{=kaikaikai}Long Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v2_h2" name="{=kaikaikai}Long Glaive +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h2" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h2" Type="Guard" scale_factor="97" />
@@ -8176,7 +8176,7 @@
       <Piece id="crpg_long_glaive_pommel_h2" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_glaive_v1_h3" name="{=kaikaikai}Long Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_glaive_v2_h3" name="{=kaikaikai}Long Glaive +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_glaive_blade_h3" Type="Blade" scale_factor="97" />
       <Piece id="crpg_long_glaive_guard_h3" Type="Guard" scale_factor="97" />
@@ -8184,7 +8184,7 @@
       <Piece id="crpg_long_glaive_pommel_h3" Type="Pommel" scale_factor="97" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v1_h0" name="{=kaikaikai}Fine Steel Menavlion" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v2_h0" name="{=kaikaikai}Fine Steel Menavlion" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h0" Type="Guard" scale_factor="100" />
@@ -8192,7 +8192,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v1_h1" name="{=kaikaikai}Fine Steel Menavlion +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v2_h1" name="{=kaikaikai}Fine Steel Menavlion +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h1" Type="Guard" scale_factor="100" />
@@ -8200,7 +8200,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v1_h2" name="{=kaikaikai}Fine Steel Menavlion +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v2_h2" name="{=kaikaikai}Fine Steel Menavlion +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h2" Type="Guard" scale_factor="100" />
@@ -8208,7 +8208,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_menavlion_v1_h3" name="{=kaikaikai}Fine Steel Menavlion +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_menavlion_v2_h3" name="{=kaikaikai}Fine Steel Menavlion +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_menavlion_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_fine_steel_menavlion_guard_h3" Type="Guard" scale_factor="100" />
@@ -8216,7 +8216,7 @@
       <Piece id="crpg_fine_steel_menavlion_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v1_h0" name="{=kaikaikai}Early Halberd" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v2_h0" name="{=kaikaikai}Early Halberd" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h0" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h0" Type="Guard" scale_factor="100" />
@@ -8224,7 +8224,7 @@
       <Piece id="crpg_early_halberd_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v1_h1" name="{=kaikaikai}Early Halberd +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v2_h1" name="{=kaikaikai}Early Halberd +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h1" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h1" Type="Guard" scale_factor="100" />
@@ -8232,7 +8232,7 @@
       <Piece id="crpg_early_halberd_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v1_h2" name="{=kaikaikai}Early Halberd +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v2_h2" name="{=kaikaikai}Early Halberd +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h2" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h2" Type="Guard" scale_factor="100" />
@@ -8240,7 +8240,7 @@
       <Piece id="crpg_early_halberd_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_early_halberd_v1_h3" name="{=kaikaikai}Early Halberd +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_early_halberd_v2_h3" name="{=kaikaikai}Early Halberd +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_early_halberd_blade_h3" Type="Blade" scale_factor="99" />
       <Piece id="crpg_early_halberd_guard_h3" Type="Guard" scale_factor="100" />
@@ -8280,7 +8280,7 @@
       <Piece id="crpg_rhomphaia_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_polesword_h0" name="{=kaikaikai}Polesword" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_polesword_v1_h0" name="{=kaikaikai}Polesword" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_polesword_blade_h0" Type="Blade" scale_factor="150" />
       <Piece id="crpg_polesword_guard_h0" Type="Guard" scale_factor="100" />
@@ -8288,7 +8288,7 @@
       <Piece id="crpg_polesword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_polesword_h1" name="{=kaikaikai}Polesword +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_polesword_v1_h1" name="{=kaikaikai}Polesword +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_polesword_blade_h1" Type="Blade" scale_factor="150" />
       <Piece id="crpg_polesword_guard_h1" Type="Guard" scale_factor="100" />
@@ -8296,7 +8296,7 @@
       <Piece id="crpg_polesword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_polesword_h2" name="{=kaikaikai}Polesword +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_polesword_v1_h2" name="{=kaikaikai}Polesword +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_polesword_blade_h2" Type="Blade" scale_factor="150" />
       <Piece id="crpg_polesword_guard_h2" Type="Guard" scale_factor="100" />
@@ -8304,7 +8304,7 @@
       <Piece id="crpg_polesword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_polesword_h3" name="{=kaikaikai}Polesword +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_polesword_v1_h3" name="{=kaikaikai}Polesword +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_polesword_blade_h3" Type="Blade" scale_factor="150" />
       <Piece id="crpg_polesword_guard_h3" Type="Guard" scale_factor="100" />
@@ -8376,7 +8376,7 @@
       <Piece id="crpg_menavlion_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v1_h0" name="{=kaikaikai}Warrazor" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v2_h0" name="{=kaikaikai}Warrazor" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h0" Type="Guard" scale_factor="100" />
@@ -8384,7 +8384,7 @@
       <Piece id="crpg_warrazor_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v1_h1" name="{=kaikaikai}Warrazor +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v2_h1" name="{=kaikaikai}Warrazor +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h1" Type="Guard" scale_factor="100" />
@@ -8392,7 +8392,7 @@
       <Piece id="crpg_warrazor_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v1_h2" name="{=kaikaikai}Warrazor +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v2_h2" name="{=kaikaikai}Warrazor +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h2" Type="Guard" scale_factor="100" />
@@ -8400,7 +8400,7 @@
       <Piece id="crpg_warrazor_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warrazor_v1_h3" name="{=kaikaikai}Warrazor +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_warrazor_v2_h3" name="{=kaikaikai}Warrazor +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_warrazor_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_warrazor_guard_h3" Type="Guard" scale_factor="100" />
@@ -8408,7 +8408,7 @@
       <Piece id="crpg_warrazor_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v1_h0" name="{=kaikaikai}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v2_h0" name="{=kaikaikai}Billhook" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_billhook_guard_h0" Type="Guard" scale_factor="100" />
@@ -8416,7 +8416,7 @@
       <Piece id="crpg_billhook_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v1_h1" name="{=kaikaikai}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v2_h1" name="{=kaikaikai}Billhook +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_billhook_guard_h1" Type="Guard" scale_factor="100" />
@@ -8424,7 +8424,7 @@
       <Piece id="crpg_billhook_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v1_h2" name="{=kaikaikai}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v2_h2" name="{=kaikaikai}Billhook +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_billhook_guard_h2" Type="Guard" scale_factor="100" />
@@ -8432,7 +8432,7 @@
       <Piece id="crpg_billhook_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_billhook_v1_h3" name="{=kaikaikai}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_billhook_v2_h3" name="{=kaikaikai}Billhook +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_billhook_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_billhook_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
The main objective of the four-directional polearm adjustment is to modify the panel attribute data of individual polearms that are of normal length (around 140) and some that are excessively long (over 170). This adjustment aims to reduce the swing damage while providing compensation in terms of swing speed (some received thrust damage and speed adjustments as well). All weapons will have some differences in their adjusted tiers, but the differences will not be significant. If these weapons do not receive a slight power level decrease in game after this update goes live, there will be a budget allocated for a minor decrease in the 4d polearm. All adjusted weapons have been refunded.

Billhook h0
- swing damage from 46 to 44 
- swing speed from 79 to 80
- weight from 2.05 to 2.01 
- handling from 67 to 68

Billhook h1
- swing damage from 48 to 46
- swing speed from 79 to 80
- weight from 2.05 to 2.01 
- handling from 67 to 68

Billhook h2
- swing damage from 50 to 47
- swing speed from 79 to 81
- weight from 2.05 to 1.95
- handling from 67 to 68

Billhook h3
- swing damage from 50 to 47
- swing speed from 80 to 82
- weight from 1.99 to 1.91
- handling from 68 to 69

Burgundian Glaive h0
- swing damage from 45 to 42
- swing speed from 74 to 76
- thrust damage from 21 to 20
- thrust speed from 92 to 93
- weight from 1.84 to 1.78
- handling from 63 to 65


Burgundian Glaive h1
- swing damage from 46 to 43
- swing speed from 75 to 77
- thrust damage from 21 to 20
- thrust speed from 93 to 94
- weight from 1.81 to 1.75
- handling from 64 to 65

Burgundian Glaive h2
- swing damage from 47 to 44
- swing speed from 75 to 77
- thrust damage from 23 to 22
- thrust speed from 93 to 94
- weight from 1.81 to 1.75
- handling from 64 to 65

Burgundian Glaive h3
- swing damage from 49 to 46
- swing speed from 75 to 77
- thrust damage from 23 to 22
- thrust speed from 93 to 94
- weight from 1.81 to 1.75
- handling from 64 to 65

Early Halberd h0
- swing damage from 43 to 42
- swing speed from 79 to 80
- thrust damage from 24 to 21
- thrust speed from 94 to 95
- weight from 1.53 to 1.5
- handling from 64 to 65

Early Halberd h1
- swing damage from 45 to 42
- swing speed from 79 to 81
- thrust damage from 24 to 23
- thrust speed from 94 to 96
- weight from 1.53 to 1.47
- handling from 64 to 66

Early Halberd h2
- swing damage from 46 to 44
- swing speed from 79 to 81
- thrust damage from 26 to 23
- thrust speed from 94 to 96
- weight from 1.53 to 1.47
- handling from 64 to 66

Early Halberd h3
- swing damage from 48 to 46
- swing speed from 79 to 81
- thrust damage from 26 to 23
- thrust speed from 94 to 96
- weight from 1.53 to 1.47
- handling from 64 to 66

Fine Steel Menavlion h0
- swing damage from 47 to 45
- swing speed from 71 to 72
- weight from 1.29 to 1.26
- handling from 62 to 63

Fine Steel Menavlion h1
- swing damage from 48 to 47
- swing damage from 25 to 26

Fine Steel Menavlion h2
- swing damage from 49 to 47
- swing speed from 72 to 73
- weight from 1.26 to 1.22
- handling from 63 to 64

Fine Steel Menavlion h3
- swing damage from 51 to 47
- swing speed from 72 to 74
- weight from 1.26 to 1.19
- handling from 63 to 65

Long Glaive h0
- swing damage from 45 to 43
- swing speed from 73 to 74
- thrust speed from 95 to 96
- weight from 1.44 to 1.41

Long Glaive h1
- swing damage from 46 to 44
- swing speed from 74 to 75
- weight from 1.41 to 1.38
- handling from 63 to 64

Long Glaive h2
- swing damage from 47 to 45
- swing speed from 74 to 75
- weight from 1.41 to 1.38
- handling from 63 to 64

Long Glaive h3
- swing damage from 49 to 45
- swing speed from 74to 76
- thrust damage from 27 to 28
- weight from 1.41 to 1.35
- handling from 63 to 65

Polesword h0
- swing damage from 48 to 45
- swing speed from 65 to 67
- thrust speed from 93 to 94
- weight from 1.75 to 1.66
- handling from 61 to 63

Polesword h1
- swing damage from 49 to 45
- swing speed from 66 to 68
- thrust speed from 93 to 94
- weight from 1.7 to 1.62
- handling from 62 to 64

Polesword h2
- swing damage from 50 to 47
- swing speed from 66 to 68
- thrust damage from 22 to 21
- thrust speed from 93 to 94
- weight from 1.7 to 1.62
- handling from 62 to 64

Polesword h3
- swing damage from 52 to 49
- swing speed from 66 to 68
- thrust damage from 22 to 21
- thrust speed from 93 to 94
- weight from 1.7 to 1.62
- handling from 62 to 64

Spiked Polehammer h0
- swing damage from 30 to 31
- swing speed from 74 to 73
- weight from 2.06 to 2.11
- handling from 65 to 64

Spiked Polehammer h1
- swing damage from 31 to 32
- swing speed from 74 to 73
- weight from 2.08 to 2.11
- handling from 65 to 64

Spiked Polehammer h2
- swing damage from 31 to 32
- swing speed from 75 to 74
- thrust damage from 24 to 25
- thrust speed from 92 to 91
- weight from 2.03 to 2.06
- handling from 66 to 65

Spiked Polehammer h3
- swing damage from 32 to 33
- swing speed from 75 to 74
- thrust damage from 24 to 25
- thrust speed from 92 to 91
- weight from 2.02 to 2.06
- handling from 67 to 66

Warrazor h0
- swing damage from 45 to 43
- swing speed from 75 to 76
- thrust damage from 21 to 22
- thrust speed from 96 to 97
- weight from 1.23 to 1.19
- handling from 62 to 63

Warrazor h1
- swing damage from 47 to 45
- swing speed from 75 to 76
- thrust damage from 21 to 22
- thrust speed from 97 to 98
- weight from 1.2 to 1.16
- handling from 63 to 64

Warrazor h2
- swing damage from 47 to 45
- swing speed from 76 to 77
- thrust damage from 23 to 24
- thrust speed from 97 to 98
- weight from 1.17 to 1.13
- handling from 63 to 64

Warrazor h3
- swing damage from 49 to 45
- swing speed from 76 to 78
- thrust damage from 23 to 24
- thrust speed from 97 to 98
- weight from 1.17 to 1.09
- handling from 63 to 65