### PR TITLE
Caver1

### DIFF
--- a/items.json
+++ b/items.json
@@ -2098,24 +2098,24 @@
     "weapons": []
   },
   {
-    "id": "crpg_arrow_emp_1_a_h0",
-    "baseId": "crpg_arrow_emp_1_a",
-    "name": "Imperial Arrows",
-    "culture": "Empire",
+    "id": "crpg_arrows_h0",
+    "baseId": "crpg_arrows",
+    "name": "Arrows",
+    "culture": "Neutral",
     "type": "Arrows",
-    "price": 2788,
-    "weight": 0.05,
+    "price": 639,
+    "weight": 0.043,
     "rank": 0,
-    "tier": 7.6228013,
+    "tier": 3.04010773,
     "requirement": 0,
     "flags": [],
     "weapons": [
       {
         "class": "Arrow",
-        "itemUsage": "arrow_top",
+        "itemUsage": "arrow_right",
         "accuracy": 100,
         "missileSpeed": 10,
-        "stackAmount": 6,
+        "stackAmount": 27,
         "length": 97,
         "balance": 0.0,
         "handling": 0,
@@ -2123,7 +2123,7 @@
         "flags": [
           "Consumable"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 0,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -2133,24 +2133,24 @@
     ]
   },
   {
-    "id": "crpg_arrow_emp_1_a_h1",
-    "baseId": "crpg_arrow_emp_1_a",
-    "name": "Imperial Arrows +1",
-    "culture": "Empire",
+    "id": "crpg_arrows_h1",
+    "baseId": "crpg_arrows",
+    "name": "Arrows +1",
+    "culture": "Neutral",
     "type": "Arrows",
-    "price": 2482,
-    "weight": 0.05,
+    "price": 591,
+    "weight": 0.043,
     "rank": 1,
-    "tier": 7.126671,
+    "tier": 2.87827659,
     "requirement": 0,
     "flags": [],
     "weapons": [
       {
         "class": "Arrow",
-        "itemUsage": "arrow_top",
+        "itemUsage": "arrow_right",
         "accuracy": 100,
         "missileSpeed": 10,
-        "stackAmount": 7,
+        "stackAmount": 32,
         "length": 97,
         "balance": 0.0,
         "handling": 0,
@@ -2158,7 +2158,7 @@
         "flags": [
           "Consumable"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 0,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -2168,24 +2168,24 @@
     ]
   },
   {
-    "id": "crpg_arrow_emp_1_a_h2",
-    "baseId": "crpg_arrow_emp_1_a",
-    "name": "Imperial Arrows +2",
-    "culture": "Empire",
+    "id": "crpg_arrows_h2",
+    "baseId": "crpg_arrows",
+    "name": "Arrows +2",
+    "culture": "Neutral",
     "type": "Arrows",
-    "price": 2213,
-    "weight": 0.05,
+    "price": 528,
+    "weight": 0.043,
     "rank": 2,
-    "tier": 6.66351032,
+    "tier": 2.65752554,
     "requirement": 0,
     "flags": [],
     "weapons": [
       {
         "class": "Arrow",
-        "itemUsage": "arrow_top",
+        "itemUsage": "arrow_right",
         "accuracy": 100,
         "missileSpeed": 10,
-        "stackAmount": 8,
+        "stackAmount": 36,
         "length": 97,
         "balance": 0.0,
         "handling": 0,
@@ -2193,7 +2193,7 @@
         "flags": [
           "Consumable"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 0,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -2203,24 +2203,24 @@
     ]
   },
   {
-    "id": "crpg_arrow_emp_1_a_h3",
-    "baseId": "crpg_arrow_emp_1_a",
-    "name": "Imperial Arrows +3",
-    "culture": "Empire",
+    "id": "crpg_arrows_h3",
+    "baseId": "crpg_arrows",
+    "name": "Arrows +3",
+    "culture": "Neutral",
     "type": "Arrows",
-    "price": 2488,
-    "weight": 0.05,
+    "price": 725,
+    "weight": 0.043,
     "rank": 3,
-    "tier": 7.13630152,
+    "tier": 3.31530833,
     "requirement": 0,
     "flags": [],
     "weapons": [
       {
         "class": "Arrow",
-        "itemUsage": "arrow_top",
+        "itemUsage": "arrow_right",
         "accuracy": 100,
         "missileSpeed": 10,
-        "stackAmount": 8,
+        "stackAmount": 36,
         "length": 97,
         "balance": 0.0,
         "handling": 0,
@@ -2228,7 +2228,7 @@
         "flags": [
           "Consumable"
         ],
-        "thrustDamage": 8,
+        "thrustDamage": 1,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -8322,8 +8322,8 @@
     ]
   },
   {
-    "id": "crpg_barbed_arrows_h0",
-    "baseId": "crpg_barbed_arrows",
+    "id": "crpg_barbed_arrows_v1_h0",
+    "baseId": "crpg_barbed_arrows_v1",
     "name": "Barbed Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -8357,8 +8357,8 @@
     ]
   },
   {
-    "id": "crpg_barbed_arrows_h1",
-    "baseId": "crpg_barbed_arrows",
+    "id": "crpg_barbed_arrows_v1_h1",
+    "baseId": "crpg_barbed_arrows_v1",
     "name": "Barbed Arrows +1",
     "culture": "Neutral",
     "type": "Arrows",
@@ -8392,8 +8392,8 @@
     ]
   },
   {
-    "id": "crpg_barbed_arrows_h2",
-    "baseId": "crpg_barbed_arrows",
+    "id": "crpg_barbed_arrows_v1_h2",
+    "baseId": "crpg_barbed_arrows_v1",
     "name": "Barbed Arrows +2",
     "culture": "Neutral",
     "type": "Arrows",
@@ -8427,8 +8427,8 @@
     ]
   },
   {
-    "id": "crpg_barbed_arrows_h3",
-    "baseId": "crpg_barbed_arrows",
+    "id": "crpg_barbed_arrows_v1_h3",
+    "baseId": "crpg_barbed_arrows_v1",
     "name": "Barbed Arrows +3",
     "culture": "Neutral",
     "type": "Arrows",
@@ -17800,148 +17800,8 @@
     ]
   },
   {
-    "id": "crpg_bodkin_arrows_a_h0",
-    "baseId": "crpg_bodkin_arrows_a",
-    "name": "Stacked Bodkin Arrows",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 3825,
-    "weight": 0.048,
-    "rank": 0,
-    "tier": 9.12912,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 22,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_a_h1",
-    "baseId": "crpg_bodkin_arrows_a",
-    "name": "Stacked Bodkin Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 3648,
-    "weight": 0.048,
-    "rank": 1,
-    "tier": 8.887842,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 27,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_a_h2",
-    "baseId": "crpg_bodkin_arrows_a",
-    "name": "Stacked Bodkin Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 3262,
-    "weight": 0.048,
-    "rank": 2,
-    "tier": 8.340988,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 31,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_a_h3",
-    "baseId": "crpg_bodkin_arrows_a",
-    "name": "Stacked Bodkin Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4331,
-    "weight": 0.048,
-    "rank": 3,
-    "tier": 9.789079,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 31,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 3,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_b_h0",
-    "baseId": "crpg_bodkin_arrows_b",
+    "id": "crpg_bodkin_arrows_h0",
+    "baseId": "crpg_bodkin_arrows",
     "name": "Bodkin Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -17975,8 +17835,8 @@
     ]
   },
   {
-    "id": "crpg_bodkin_arrows_b_h1",
-    "baseId": "crpg_bodkin_arrows_b",
+    "id": "crpg_bodkin_arrows_h1",
+    "baseId": "crpg_bodkin_arrows",
     "name": "Bodkin Arrows +1",
     "culture": "Neutral",
     "type": "Arrows",
@@ -18010,8 +17870,8 @@
     ]
   },
   {
-    "id": "crpg_bodkin_arrows_b_h2",
-    "baseId": "crpg_bodkin_arrows_b",
+    "id": "crpg_bodkin_arrows_h2",
+    "baseId": "crpg_bodkin_arrows",
     "name": "Bodkin Arrows +2",
     "culture": "Neutral",
     "type": "Arrows",
@@ -18045,8 +17905,8 @@
     ]
   },
   {
-    "id": "crpg_bodkin_arrows_b_h3",
-    "baseId": "crpg_bodkin_arrows_b",
+    "id": "crpg_bodkin_arrows_h3",
+    "baseId": "crpg_bodkin_arrows",
     "name": "Bodkin Arrows +3",
     "culture": "Neutral",
     "type": "Arrows",
@@ -18071,146 +17931,6 @@
           "Consumable"
         ],
         "thrustDamage": 4,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_c_h0",
-    "baseId": "crpg_bodkin_arrows_c",
-    "name": "Light Bodkin Arrows",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 1964,
-    "weight": 0.048,
-    "rank": 0,
-    "tier": 6.210291,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 21,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 1,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_c_h1",
-    "baseId": "crpg_bodkin_arrows_c",
-    "name": "Light Bodkin Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 1900,
-    "weight": 0.048,
-    "rank": 1,
-    "tier": 6.088773,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 26,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 1,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_c_h2",
-    "baseId": "crpg_bodkin_arrows_c",
-    "name": "Light Bodkin Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 1720,
-    "weight": 0.048,
-    "rank": 2,
-    "tier": 5.736816,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 30,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 1,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_bodkin_arrows_c_h3",
-    "baseId": "crpg_bodkin_arrows_c",
-    "name": "Light Bodkin Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 2362,
-    "weight": 0.048,
-    "rank": 3,
-    "tier": 6.92310572,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 30,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
         "thrustDamageType": "Blunt",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -21234,286 +20954,6 @@
     "weapons": []
   },
   {
-    "id": "crpg_broad_arrows_a_h0",
-    "baseId": "crpg_broad_arrows_a",
-    "name": "Broad Head Arrows",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4124,
-    "weight": 0.098,
-    "rank": 0,
-    "tier": 9.523222,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 16,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_a_h1",
-    "baseId": "crpg_broad_arrows_a",
-    "name": "Broad Head Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4036,
-    "weight": 0.098,
-    "rank": 1,
-    "tier": 9.408631,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 20,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_a_h2",
-    "baseId": "crpg_broad_arrows_a",
-    "name": "Broad Head Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4063,
-    "weight": 0.098,
-    "rank": 2,
-    "tier": 9.44430351,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 20,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_a_h3",
-    "baseId": "crpg_broad_arrows_a",
-    "name": "Broad Head Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4137,
-    "weight": 0.098,
-    "rank": 3,
-    "tier": 9.540683,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 20,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 14,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_b_h0",
-    "baseId": "crpg_broad_arrows_b",
-    "name": "Light Broad Head Arrows",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4070,
-    "weight": 0.078,
-    "rank": 0,
-    "tier": 9.454156,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 33,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_b_h1",
-    "baseId": "crpg_broad_arrows_b",
-    "name": "Light Broad Head Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4087,
-    "weight": 0.078,
-    "rank": 1,
-    "tier": 9.476011,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 42,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_b_h2",
-    "baseId": "crpg_broad_arrows_b",
-    "name": "Light Broad Head Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4321,
-    "weight": 0.078,
-    "rank": 2,
-    "tier": 9.775841,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 42,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_broad_arrows_b_h3",
-    "baseId": "crpg_broad_arrows_b",
-    "name": "Light Broad Head Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 4601,
-    "weight": 0.078,
-    "rank": 3,
-    "tier": 10.1248169,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 42,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Cut",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
     "id": "crpg_broad_blade_javelin_v1_h0",
     "baseId": "crpg_broad_blade_javelin_v1",
     "name": "Broad Blade Javelin",
@@ -22054,6 +21494,146 @@
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_broad_head_arrows_h0",
+    "baseId": "crpg_broad_head_arrows",
+    "name": "Broad Head Arrows",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4124,
+    "weight": 0.098,
+    "rank": 0,
+    "tier": 9.523222,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 16,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_broad_head_arrows_h1",
+    "baseId": "crpg_broad_head_arrows",
+    "name": "Broad Head Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4036,
+    "weight": 0.098,
+    "rank": 1,
+    "tier": 9.408631,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 20,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_broad_head_arrows_h2",
+    "baseId": "crpg_broad_head_arrows",
+    "name": "Broad Head Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4063,
+    "weight": 0.098,
+    "rank": 2,
+    "tier": 9.44430351,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 20,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_broad_head_arrows_h3",
+    "baseId": "crpg_broad_head_arrows",
+    "name": "Broad Head Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4137,
+    "weight": 0.098,
+    "rank": 3,
+    "tier": 9.540683,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 20,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
       }
     ]
   },
@@ -26772,15 +26352,15 @@
     "weapons": []
   },
   {
-    "id": "crpg_composite_bow_REFUND_h0",
-    "baseId": "crpg_composite_bow_REFUND",
-    "name": "Simple Short Bow",
-    "culture": "Neutral",
+    "id": "crpg_common_long_bow_h0",
+    "baseId": "crpg_common_long_bow",
+    "name": "Common Long Bow",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 6404,
-    "weight": 0.3,
+    "price": 8945,
+    "weight": 0.45,
     "rank": 0,
-    "tier": 6.41871357,
+    "tier": 7.778077,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -26788,13 +26368,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 116,
-        "missileSpeed": 73,
+        "itemUsage": "long_bow",
+        "accuracy": 107,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 115,
+        "handling": 88,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26804,22 +26384,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 115,
+        "thrustSpeed": 88,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 90
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 116,
-        "missileSpeed": 73,
+        "itemUsage": "long_bow",
+        "accuracy": 107,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 115,
+        "handling": 88,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26830,25 +26410,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 115,
+        "thrustSpeed": 88,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 82
+        "swingSpeed": 90
       }
     ]
   },
   {
-    "id": "crpg_composite_bow_REFUND_h1",
-    "baseId": "crpg_composite_bow_REFUND",
-    "name": "Simple Short Bow +1",
-    "culture": "Neutral",
+    "id": "crpg_common_long_bow_h1",
+    "baseId": "crpg_common_long_bow",
+    "name": "Common Long Bow +1",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 6552,
-    "weight": 0.3,
+    "price": 8260,
+    "weight": 0.45,
     "rank": 1,
-    "tier": 6.50463247,
+    "tier": 7.43295527,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -26856,13 +26436,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 116,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 109,
+        "missileSpeed": 88,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 117,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26872,22 +26452,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 117,
+        "thrustSpeed": 89,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 93
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 116,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 109,
+        "missileSpeed": 88,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 117,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26898,25 +26478,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 117,
+        "thrustSpeed": 89,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 93
       }
     ]
   },
   {
-    "id": "crpg_composite_bow_REFUND_h2",
-    "baseId": "crpg_composite_bow_REFUND",
-    "name": "Simple Short Bow +2",
-    "culture": "Neutral",
+    "id": "crpg_common_long_bow_h2",
+    "baseId": "crpg_common_long_bow",
+    "name": "Common Long Bow +2",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 6591,
-    "weight": 0.3,
+    "price": 7981,
+    "weight": 0.45,
     "rank": 2,
-    "tier": 6.52696133,
+    "tier": 7.288411,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -26924,13 +26504,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 119,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 111,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26940,22 +26520,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 94
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 119,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 111,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -26966,25 +26546,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 94
       }
     ]
   },
   {
-    "id": "crpg_composite_bow_REFUND_h3",
-    "baseId": "crpg_composite_bow_REFUND",
-    "name": "Simple Short Bow +3",
-    "culture": "Neutral",
+    "id": "crpg_common_long_bow_h3",
+    "baseId": "crpg_common_long_bow",
+    "name": "Common Long Bow +3",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 6450,
-    "weight": 0.3,
+    "price": 10267,
+    "weight": 0.45,
     "rank": 3,
-    "tier": 6.44578934,
+    "tier": 8.409175,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -26992,13 +26572,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 125,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 111,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27008,22 +26588,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 94
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 125,
-        "missileSpeed": 82,
+        "itemUsage": "long_bow",
+        "accuracy": 111,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 110,
+        "length": 111,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27034,25 +26614,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 17,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 85
+        "swingSpeed": 94
       }
     ]
   },
   {
-    "id": "crpg_composite_steppe_bow_REFUND_h0",
-    "baseId": "crpg_composite_steppe_bow_REFUND",
-    "name": "Steppe Recurve Bow",
-    "culture": "Khuzait",
+    "id": "crpg_common_ranger_bow_h0",
+    "baseId": "crpg_common_ranger_bow",
+    "name": "Common Ranger Bow",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13402,
-    "weight": 0.35,
+    "price": 9040,
+    "weight": 0.5,
     "rank": 0,
-    "tier": 9.761091,
+    "tier": 7.8248167,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -27060,13 +26640,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 74,
+        "itemUsage": "long_bow",
+        "accuracy": 115,
+        "missileSpeed": 82,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 103,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27076,22 +26656,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 103,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 93
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 74,
+        "itemUsage": "long_bow",
+        "accuracy": 115,
+        "missileSpeed": 82,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 103,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27102,25 +26682,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 103,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 83
+        "swingSpeed": 93
       }
     ]
   },
   {
-    "id": "crpg_composite_steppe_bow_REFUND_h1",
-    "baseId": "crpg_composite_steppe_bow_REFUND",
-    "name": "Steppe Recurve Bow +1",
-    "culture": "Khuzait",
+    "id": "crpg_common_ranger_bow_h1",
+    "baseId": "crpg_common_ranger_bow",
+    "name": "Common Ranger Bow +1",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13618,
-    "weight": 0.35,
+    "price": 8222,
+    "weight": 0.5,
     "rank": 1,
-    "tier": 9.847792,
+    "tier": 7.41301441,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -27128,13 +26708,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 83,
+        "itemUsage": "long_bow",
+        "accuracy": 117,
+        "missileSpeed": 84,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 123,
+        "handling": 104,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27144,22 +26724,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 123,
+        "thrustSpeed": 104,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 96
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 83,
+        "itemUsage": "long_bow",
+        "accuracy": 117,
+        "missileSpeed": 84,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 123,
+        "handling": 104,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27170,25 +26750,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 123,
+        "thrustSpeed": 104,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 96
       }
     ]
   },
   {
-    "id": "crpg_composite_steppe_bow_REFUND_h2",
-    "baseId": "crpg_composite_steppe_bow_REFUND",
-    "name": "Steppe Recurve Bow +2",
-    "culture": "Khuzait",
+    "id": "crpg_common_ranger_bow_h2",
+    "baseId": "crpg_common_ranger_bow",
+    "name": "Common Ranger Bow +2",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13684,
-    "weight": 0.35,
+    "price": 7773,
+    "weight": 0.5,
     "rank": 2,
-    "tier": 9.874495,
+    "tier": 7.178576,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -27196,13 +26776,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 113,
-        "missileSpeed": 83,
+        "itemUsage": "long_bow",
+        "accuracy": 119,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 127,
+        "handling": 106,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27212,22 +26792,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 127,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 97
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 113,
-        "missileSpeed": 83,
+        "itemUsage": "long_bow",
+        "accuracy": 119,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 127,
+        "handling": 106,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27238,25 +26818,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 14,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 127,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 97
       }
     ]
   },
   {
-    "id": "crpg_composite_steppe_bow_REFUND_h3",
-    "baseId": "crpg_composite_steppe_bow_REFUND",
-    "name": "Steppe Recurve Bow +3",
-    "culture": "Khuzait",
+    "id": "crpg_common_ranger_bow_h3",
+    "baseId": "crpg_common_ranger_bow",
+    "name": "Common Ranger Bow +3",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13564,
-    "weight": 0.35,
+    "price": 10765,
+    "weight": 0.5,
     "rank": 3,
-    "tier": 9.826441,
+    "tier": 8.636351,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -27264,13 +26844,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
+        "itemUsage": "long_bow",
         "accuracy": 119,
-        "missileSpeed": 83,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 127,
+        "handling": 106,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27280,22 +26860,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 127,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 97
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
+        "itemUsage": "long_bow",
         "accuracy": 119,
-        "missileSpeed": 83,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 108,
+        "length": 113,
         "balance": 0.0,
-        "handling": 127,
+        "handling": 106,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -27306,12 +26886,12 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 13,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 127,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 86
+        "swingSpeed": 97
       }
     ]
   },
@@ -33390,146 +32970,6 @@
         "swingDamage": 6,
         "swingDamageType": "Blunt",
         "swingSpeed": 97
-      }
-    ]
-  },
-  {
-    "id": "crpg_default_arrows_h0",
-    "baseId": "crpg_default_arrows",
-    "name": "Arrows",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 639,
-    "weight": 0.043,
-    "rank": 0,
-    "tier": 3.04010773,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 27,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_default_arrows_h1",
-    "baseId": "crpg_default_arrows",
-    "name": "Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 591,
-    "weight": 0.043,
-    "rank": 1,
-    "tier": 2.87827659,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 32,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_default_arrows_h2",
-    "baseId": "crpg_default_arrows",
-    "name": "Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 528,
-    "weight": 0.043,
-    "rank": 2,
-    "tier": 2.65752554,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 36,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_default_arrows_h3",
-    "baseId": "crpg_default_arrows",
-    "name": "Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 725,
-    "weight": 0.043,
-    "rank": 3,
-    "tier": 3.31530833,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 36,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 1,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
       }
     ]
   },
@@ -42174,6 +41614,278 @@
     "weapons": []
   },
   {
+    "id": "crpg_fine_long_bow_h0",
+    "baseId": "crpg_fine_long_bow",
+    "name": "Fine Long Bow",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 11405,
+    "weight": 0.7,
+    "rank": 0,
+    "tier": 8.920876,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 102,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 87,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 89
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 102,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 87,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 89
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_long_bow_h1",
+    "baseId": "crpg_fine_long_bow",
+    "name": "Fine Long Bow +1",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 10575,
+    "weight": 0.7,
+    "rank": 1,
+    "tier": 8.550067,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 104,
+        "missileSpeed": 90,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 88,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 92
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 104,
+        "missileSpeed": 90,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 88,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 92
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_long_bow_h2",
+    "baseId": "crpg_fine_long_bow",
+    "name": "Fine Long Bow +2",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 10266,
+    "weight": 0.7,
+    "rank": 2,
+    "tier": 8.40872,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 92,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 92,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_long_bow_h3",
+    "baseId": "crpg_fine_long_bow",
+    "name": "Fine Long Bow +3",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 12849,
+    "weight": 0.7,
+    "rank": 3,
+    "tier": 9.535067,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 92,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 18,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 92,
+        "stackAmount": 1,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 18,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      }
+    ]
+  },
+  {
     "id": "crpg_fine_pike_h0",
     "baseId": "crpg_fine_pike",
     "name": "Fine Pike",
@@ -42422,6 +42134,278 @@
         "swingDamage": 0,
         "swingDamageType": "Undefined",
         "swingSpeed": 24
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_ranger_bow_h0",
+    "baseId": "crpg_fine_ranger_bow",
+    "name": "Fine Ranger Bow",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 10497,
+    "weight": 0.65,
+    "rank": 0,
+    "tier": 8.514781,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 92
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 106,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 92
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_ranger_bow_h1",
+    "baseId": "crpg_fine_ranger_bow",
+    "name": "Fine Ranger Bow +1",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 9613,
+    "weight": 0.65,
+    "rank": 1,
+    "tier": 8.102292,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 108,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 95
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 108,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 95
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_ranger_bow_h2",
+    "baseId": "crpg_fine_ranger_bow",
+    "name": "Fine Ranger Bow +2",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 9153,
+    "weight": 0.65,
+    "rank": 2,
+    "tier": 7.87998724,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 110,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 110,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
+      }
+    ]
+  },
+  {
+    "id": "crpg_fine_ranger_bow_h3",
+    "baseId": "crpg_fine_ranger_bow",
+    "name": "Fine Ranger Bow +3",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 12219,
+    "weight": 0.65,
+    "rank": 3,
+    "tier": 9.271395,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 110,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 110,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 117,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 16,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
       }
     ]
   },
@@ -49216,278 +49200,6 @@
     ]
   },
   {
-    "id": "crpg_glen_ranger_bow_REFUND_h0",
-    "baseId": "crpg_glen_ranger_bow_REFUND",
-    "name": "Longbow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 2100,
-    "weight": 0.45,
-    "rank": 0,
-    "tier": 3.248378,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 110,
-        "missileSpeed": 83,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 97
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 110,
-        "missileSpeed": 83,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 97
-      }
-    ]
-  },
-  {
-    "id": "crpg_glen_ranger_bow_REFUND_h1",
-    "baseId": "crpg_glen_ranger_bow_REFUND",
-    "name": "Longbow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1936,
-    "weight": 0.45,
-    "rank": 1,
-    "tier": 3.08061552,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 112,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 100
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 112,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 100
-      }
-    ]
-  },
-  {
-    "id": "crpg_glen_ranger_bow_REFUND_h2",
-    "baseId": "crpg_glen_ranger_bow_REFUND",
-    "name": "Longbow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1849,
-    "weight": 0.45,
-    "rank": 2,
-    "tier": 2.98950148,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 114,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 105,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 105,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 114,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 105,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 105,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      }
-    ]
-  },
-  {
-    "id": "crpg_glen_ranger_bow_REFUND_h3",
-    "baseId": "crpg_glen_ranger_bow_REFUND",
-    "name": "Longbow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 2687,
-    "weight": 0.45,
-    "rank": 3,
-    "tier": 3.80088854,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 114,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 105,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 105,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 114,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 111,
-        "balance": 0.0,
-        "handling": 105,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 105,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      }
-    ]
-  },
-  {
     "id": "crpg_goggled_helmet_over_full_mail_v1_h0",
     "baseId": "crpg_goggled_helmet_over_full_mail_v1",
     "name": "Closed Huscarl Helmet",
@@ -52320,6 +52032,278 @@
     ]
   },
   {
+    "id": "crpg_hassun_yumi_h0",
+    "baseId": "crpg_hassun_yumi",
+    "name": "Hassun Yumi",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 13721,
+    "weight": 0.7,
+    "rank": 0,
+    "tier": 9.889191,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 70
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 70
+      }
+    ]
+  },
+  {
+    "id": "crpg_hassun_yumi_h1",
+    "baseId": "crpg_hassun_yumi",
+    "name": "Hassun Yumi +1",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 14258,
+    "weight": 0.7,
+    "rank": 1,
+    "tier": 10.1020222,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      }
+    ]
+  },
+  {
+    "id": "crpg_hassun_yumi_h2",
+    "baseId": "crpg_hassun_yumi",
+    "name": "Hassun Yumi +2",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 14840,
+    "weight": 0.7,
+    "rank": 2,
+    "tier": 10.3277483,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 113,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 113,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      }
+    ]
+  },
+  {
+    "id": "crpg_hassun_yumi_h3",
+    "baseId": "crpg_hassun_yumi",
+    "name": "Hassun Yumi +3",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 14709,
+    "weight": 0.7,
+    "rank": 3,
+    "tier": 10.27749,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 119,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 119,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 114,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 73
+      }
+    ]
+  },
+  {
     "id": "crpg_hatchet_h0",
     "baseId": "crpg_hatchet",
     "name": "Hatchet",
@@ -55064,6 +55048,278 @@
     ]
   },
   {
+    "id": "crpg_heavy_hunting_bow_h0",
+    "baseId": "crpg_heavy_hunting_bow",
+    "name": "Heavy Hunting Bow",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 14005,
+    "weight": 0.3,
+    "rank": 0,
+    "tier": 10.002018,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 72,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 72,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 90,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 90,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_heavy_hunting_bow_h1",
+    "baseId": "crpg_heavy_hunting_bow",
+    "name": "Heavy Hunting Bow +1",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 14782,
+    "weight": 0.3,
+    "rank": 1,
+    "tier": 10.3057308,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 92,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 92,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 92,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 92,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
+    "id": "crpg_heavy_hunting_bow_h2",
+    "baseId": "crpg_heavy_hunting_bow",
+    "name": "Heavy Hunting Bow +2",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 15544,
+    "weight": 0.3,
+    "rank": 2,
+    "tier": 10.5955515,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 123,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 123,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
+    "id": "crpg_heavy_hunting_bow_h3",
+    "baseId": "crpg_heavy_hunting_bow",
+    "name": "Heavy Hunting Bow +3",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 15067,
+    "weight": 0.3,
+    "rank": 3,
+    "tier": 10.414854,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 129,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 129,
+        "missileSpeed": 81,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
     "id": "crpg_heavy_knightly_lance_h0",
     "baseId": "crpg_heavy_knightly_lance",
     "name": "Heavy Knightly Lance",
@@ -56340,146 +56596,6 @@
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 88
-      }
-    ]
-  },
-  {
-    "id": "crpg_heavy_steppe_arrows_h0",
-    "baseId": "crpg_heavy_steppe_arrows",
-    "name": "Stacked Steppe Arrows",
-    "culture": "Khuzait",
-    "type": "Arrows",
-    "price": 4457,
-    "weight": 0.036,
-    "rank": 0,
-    "tier": 9.946981,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 32,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 3,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_heavy_steppe_arrows_h1",
-    "baseId": "crpg_heavy_steppe_arrows",
-    "name": "Stacked Steppe Arrows +1",
-    "culture": "Khuzait",
-    "type": "Arrows",
-    "price": 3903,
-    "weight": 0.036,
-    "rank": 1,
-    "tier": 9.233096,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 37,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 3,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_heavy_steppe_arrows_h2",
-    "baseId": "crpg_heavy_steppe_arrows",
-    "name": "Stacked Steppe Arrows +2",
-    "culture": "Khuzait",
-    "type": "Arrows",
-    "price": 3432,
-    "weight": 0.036,
-    "rank": 2,
-    "tier": 8.586344,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 42,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 3,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_heavy_steppe_arrows_h3",
-    "baseId": "crpg_heavy_steppe_arrows",
-    "name": "Stacked Steppe Arrows +3",
-    "culture": "Khuzait",
-    "type": "Arrows",
-    "price": 4372,
-    "weight": 0.036,
-    "rank": 3,
-    "tier": 9.840629,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_right",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 42,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 4,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
       }
     ]
   },
@@ -58308,278 +58424,6 @@
         "swingDamage": 33,
         "swingDamageType": "Cut",
         "swingSpeed": 88
-      }
-    ]
-  },
-  {
-    "id": "crpg_highland_ranger_bow_REFUND_h0",
-    "baseId": "crpg_highland_ranger_bow_REFUND",
-    "name": "Ranger Bow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 2014,
-    "weight": 0.5,
-    "rank": 0,
-    "tier": 3.16146564,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 131,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 86,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 86
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 131,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 86,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 86
-      }
-    ]
-  },
-  {
-    "id": "crpg_highland_ranger_bow_REFUND_h1",
-    "baseId": "crpg_highland_ranger_bow_REFUND",
-    "name": "Ranger Bow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1854,
-    "weight": 0.5,
-    "rank": 1,
-    "tier": 2.99463081,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 133,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 87,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 89
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 133,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 87,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 89
-      }
-    ]
-  },
-  {
-    "id": "crpg_highland_ranger_bow_REFUND_h2",
-    "baseId": "crpg_highland_ranger_bow_REFUND",
-    "name": "Ranger Bow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1776,
-    "weight": 0.5,
-    "rank": 2,
-    "tier": 2.910833,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 135,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 90
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 135,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 12,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 90
-      }
-    ]
-  },
-  {
-    "id": "crpg_highland_ranger_bow_REFUND_h3",
-    "baseId": "crpg_highland_ranger_bow_REFUND",
-    "name": "Ranger Bow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 2575,
-    "weight": 0.5,
-    "rank": 3,
-    "tier": 3.70086861,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 135,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 90
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 135,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 113,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 90
       }
     ]
   },
@@ -61326,278 +61170,6 @@
     ]
   },
   {
-    "id": "crpg_hunting_bow_REFUND_h0",
-    "baseId": "crpg_hunting_bow_REFUND",
-    "name": "Hunting Bow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1466,
-    "weight": 0.2,
-    "rank": 0,
-    "tier": 2.55985117,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 135,
-        "missileSpeed": 72,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 119,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 119,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 135,
-        "missileSpeed": 72,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 119,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 119,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
-    "id": "crpg_hunting_bow_REFUND_h1",
-    "baseId": "crpg_hunting_bow_REFUND",
-    "name": "Hunting Bow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1497,
-    "weight": 0.2,
-    "rank": 1,
-    "tier": 2.59588432,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 135,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 121,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 135,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 121,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      }
-    ]
-  },
-  {
-    "id": "crpg_hunting_bow_REFUND_h2",
-    "baseId": "crpg_hunting_bow_REFUND",
-    "name": "Hunting Bow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1474,
-    "weight": 0.2,
-    "rank": 2,
-    "tier": 2.56872749,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 138,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 125,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 125,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 138,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 125,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 125,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      }
-    ]
-  },
-  {
-    "id": "crpg_hunting_bow_REFUND_h3",
-    "baseId": "crpg_hunting_bow_REFUND",
-    "name": "Hunting Bow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 1405,
-    "weight": 0.2,
-    "rank": 3,
-    "tier": 2.48681855,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 144,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 125,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 125,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 144,
-        "missileSpeed": 81,
-        "stackAmount": 1,
-        "length": 110,
-        "balance": 0.0,
-        "handling": 125,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 125,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 83
-      }
-    ]
-  },
-  {
     "id": "crpg_iklwa_h0",
     "baseId": "crpg_iklwa",
     "name": "Iklwa",
@@ -61830,6 +61402,146 @@
         "swingDamage": 32,
         "swingDamageType": "Cut",
         "swingSpeed": 93
+      }
+    ]
+  },
+  {
+    "id": "crpg_imperial_arrows_h0",
+    "baseId": "crpg_imperial_arrows",
+    "name": "Imperial Arrows",
+    "culture": "Empire",
+    "type": "Arrows",
+    "price": 2788,
+    "weight": 0.05,
+    "rank": 0,
+    "tier": 7.6228013,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 6,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 7,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_imperial_arrows_h1",
+    "baseId": "crpg_imperial_arrows",
+    "name": "Imperial Arrows +1",
+    "culture": "Empire",
+    "type": "Arrows",
+    "price": 2482,
+    "weight": 0.05,
+    "rank": 1,
+    "tier": 7.126671,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 7,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 7,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_imperial_arrows_h2",
+    "baseId": "crpg_imperial_arrows",
+    "name": "Imperial Arrows +2",
+    "culture": "Empire",
+    "type": "Arrows",
+    "price": 2213,
+    "weight": 0.05,
+    "rank": 2,
+    "tier": 6.66351032,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 8,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 7,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_imperial_arrows_h3",
+    "baseId": "crpg_imperial_arrows",
+    "name": "Imperial Arrows +3",
+    "culture": "Empire",
+    "type": "Arrows",
+    "price": 2488,
+    "weight": 0.05,
+    "rank": 3,
+    "tier": 7.13630152,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 8,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 8,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
       }
     ]
   },
@@ -76956,6 +76668,286 @@
     "weapons": []
   },
   {
+    "id": "crpg_light_bodkin_arrows_h0",
+    "baseId": "crpg_light_bodkin_arrows",
+    "name": "Light Bodkin Arrows",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 1964,
+    "weight": 0.048,
+    "rank": 0,
+    "tier": 6.210291,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 21,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 1,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_bodkin_arrows_h1",
+    "baseId": "crpg_light_bodkin_arrows",
+    "name": "Light Bodkin Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 1900,
+    "weight": 0.048,
+    "rank": 1,
+    "tier": 6.088773,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 26,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 1,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_bodkin_arrows_h2",
+    "baseId": "crpg_light_bodkin_arrows",
+    "name": "Light Bodkin Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 1720,
+    "weight": 0.048,
+    "rank": 2,
+    "tier": 5.736816,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 30,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 1,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_bodkin_arrows_h3",
+    "baseId": "crpg_light_bodkin_arrows",
+    "name": "Light Bodkin Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 2362,
+    "weight": 0.048,
+    "rank": 3,
+    "tier": 6.92310572,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 30,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_broad_arrows_h0",
+    "baseId": "crpg_light_broad_arrows",
+    "name": "Light Broad Head Arrows",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4070,
+    "weight": 0.078,
+    "rank": 0,
+    "tier": 9.454156,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 33,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 9,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_broad_arrows_h1",
+    "baseId": "crpg_light_broad_arrows",
+    "name": "Light Broad Head Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4087,
+    "weight": 0.078,
+    "rank": 1,
+    "tier": 9.476011,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 42,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 9,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_broad_arrows_h2",
+    "baseId": "crpg_light_broad_arrows",
+    "name": "Light Broad Head Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4321,
+    "weight": 0.078,
+    "rank": 2,
+    "tier": 9.775841,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 42,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_broad_arrows_h3",
+    "baseId": "crpg_light_broad_arrows",
+    "name": "Light Broad Head Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4601,
+    "weight": 0.078,
+    "rank": 3,
+    "tier": 10.1248169,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 42,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Cut",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
     "id": "crpg_light_chain_shoulders_v1_h0",
     "baseId": "crpg_light_chain_shoulders_v1",
     "name": "Light Chain Shoulders",
@@ -77432,6 +77424,278 @@
     ]
   },
   {
+    "id": "crpg_light_hunting_bow_h0",
+    "baseId": "crpg_light_hunting_bow",
+    "name": "Light Hunting Bow",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 7874,
+    "weight": 0.25,
+    "rank": 0,
+    "tier": 7.23178,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 70,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 94,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 94,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 84
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 70,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 94,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 94,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 84
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_hunting_bow_h1",
+    "baseId": "crpg_light_hunting_bow",
+    "name": "Light Hunting Bow +1",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 8277,
+    "weight": 0.25,
+    "rank": 1,
+    "tier": 7.441476,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 96,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_hunting_bow_h2",
+    "baseId": "crpg_light_hunting_bow",
+    "name": "Light Hunting Bow +2",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 8525,
+    "weight": 0.25,
+    "rank": 2,
+    "tier": 7.56820965,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_hunting_bow_h3",
+    "baseId": "crpg_light_hunting_bow",
+    "name": "Light Hunting Bow +3",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 8122,
+    "weight": 0.25,
+    "rank": 3,
+    "tier": 7.36136627,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 79,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 100,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 100,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 87
+      }
+    ]
+  },
+  {
     "id": "crpg_light_mace_h0",
     "baseId": "crpg_light_mace",
     "name": "Light Mace",
@@ -77720,6 +77984,278 @@
         "swingDamage": 27,
         "swingDamageType": "Pierce",
         "swingSpeed": 91
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_recurve_bow_h0",
+    "baseId": "crpg_light_recurve_bow",
+    "name": "Light Recurve Bow",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 2066,
+    "weight": 0.3,
+    "rank": 0,
+    "tier": 3.213821,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 100,
+        "missileSpeed": 75,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 122,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 122,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 130
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 100,
+        "missileSpeed": 75,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 122,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 122,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 130
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_recurve_bow_h1",
+    "baseId": "crpg_light_recurve_bow",
+    "name": "Light Recurve Bow +1",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 2048,
+    "weight": 0.3,
+    "rank": 1,
+    "tier": 3.19556856,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 100,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 124,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 124,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 100,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 124,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 124,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_recurve_bow_h2",
+    "baseId": "crpg_light_recurve_bow",
+    "name": "Light Recurve Bow +2",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 2079,
+    "weight": 0.3,
+    "rank": 2,
+    "tier": 3.22736168,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 103,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 128,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 128,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 103,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 128,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 128,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
+      }
+    ]
+  },
+  {
+    "id": "crpg_light_recurve_bow_h3",
+    "baseId": "crpg_light_recurve_bow",
+    "name": "Light Recurve Bow +3",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 2111,
+    "weight": 0.3,
+    "rank": 3,
+    "tier": 3.2590518,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 109,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 128,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 128,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 109,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 128,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 128,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 133
       }
     ]
   },
@@ -81582,6 +82118,111 @@
     "weapons": []
   },
   {
+    "id": "crpg_lowland_arrows_h1",
+    "baseId": "crpg_lowland_arrows",
+    "name": "Lowland Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3018,
+    "weight": 0.06,
+    "rank": 1,
+    "tier": 7.97891474,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 46,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_lowland_arrows_h2",
+    "baseId": "crpg_lowland_arrows",
+    "name": "Lowland Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 2645,
+    "weight": 0.06,
+    "rank": 2,
+    "tier": 7.395425,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 52,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_lowland_arrows_h3",
+    "baseId": "crpg_lowland_arrows",
+    "name": "Lowland Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3498,
+    "weight": 0.06,
+    "rank": 3,
+    "tier": 8.679353,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 52,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 3,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
     "id": "crpg_lowland_javelin_v1_h0",
     "baseId": "crpg_lowland_javelin_v1",
     "name": "Lowland Javelin",
@@ -81822,278 +82463,6 @@
     ]
   },
   {
-    "id": "crpg_lowland_longbow_REFUND_h0",
-    "baseId": "crpg_lowland_longbow_REFUND",
-    "name": "Yonsun Yumi",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 2114,
-    "weight": 0.5,
-    "rank": 0,
-    "tier": 3.26200414,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 130,
-        "missileSpeed": 77,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 93,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 82
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 130,
-        "missileSpeed": 77,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 93,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 82
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_longbow_REFUND_h1",
-    "baseId": "crpg_lowland_longbow_REFUND",
-    "name": "Yonsun Yumi +1",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 2179,
-    "weight": 0.5,
-    "rank": 1,
-    "tier": 3.32685542,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 130,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 95,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 130,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 95,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_longbow_REFUND_h2",
-    "baseId": "crpg_lowland_longbow_REFUND",
-    "name": "Yonsun Yumi +2",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 2242,
-    "weight": 0.5,
-    "rank": 2,
-    "tier": 3.38778925,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 133,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 99,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 133,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 99,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_longbow_REFUND_h3",
-    "baseId": "crpg_lowland_longbow_REFUND",
-    "name": "Yonsun Yumi +3",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 2147,
-    "weight": 0.5,
-    "rank": 3,
-    "tier": 3.295199,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 139,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 99,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 139,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 99,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 85
-      }
-    ]
-  },
-  {
     "id": "crpg_lowland_throwing_knife_v1_h0",
     "baseId": "crpg_lowland_throwing_knife_v1",
     "name": "Lowland Throwing Knife",
@@ -82254,278 +82623,6 @@
         "swingDamage": 0,
         "swingDamageType": "Cut",
         "swingSpeed": 130
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_yew_bow_REFUND_h0",
-    "baseId": "crpg_lowland_yew_bow_REFUND",
-    "name": "Yew Bow",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 9845,
-    "weight": 0.65,
-    "rank": 0,
-    "tier": 8.212027,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 111,
-        "missileSpeed": 82,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 100,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 111,
-        "missileSpeed": 82,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 100,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_yew_bow_REFUND_h1",
-    "baseId": "crpg_lowland_yew_bow_REFUND",
-    "name": "Yew Bow +1",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 9045,
-    "weight": 0.65,
-    "rank": 1,
-    "tier": 7.8271,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 113,
-        "missileSpeed": 84,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 101,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 87
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 113,
-        "missileSpeed": 84,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 101,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_yew_bow_REFUND_h2",
-    "baseId": "crpg_lowland_yew_bow_REFUND",
-    "name": "Yew Bow +2",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 8616,
-    "weight": 0.65,
-    "rank": 2,
-    "tier": 7.61398458,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 88
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 88
-      }
-    ]
-  },
-  {
-    "id": "crpg_lowland_yew_bow_REFUND_h3",
-    "baseId": "crpg_lowland_yew_bow_REFUND",
-    "name": "Yew Bow +3",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 11491,
-    "weight": 0.65,
-    "rank": 3,
-    "tier": 8.958422,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 88
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 117,
-        "balance": 0.0,
-        "handling": 103,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 88
       }
     ]
   },
@@ -93116,278 +93213,6 @@
     "weapons": []
   },
   {
-    "id": "crpg_mountain_hunting_bow_REFUND_h0",
-    "baseId": "crpg_mountain_hunting_bow_REFUND",
-    "name": "Mountain Hunting Bow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 475,
-    "weight": 0.25,
-    "rank": 0,
-    "tier": 1.09685206,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 71,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 107,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 107,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 125
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 71,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 107,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 107,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 125
-      }
-    ]
-  },
-  {
-    "id": "crpg_mountain_hunting_bow_REFUND_h1",
-    "baseId": "crpg_mountain_hunting_bow_REFUND",
-    "name": "Mountain Hunting Bow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 480,
-    "weight": 0.25,
-    "rank": 1,
-    "tier": 1.10566211,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 109,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 109,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 109,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 109,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      }
-    ]
-  },
-  {
-    "id": "crpg_mountain_hunting_bow_REFUND_h2",
-    "baseId": "crpg_mountain_hunting_bow_REFUND",
-    "name": "Mountain Hunting Bow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 494,
-    "weight": 0.25,
-    "rank": 2,
-    "tier": 1.133149,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 113,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 113,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 113,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 113,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      }
-    ]
-  },
-  {
-    "id": "crpg_mountain_hunting_bow_REFUND_h3",
-    "baseId": "crpg_mountain_hunting_bow_REFUND",
-    "name": "Mountain Hunting Bow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 502,
-    "weight": 0.25,
-    "rank": 3,
-    "tier": 1.14802158,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 113,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 113,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 80,
-        "stackAmount": 1,
-        "length": 108,
-        "balance": 0.0,
-        "handling": 113,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 9,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 113,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 128
-      }
-    ]
-  },
-  {
     "id": "crpg_mule_load_a_h0",
     "baseId": "crpg_mule_load_a",
     "name": "Mule Harness with Pack",
@@ -95812,278 +95637,6 @@
     "weapons": []
   },
   {
-    "id": "crpg_noble_bow_REFUND_h0",
-    "baseId": "crpg_noble_bow_REFUND",
-    "name": "Noble Bow",
-    "culture": "Neutral",
-    "type": "Bow",
-    "price": 13161,
-    "weight": 0.4,
-    "rank": 0,
-    "tier": 9.662995,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 76,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 100,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 98
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 76,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 100,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 98
-      }
-    ]
-  },
-  {
-    "id": "crpg_noble_bow_REFUND_h1",
-    "baseId": "crpg_noble_bow_REFUND",
-    "name": "Noble Bow +1",
-    "culture": "Neutral",
-    "type": "Bow",
-    "price": 13421,
-    "weight": 0.4,
-    "rank": 1,
-    "tier": 9.768493,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      }
-    ]
-  },
-  {
-    "id": "crpg_noble_bow_REFUND_h2",
-    "baseId": "crpg_noble_bow_REFUND",
-    "name": "Noble Bow +2",
-    "culture": "Neutral",
-    "type": "Bow",
-    "price": 14214,
-    "weight": 0.4,
-    "rank": 2,
-    "tier": 10.0844784,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 106,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 106,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 106,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 106,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      }
-    ]
-  },
-  {
-    "id": "crpg_noble_bow_REFUND_h3",
-    "baseId": "crpg_noble_bow_REFUND",
-    "name": "Noble Bow +3",
-    "culture": "Neutral",
-    "type": "Bow",
-    "price": 14553,
-    "weight": 0.4,
-    "rank": 3,
-    "tier": 10.2168379,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 106,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 106,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 116,
-        "balance": 0.0,
-        "handling": 106,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 15,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 106,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 101
-      }
-    ]
-  },
-  {
     "id": "crpg_noble_cavalry_lance_h0",
     "baseId": "crpg_noble_cavalry_lance",
     "name": "Noble Cavalry Lance",
@@ -96412,8 +95965,8 @@
     ]
   },
   {
-    "id": "crpg_noble_long_bow_REFUND_h0",
-    "baseId": "crpg_noble_long_bow_REFUND",
+    "id": "crpg_noble_long_bow_h0",
+    "baseId": "crpg_noble_long_bow",
     "name": "Noble Long Bow",
     "culture": "Neutral",
     "type": "Bow",
@@ -96480,8 +96033,8 @@
     ]
   },
   {
-    "id": "crpg_noble_long_bow_REFUND_h1",
-    "baseId": "crpg_noble_long_bow_REFUND",
+    "id": "crpg_noble_long_bow_h1",
+    "baseId": "crpg_noble_long_bow",
     "name": "Noble Long Bow +1",
     "culture": "Neutral",
     "type": "Bow",
@@ -96548,8 +96101,8 @@
     ]
   },
   {
-    "id": "crpg_noble_long_bow_REFUND_h2",
-    "baseId": "crpg_noble_long_bow_REFUND",
+    "id": "crpg_noble_long_bow_h2",
+    "baseId": "crpg_noble_long_bow",
     "name": "Noble Long Bow +2",
     "culture": "Neutral",
     "type": "Bow",
@@ -96616,8 +96169,8 @@
     ]
   },
   {
-    "id": "crpg_noble_long_bow_REFUND_h3",
-    "baseId": "crpg_noble_long_bow_REFUND",
+    "id": "crpg_noble_long_bow_h3",
+    "baseId": "crpg_noble_long_bow",
     "name": "Noble Long Bow +3",
     "culture": "Neutral",
     "type": "Bow",
@@ -96948,15 +96501,15 @@
     "weapons": []
   },
   {
-    "id": "crpg_nomad_bow_REFUND_h0",
-    "baseId": "crpg_nomad_bow_REFUND",
-    "name": "Hassun Yumi",
-    "culture": "Aserai",
+    "id": "crpg_noble_ranger_bow_h0",
+    "baseId": "crpg_noble_ranger_bow",
+    "name": "Noble Ranger Bow",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13526,
+    "price": 14000,
     "weight": 0.7,
     "rank": 0,
-    "tier": 9.811117,
+    "tier": 10.0,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -96964,13 +96517,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 77,
+        "itemUsage": "long_bow",
+        "accuracy": 101,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 95,
+        "handling": 101,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -96980,22 +96533,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
+        "thrustSpeed": 101,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 91
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 77,
+        "itemUsage": "long_bow",
+        "accuracy": 101,
+        "missileSpeed": 86,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 95,
+        "handling": 101,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97006,25 +96559,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
+        "thrustSpeed": 101,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 91
       }
     ]
   },
   {
-    "id": "crpg_nomad_bow_REFUND_h1",
-    "baseId": "crpg_nomad_bow_REFUND",
-    "name": "Hassun Yumi +1",
-    "culture": "Aserai",
+    "id": "crpg_noble_ranger_bow_h1",
+    "baseId": "crpg_noble_ranger_bow",
+    "name": "Noble Ranger Bow +1",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 13992,
+    "price": 12868,
     "weight": 0.7,
     "rank": 1,
-    "tier": 9.997225,
+    "tier": 9.542654,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -97032,13 +96585,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 86,
+        "itemUsage": "long_bow",
+        "accuracy": 103,
+        "missileSpeed": 88,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 97,
+        "handling": 102,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97048,22 +96601,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
+        "thrustSpeed": 102,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 94
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 110,
-        "missileSpeed": 86,
+        "itemUsage": "long_bow",
+        "accuracy": 103,
+        "missileSpeed": 88,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 97,
+        "handling": 102,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97074,25 +96627,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
+        "thrustSpeed": 102,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 94
       }
     ]
   },
   {
-    "id": "crpg_nomad_bow_REFUND_h2",
-    "baseId": "crpg_nomad_bow_REFUND",
-    "name": "Hassun Yumi +2",
-    "culture": "Aserai",
+    "id": "crpg_noble_ranger_bow_h2",
+    "baseId": "crpg_noble_ranger_bow",
+    "name": "Noble Ranger Bow +2",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 14717,
+    "price": 12303,
     "weight": 0.7,
     "rank": 2,
-    "tier": 10.2803669,
+    "tier": 9.306863,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -97100,13 +96653,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 113,
-        "missileSpeed": 86,
+        "itemUsage": "long_bow",
+        "accuracy": 105,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 101,
+        "handling": 104,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97116,22 +96669,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
+        "thrustSpeed": 104,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 95
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 113,
-        "missileSpeed": 86,
+        "itemUsage": "long_bow",
+        "accuracy": 105,
+        "missileSpeed": 90,
         "stackAmount": 1,
-        "length": 114,
+        "length": 115,
         "balance": 0.0,
-        "handling": 101,
+        "handling": 104,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97142,25 +96695,93 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 15,
+        "thrustDamage": 16,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
+        "thrustSpeed": 104,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 95
       }
     ]
   },
   {
-    "id": "crpg_nomad_bow_REFUND_h3",
-    "baseId": "crpg_nomad_bow_REFUND",
-    "name": "Hassun Yumi +3",
-    "culture": "Aserai",
+    "id": "crpg_noble_ranger_bow_h3",
+    "baseId": "crpg_noble_ranger_bow",
+    "name": "Noble Ranger Bow +3",
+    "culture": "Battania",
     "type": "Bow",
-    "price": 14587,
+    "price": 15925,
     "weight": 0.7,
     "rank": 3,
-    "tier": 10.23034,
+    "tier": 10.73801,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 105,
+        "missileSpeed": 90,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 104,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 104,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 95
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 105,
+        "missileSpeed": 90,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 104,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 104,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 95
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_short_bow_h0",
+    "baseId": "crpg_noble_short_bow",
+    "name": "Noble Short Bow",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 13161,
+    "weight": 0.4,
+    "rank": 0,
+    "tier": 9.662995,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -97169,12 +96790,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 119,
-        "missileSpeed": 86,
+        "accuracy": 98,
+        "missileSpeed": 76,
         "stackAmount": 1,
-        "length": 114,
+        "length": 116,
         "balance": 0.0,
-        "handling": 101,
+        "handling": 100,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97186,20 +96807,20 @@
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
+        "thrustSpeed": 100,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 98
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 119,
-        "missileSpeed": 86,
+        "accuracy": 98,
+        "missileSpeed": 76,
         "stackAmount": 1,
-        "length": 114,
+        "length": 116,
         "balance": 0.0,
-        "handling": 101,
+        "handling": 100,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -97212,10 +96833,486 @@
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
+        "thrustSpeed": 100,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 98
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_short_bow_h1",
+    "baseId": "crpg_noble_short_bow",
+    "name": "Noble Short Bow +1",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 13421,
+    "weight": 0.4,
+    "rank": 1,
+    "tier": 9.768493,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 98,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 98,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 102,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 102,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_short_bow_h2",
+    "baseId": "crpg_noble_short_bow",
+    "name": "Noble Short Bow +2",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 14214,
+    "weight": 0.4,
+    "rank": 2,
+    "tier": 10.0844784,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 101,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 101,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_short_bow_h3",
+    "baseId": "crpg_noble_short_bow",
+    "name": "Noble Short Bow +3",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 14553,
+    "weight": 0.4,
+    "rank": 3,
+    "tier": 10.2168379,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 107,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 107,
+        "missileSpeed": 85,
+        "stackAmount": 1,
+        "length": 116,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 101
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_steppe_bow_h0",
+    "baseId": "crpg_noble_steppe_bow",
+    "name": "Noble Steppe Bow",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 13402,
+    "weight": 0.35,
+    "rank": 0,
+    "tier": 9.761091,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 74,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 121,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 121,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 74,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 121,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 121,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_steppe_bow_h1",
+    "baseId": "crpg_noble_steppe_bow",
+    "name": "Noble Steppe Bow +1",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 13618,
+    "weight": 0.35,
+    "rank": 1,
+    "tier": 9.847792,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 123,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 123,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 110,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 123,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 123,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_steppe_bow_h2",
+    "baseId": "crpg_noble_steppe_bow",
+    "name": "Noble Steppe Bow +2",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 13684,
+    "weight": 0.35,
+    "rank": 2,
+    "tier": 9.874495,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 113,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 113,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
+      }
+    ]
+  },
+  {
+    "id": "crpg_noble_steppe_bow_h3",
+    "baseId": "crpg_noble_steppe_bow",
+    "name": "Noble Steppe Bow +3",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 13564,
+    "weight": 0.35,
+    "rank": 3,
+    "tier": 9.826441,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 119,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 119,
+        "missileSpeed": 83,
+        "stackAmount": 1,
+        "length": 108,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 86
       }
     ]
   },
@@ -98168,9 +98265,9 @@
     "weapons": []
   },
   {
-    "id": "crpg_nordic_shortbow_REFUND_h0",
-    "baseId": "crpg_nordic_shortbow_REFUND",
-    "name": "Nordic Shortbow",
+    "id": "crpg_nordic_short_bow_h0",
+    "baseId": "crpg_nordic_short_bow",
+    "name": "Nordic Short Bow",
     "culture": "Sturgia",
     "type": "Bow",
     "price": 11818,
@@ -98236,9 +98333,9 @@
     ]
   },
   {
-    "id": "crpg_nordic_shortbow_REFUND_h1",
-    "baseId": "crpg_nordic_shortbow_REFUND",
-    "name": "Nordic Shortbow +1",
+    "id": "crpg_nordic_short_bow_h1",
+    "baseId": "crpg_nordic_short_bow",
+    "name": "Nordic Short Bow +1",
     "culture": "Sturgia",
     "type": "Bow",
     "price": 12025,
@@ -98304,9 +98401,9 @@
     ]
   },
   {
-    "id": "crpg_nordic_shortbow_REFUND_h2",
-    "baseId": "crpg_nordic_shortbow_REFUND",
-    "name": "Nordic Shortbow +2",
+    "id": "crpg_nordic_short_bow_h2",
+    "baseId": "crpg_nordic_short_bow",
+    "name": "Nordic Short Bow +2",
     "culture": "Sturgia",
     "type": "Bow",
     "price": 12210,
@@ -98372,9 +98469,9 @@
     ]
   },
   {
-    "id": "crpg_nordic_shortbow_REFUND_h3",
-    "baseId": "crpg_nordic_shortbow_REFUND",
-    "name": "Nordic Shortbow +3",
+    "id": "crpg_nordic_short_bow_h3",
+    "baseId": "crpg_nordic_short_bow",
+    "name": "Nordic Short Bow +3",
     "culture": "Sturgia",
     "type": "Bow",
     "price": 11816,
@@ -105578,8 +105675,8 @@
     ]
   },
   {
-    "id": "crpg_piercing_arrows_h0",
-    "baseId": "crpg_piercing_arrows",
+    "id": "crpg_piercing_arrows_v1_h0",
+    "baseId": "crpg_piercing_arrows_v1",
     "name": "Piercing Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -105613,8 +105710,8 @@
     ]
   },
   {
-    "id": "crpg_piercing_arrows_h1",
-    "baseId": "crpg_piercing_arrows",
+    "id": "crpg_piercing_arrows_v1_h1",
+    "baseId": "crpg_piercing_arrows_v1",
     "name": "Piercing Arrows +1",
     "culture": "Neutral",
     "type": "Arrows",
@@ -105648,8 +105745,8 @@
     ]
   },
   {
-    "id": "crpg_piercing_arrows_h2",
-    "baseId": "crpg_piercing_arrows",
+    "id": "crpg_piercing_arrows_v1_h2",
+    "baseId": "crpg_piercing_arrows_v1",
     "name": "Piercing Arrows +2",
     "culture": "Neutral",
     "type": "Arrows",
@@ -105683,8 +105780,8 @@
     ]
   },
   {
-    "id": "crpg_piercing_arrows_h3",
-    "baseId": "crpg_piercing_arrows",
+    "id": "crpg_piercing_arrows_v1_h3",
+    "baseId": "crpg_piercing_arrows_v1",
     "name": "Piercing Arrows +3",
     "culture": "Neutral",
     "type": "Arrows",
@@ -109516,8 +109613,8 @@
     ]
   },
   {
-    "id": "crpg_range_arrows_h0",
-    "baseId": "crpg_range_arrows",
+    "id": "crpg_range_arrows_v1_h0",
+    "baseId": "crpg_range_arrows_v1",
     "name": "Range Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -109551,8 +109648,8 @@
     ]
   },
   {
-    "id": "crpg_range_arrows_h1",
-    "baseId": "crpg_range_arrows",
+    "id": "crpg_range_arrows_v1_h1",
+    "baseId": "crpg_range_arrows_v1",
     "name": "Range Arrows +1",
     "culture": "Neutral",
     "type": "Arrows",
@@ -109586,8 +109683,8 @@
     ]
   },
   {
-    "id": "crpg_range_arrows_h2",
-    "baseId": "crpg_range_arrows",
+    "id": "crpg_range_arrows_v1_h2",
+    "baseId": "crpg_range_arrows_v1",
     "name": "Range Arrows +2",
     "culture": "Neutral",
     "type": "Arrows",
@@ -109621,8 +109718,8 @@
     ]
   },
   {
-    "id": "crpg_range_arrows_h3",
-    "baseId": "crpg_range_arrows",
+    "id": "crpg_range_arrows_v1_h3",
+    "baseId": "crpg_range_arrows_v1",
     "name": "Range Arrows +3",
     "culture": "Neutral",
     "type": "Arrows",
@@ -109750,6 +109847,146 @@
       "familyType": 0
     },
     "weapons": []
+  },
+  {
+    "id": "crpg_rangers_arrows_h0",
+    "baseId": "crpg_rangers_arrows",
+    "name": "Rangers Arrows",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3868,
+    "weight": 0.05,
+    "rank": 0,
+    "tier": 9.18616,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 20,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 4,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_rangers_arrows_h1",
+    "baseId": "crpg_rangers_arrows",
+    "name": "Rangers Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3365,
+    "weight": 0.05,
+    "rank": 1,
+    "tier": 8.48998451,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 23,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 4,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_rangers_arrows_h2",
+    "baseId": "crpg_rangers_arrows",
+    "name": "Rangers Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 2946,
+    "weight": 0.05,
+    "rank": 2,
+    "tier": 7.8691206,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 26,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 4,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_rangers_arrows_h3",
+    "baseId": "crpg_rangers_arrows",
+    "name": "Rangers Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3610,
+    "weight": 0.05,
+    "rank": 3,
+    "tier": 8.835987,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_top",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 26,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
   },
   {
     "id": "crpg_rangers_flag_t2",
@@ -112368,6 +112605,278 @@
       "familyType": 0
     },
     "weapons": []
+  },
+  {
+    "id": "crpg_rokusun_yumi_h0",
+    "baseId": "crpg_rokusun_yumi",
+    "name": "Rokusun Yumi",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 7542,
+    "weight": 0.6,
+    "rank": 0,
+    "tier": 7.055585,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 72
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 72
+      }
+    ]
+  },
+  {
+    "id": "crpg_rokusun_yumi_h1",
+    "baseId": "crpg_rokusun_yumi",
+    "name": "Rokusun Yumi +1",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 7788,
+    "weight": 0.6,
+    "rank": 1,
+    "tier": 7.18687963,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 120,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 105,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 105,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      }
+    ]
+  },
+  {
+    "id": "crpg_rokusun_yumi_h2",
+    "baseId": "crpg_rokusun_yumi",
+    "name": "Rokusun Yumi +2",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 7956,
+    "weight": 0.6,
+    "rank": 2,
+    "tier": 7.275222,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 123,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 123,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      }
+    ]
+  },
+  {
+    "id": "crpg_rokusun_yumi_h3",
+    "baseId": "crpg_rokusun_yumi",
+    "name": "Rokusun Yumi +3",
+    "culture": "Aserai",
+    "type": "Bow",
+    "price": 7721,
+    "weight": 0.6,
+    "rank": 3,
+    "tier": 7.151152,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 129,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 129,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 115,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 75
+      }
+    ]
   },
   {
     "id": "crpg_roningasa_v1_h0",
@@ -120834,6 +121343,278 @@
     ]
   },
   {
+    "id": "crpg_simple_long_bow_h0",
+    "baseId": "crpg_simple_long_bow",
+    "name": "Simple Long Bow",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 3488,
+    "weight": 0.45,
+    "rank": 0,
+    "tier": 4.468853,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 112,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 88,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 90
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 112,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 88,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 90
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_long_bow_h1",
+    "baseId": "crpg_simple_long_bow",
+    "name": "Simple Long Bow +1",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 3229,
+    "weight": 0.45,
+    "rank": 1,
+    "tier": 4.262385,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 114,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 89,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 89,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 114,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 89,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 89,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_long_bow_h2",
+    "baseId": "crpg_simple_long_bow",
+    "name": "Simple Long Bow +2",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 3119,
+    "weight": 0.45,
+    "rank": 2,
+    "tier": 4.17175055,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 116,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 91,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 94
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 116,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 91,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 14,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 94
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_long_bow_h3",
+    "baseId": "crpg_simple_long_bow",
+    "name": "Simple Long Bow +3",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 4223,
+    "weight": 0.45,
+    "rank": 3,
+    "tier": 5.01892,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 116,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 91,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 94
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 116,
+        "missileSpeed": 88,
+        "stackAmount": 1,
+        "length": 111,
+        "balance": 0.0,
+        "handling": 91,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 91,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 94
+      }
+    ]
+  },
+  {
     "id": "crpg_simple_pike_h0",
     "baseId": "crpg_simple_pike",
     "name": "Simple Pike",
@@ -121246,6 +122027,278 @@
         "swingDamage": 41,
         "swingDamageType": "Cut",
         "swingSpeed": 82
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_ranger_bow_h0",
+    "baseId": "crpg_simple_ranger_bow",
+    "name": "Simple Ranger Bow",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 4340,
+    "weight": 0.5,
+    "rank": 0,
+    "tier": 5.10214567,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 103,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 103,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 93
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_ranger_bow_h1",
+    "baseId": "crpg_simple_ranger_bow",
+    "name": "Simple Ranger Bow +1",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 3933,
+    "weight": 0.5,
+    "rank": 1,
+    "tier": 4.807947,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 132,
+        "missileSpeed": 82,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 104,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 104,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 132,
+        "missileSpeed": 82,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 104,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 104,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 96
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_ranger_bow_h2",
+    "baseId": "crpg_simple_ranger_bow",
+    "name": "Simple Ranger Bow +2",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 3699,
+    "weight": 0.5,
+    "rank": 2,
+    "tier": 4.631895,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 134,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 97
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 134,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 12,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 97
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_ranger_bow_h3",
+    "baseId": "crpg_simple_ranger_bow",
+    "name": "Simple Ranger Bow +3",
+    "culture": "Battania",
+    "type": "Bow",
+    "price": 5526,
+    "weight": 0.5,
+    "rank": 3,
+    "tier": 5.88904858,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 134,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 97
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "long_bow",
+        "accuracy": 134,
+        "missileSpeed": 84,
+        "stackAmount": 1,
+        "length": 113,
+        "balance": 0.0,
+        "handling": 106,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 106,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 97
       }
     ]
   },
@@ -122018,6 +123071,278 @@
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 91
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_steppe_bow_h0",
+    "baseId": "crpg_simple_steppe_bow",
+    "name": "Simple Steppe Bow",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 3790,
+    "weight": 0.25,
+    "rank": 0,
+    "tier": 4.70083427,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 71,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 125,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 125,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 85
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 71,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 125,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 125,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 85
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_steppe_bow_h1",
+    "baseId": "crpg_simple_steppe_bow",
+    "name": "Simple Steppe Bow +1",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 3859,
+    "weight": 0.25,
+    "rank": 1,
+    "tier": 4.75298071,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 127,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 127,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_steppe_bow_h2",
+    "baseId": "crpg_simple_steppe_bow",
+    "name": "Simple Steppe Bow +2",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 3780,
+    "weight": 0.25,
+    "rank": 2,
+    "tier": 4.693713,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 131,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 131,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 131,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 131,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
+      }
+    ]
+  },
+  {
+    "id": "crpg_simple_steppe_bow_h3",
+    "baseId": "crpg_simple_steppe_bow",
+    "name": "Simple Steppe Bow +3",
+    "culture": "Khuzait",
+    "type": "Bow",
+    "price": 3612,
+    "weight": 0.25,
+    "rank": 3,
+    "tier": 4.56543255,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 131,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 131,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 80,
+        "stackAmount": 1,
+        "length": 110,
+        "balance": 0.0,
+        "handling": 131,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 10,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 131,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 88
       }
     ]
   },
@@ -126022,6 +127347,286 @@
     ]
   },
   {
+    "id": "crpg_stacked_bodkin_arrows_h0",
+    "baseId": "crpg_stacked_bodkin_arrows",
+    "name": "Stacked Bodkin Arrows",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3825,
+    "weight": 0.048,
+    "rank": 0,
+    "tier": 9.12912,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 22,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_bodkin_arrows_h1",
+    "baseId": "crpg_stacked_bodkin_arrows",
+    "name": "Stacked Bodkin Arrows +1",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3648,
+    "weight": 0.048,
+    "rank": 1,
+    "tier": 8.887842,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 27,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_bodkin_arrows_h2",
+    "baseId": "crpg_stacked_bodkin_arrows",
+    "name": "Stacked Bodkin Arrows +2",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 3262,
+    "weight": 0.048,
+    "rank": 2,
+    "tier": 8.340988,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 31,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 2,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_bodkin_arrows_h3",
+    "baseId": "crpg_stacked_bodkin_arrows",
+    "name": "Stacked Bodkin Arrows +3",
+    "culture": "Neutral",
+    "type": "Arrows",
+    "price": 4331,
+    "weight": 0.048,
+    "rank": 3,
+    "tier": 9.789079,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 31,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 3,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_steppe_arrows_h0",
+    "baseId": "crpg_stacked_steppe_arrows",
+    "name": "Stacked Steppe Arrows",
+    "culture": "Khuzait",
+    "type": "Arrows",
+    "price": 4457,
+    "weight": 0.036,
+    "rank": 0,
+    "tier": 9.946981,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 32,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 3,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_steppe_arrows_h1",
+    "baseId": "crpg_stacked_steppe_arrows",
+    "name": "Stacked Steppe Arrows +1",
+    "culture": "Khuzait",
+    "type": "Arrows",
+    "price": 3903,
+    "weight": 0.036,
+    "rank": 1,
+    "tier": 9.233096,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 37,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 3,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_steppe_arrows_h2",
+    "baseId": "crpg_stacked_steppe_arrows",
+    "name": "Stacked Steppe Arrows +2",
+    "culture": "Khuzait",
+    "type": "Arrows",
+    "price": 3432,
+    "weight": 0.036,
+    "rank": 2,
+    "tier": 8.586344,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 42,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 3,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
+    "id": "crpg_stacked_steppe_arrows_h3",
+    "baseId": "crpg_stacked_steppe_arrows",
+    "name": "Stacked Steppe Arrows +3",
+    "culture": "Khuzait",
+    "type": "Arrows",
+    "price": 4372,
+    "weight": 0.036,
+    "rank": 3,
+    "tier": 9.840629,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "Arrow",
+        "itemUsage": "arrow_right",
+        "accuracy": 100,
+        "missileSpeed": 10,
+        "stackAmount": 42,
+        "length": 97,
+        "balance": 0.0,
+        "handling": 0,
+        "bodyArmor": 0,
+        "flags": [
+          "Consumable"
+        ],
+        "thrustDamage": 4,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 0,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 0
+      }
+    ]
+  },
+  {
     "id": "crpg_standard_of_courage_t2",
     "baseId": "crpg_standard_of_courage",
     "name": "Standard of Courage",
@@ -127964,8 +129569,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_steppe_arrows_h0",
-    "baseId": "crpg_steppe_arrows",
+    "id": "crpg_steppe_arrows_v1_h0",
+    "baseId": "crpg_steppe_arrows_v1",
     "name": "Steppe Arrows",
     "culture": "Khuzait",
     "type": "Arrows",
@@ -127999,8 +129604,8 @@
     ]
   },
   {
-    "id": "crpg_steppe_arrows_h1",
-    "baseId": "crpg_steppe_arrows",
+    "id": "crpg_steppe_arrows_v1_h1",
+    "baseId": "crpg_steppe_arrows_v1",
     "name": "Steppe Arrows +1",
     "culture": "Khuzait",
     "type": "Arrows",
@@ -128034,8 +129639,8 @@
     ]
   },
   {
-    "id": "crpg_steppe_arrows_h2",
-    "baseId": "crpg_steppe_arrows",
+    "id": "crpg_steppe_arrows_v1_h2",
+    "baseId": "crpg_steppe_arrows_v1",
     "name": "Steppe Arrows +2",
     "culture": "Khuzait",
     "type": "Arrows",
@@ -128069,8 +129674,8 @@
     ]
   },
   {
-    "id": "crpg_steppe_arrows_h3",
-    "baseId": "crpg_steppe_arrows",
+    "id": "crpg_steppe_arrows_v1_h3",
+    "baseId": "crpg_steppe_arrows_v1",
     "name": "Steppe Arrows +3",
     "culture": "Khuzait",
     "type": "Arrows",
@@ -128104,15 +129709,15 @@
     ]
   },
   {
-    "id": "crpg_steppe_bow_REFUND_h0",
-    "baseId": "crpg_steppe_bow_REFUND",
+    "id": "crpg_steppe_bow_h0",
+    "baseId": "crpg_steppe_bow",
     "name": "Steppe Bow",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2517,
+    "price": 5767,
     "weight": 0.25,
     "rank": 0,
-    "tier": 3.64780045,
+    "tier": 6.03846025,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -128121,12 +129726,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 128,
+        "accuracy": 120,
         "missileSpeed": 72,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 118,
+        "handling": 125,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128136,22 +129741,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 118,
+        "thrustSpeed": 125,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 85
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 128,
+        "accuracy": 120,
         "missileSpeed": 72,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 118,
+        "handling": 125,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128162,25 +129767,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 118,
+        "thrustSpeed": 125,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 81
+        "swingSpeed": 85
       }
     ]
   },
   {
-    "id": "crpg_steppe_bow_REFUND_h1",
-    "baseId": "crpg_steppe_bow_REFUND",
+    "id": "crpg_steppe_bow_h1",
+    "baseId": "crpg_steppe_bow",
     "name": "Steppe Bow +1",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2573,
+    "price": 5861,
     "weight": 0.25,
     "rank": 1,
-    "tier": 3.69904947,
+    "tier": 6.09590435,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -128189,12 +129794,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 128,
+        "accuracy": 120,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 120,
+        "handling": 127,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128204,22 +129809,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 120,
+        "thrustSpeed": 127,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 128,
+        "accuracy": 120,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 120,
+        "handling": 127,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128230,25 +129835,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 120,
+        "thrustSpeed": 127,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_steppe_bow_REFUND_h2",
-    "baseId": "crpg_steppe_bow_REFUND",
+    "id": "crpg_steppe_bow_h2",
+    "baseId": "crpg_steppe_bow",
     "name": "Steppe Bow +2",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2548,
+    "price": 5793,
     "weight": 0.25,
     "rank": 2,
-    "tier": 3.6763618,
+    "tier": 6.053902,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -128257,12 +129862,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 131,
+        "accuracy": 123,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 124,
+        "handling": 131,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128272,22 +129877,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
+        "thrustSpeed": 131,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 131,
+        "accuracy": 123,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 124,
+        "handling": 131,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128298,25 +129903,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
+        "thrustSpeed": 131,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_steppe_bow_REFUND_h3",
-    "baseId": "crpg_steppe_bow_REFUND",
+    "id": "crpg_steppe_bow_h3",
+    "baseId": "crpg_steppe_bow",
     "name": "Steppe Bow +3",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2447,
+    "price": 5625,
     "weight": 0.25,
     "rank": 3,
-    "tier": 3.58295965,
+    "tier": 5.95065975,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -128325,12 +129930,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 137,
+        "accuracy": 129,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 124,
+        "handling": 131,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128340,22 +129945,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
+        "thrustSpeed": 131,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 137,
+        "accuracy": 129,
         "missileSpeed": 81,
         "stackAmount": 1,
         "length": 110,
         "balance": 0.0,
-        "handling": 124,
+        "handling": 131,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -128366,12 +129971,12 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
+        "thrustSpeed": 131,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 84
+        "swingSpeed": 88
       }
     ]
   },
@@ -128898,278 +130503,6 @@
       "familyType": 1
     },
     "weapons": []
-  },
-  {
-    "id": "crpg_steppe_heavy_bow_REFUND_h0",
-    "baseId": "crpg_steppe_heavy_bow_REFUND",
-    "name": "Light Recurve Bow",
-    "culture": "Khuzait",
-    "type": "Bow",
-    "price": 7624,
-    "weight": 0.3,
-    "rank": 0,
-    "tier": 7.099331,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 128,
-        "missileSpeed": 79,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 122,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 122,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 130
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 128,
-        "missileSpeed": 79,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 122,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 122,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 130
-      }
-    ]
-  },
-  {
-    "id": "crpg_steppe_heavy_bow_REFUND_h1",
-    "baseId": "crpg_steppe_heavy_bow_REFUND",
-    "name": "Light Recurve Bow +1",
-    "culture": "Khuzait",
-    "type": "Bow",
-    "price": 7478,
-    "weight": 0.3,
-    "rank": 1,
-    "tier": 7.02071762,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 128,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 124,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 128,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 124,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 124,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      }
-    ]
-  },
-  {
-    "id": "crpg_steppe_heavy_bow_REFUND_h2",
-    "baseId": "crpg_steppe_heavy_bow_REFUND",
-    "name": "Light Recurve Bow +2",
-    "culture": "Khuzait",
-    "type": "Bow",
-    "price": 7358,
-    "weight": 0.3,
-    "rank": 2,
-    "tier": 6.95589733,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 128,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 128,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 128,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 128,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      }
-    ]
-  },
-  {
-    "id": "crpg_steppe_heavy_bow_REFUND_h3",
-    "baseId": "crpg_steppe_heavy_bow_REFUND",
-    "name": "Light Recurve Bow +3",
-    "culture": "Khuzait",
-    "type": "Bow",
-    "price": 7037,
-    "weight": 0.3,
-    "rank": 3,
-    "tier": 6.77917576,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 137,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 128,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 128,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 137,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 128,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 10,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 128,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 133
-      }
-    ]
   },
   {
     "id": "crpg_steppe_helmet_v1_h0",
@@ -129780,15 +131113,15 @@
     "weapons": []
   },
   {
-    "id": "crpg_steppe_war_bow_REFUND_h0",
-    "baseId": "crpg_steppe_war_bow_REFUND",
+    "id": "crpg_steppe_war_bow_h0",
+    "baseId": "crpg_steppe_war_bow",
     "name": "Steppe War Bow",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2365,
+    "price": 9069,
     "weight": 0.35,
     "rank": 0,
-    "tier": 3.505448,
+    "tier": 7.838895,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -129797,12 +131130,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 74,
+        "accuracy": 115,
+        "missileSpeed": 73,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 102,
+        "handling": 123,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129814,20 +131147,20 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
+        "thrustSpeed": 123,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 105
+        "swingSpeed": 84
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 74,
+        "accuracy": 115,
+        "missileSpeed": 73,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 102,
+        "handling": 123,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129840,23 +131173,23 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
+        "thrustSpeed": 123,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 105
+        "swingSpeed": 84
       }
     ]
   },
   {
-    "id": "crpg_steppe_war_bow_REFUND_h1",
-    "baseId": "crpg_steppe_war_bow_REFUND",
+    "id": "crpg_steppe_war_bow_h1",
+    "baseId": "crpg_steppe_war_bow",
     "name": "Steppe War Bow +1",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2404,
+    "price": 9216,
     "weight": 0.35,
     "rank": 1,
-    "tier": 3.54273367,
+    "tier": 7.910704,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -129865,12 +131198,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 83,
+        "accuracy": 115,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 104,
+        "handling": 125,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129882,20 +131215,20 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
+        "thrustSpeed": 125,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 98,
-        "missileSpeed": 83,
+        "accuracy": 115,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 104,
+        "handling": 125,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129908,23 +131241,23 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
+        "thrustSpeed": 125,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       }
     ]
   },
   {
-    "id": "crpg_steppe_war_bow_REFUND_h2",
-    "baseId": "crpg_steppe_war_bow_REFUND",
+    "id": "crpg_steppe_war_bow_h2",
+    "baseId": "crpg_steppe_war_bow",
     "name": "Steppe War Bow +2",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2519,
+    "price": 9179,
     "weight": 0.35,
     "rank": 2,
-    "tier": 3.64937544,
+    "tier": 7.89277029,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -129933,12 +131266,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 83,
+        "accuracy": 118,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 108,
+        "handling": 129,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129950,20 +131283,20 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 108,
+        "thrustSpeed": 129,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 101,
-        "missileSpeed": 83,
+        "accuracy": 118,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 108,
+        "handling": 129,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -129976,23 +131309,23 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 108,
+        "thrustSpeed": 129,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       }
     ]
   },
   {
-    "id": "crpg_steppe_war_bow_REFUND_h3",
-    "baseId": "crpg_steppe_war_bow_REFUND",
+    "id": "crpg_steppe_war_bow_h3",
+    "baseId": "crpg_steppe_war_bow",
     "name": "Steppe War Bow +3",
     "culture": "Khuzait",
     "type": "Bow",
-    "price": 2571,
+    "price": 8998,
     "weight": 0.35,
     "rank": 3,
-    "tier": 3.69727373,
+    "tier": 7.804128,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -130001,12 +131334,12 @@
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 83,
+        "accuracy": 124,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 108,
+        "handling": 129,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -130018,20 +131351,20 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 108,
+        "thrustSpeed": 129,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       },
       {
         "class": "Bow",
         "itemUsage": "bow",
-        "accuracy": 107,
-        "missileSpeed": 83,
+        "accuracy": 124,
+        "missileSpeed": 82,
         "stackAmount": 1,
         "length": 107,
         "balance": 0.0,
-        "handling": 108,
+        "handling": 129,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -130044,10 +131377,10 @@
         ],
         "thrustDamage": 12,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 108,
+        "thrustSpeed": 129,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 108
+        "swingSpeed": 87
       }
     ]
   },
@@ -131120,8 +132453,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_strong_tribal_long_bow_REFUND_h0",
-    "baseId": "crpg_strong_tribal_long_bow_REFUND",
+    "id": "crpg_strong_tribal_long_bow_h0",
+    "baseId": "crpg_strong_tribal_long_bow",
     "name": "Strong Tribal Long Bow",
     "culture": "Aserai",
     "type": "Bow",
@@ -131188,8 +132521,8 @@
     ]
   },
   {
-    "id": "crpg_strong_tribal_long_bow_REFUND_h1",
-    "baseId": "crpg_strong_tribal_long_bow_REFUND",
+    "id": "crpg_strong_tribal_long_bow_h1",
+    "baseId": "crpg_strong_tribal_long_bow",
     "name": "Strong Tribal Long Bow +1",
     "culture": "Aserai",
     "type": "Bow",
@@ -131256,8 +132589,8 @@
     ]
   },
   {
-    "id": "crpg_strong_tribal_long_bow_REFUND_h2",
-    "baseId": "crpg_strong_tribal_long_bow_REFUND",
+    "id": "crpg_strong_tribal_long_bow_h2",
+    "baseId": "crpg_strong_tribal_long_bow",
     "name": "Strong Tribal Long Bow +2",
     "culture": "Aserai",
     "type": "Bow",
@@ -131324,8 +132657,8 @@
     ]
   },
   {
-    "id": "crpg_strong_tribal_long_bow_REFUND_h3",
-    "baseId": "crpg_strong_tribal_long_bow_REFUND",
+    "id": "crpg_strong_tribal_long_bow_h3",
+    "baseId": "crpg_strong_tribal_long_bow",
     "name": "Strong Tribal Long Bow +3",
     "culture": "Aserai",
     "type": "Bow",
@@ -140356,8 +141689,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_tournament_arrows_h0",
-    "baseId": "crpg_tournament_arrows",
+    "id": "crpg_tournament_arrows_v1_h0",
+    "baseId": "crpg_tournament_arrows_v1",
     "name": "Tournament Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -140391,8 +141724,8 @@
     ]
   },
   {
-    "id": "crpg_tournament_arrows_h1",
-    "baseId": "crpg_tournament_arrows",
+    "id": "crpg_tournament_arrows_v1_h1",
+    "baseId": "crpg_tournament_arrows_v1",
     "name": "Tournament Arrows +1",
     "culture": "Neutral",
     "type": "Arrows",
@@ -140426,8 +141759,8 @@
     ]
   },
   {
-    "id": "crpg_tournament_arrows_h2",
-    "baseId": "crpg_tournament_arrows",
+    "id": "crpg_tournament_arrows_v1_h2",
+    "baseId": "crpg_tournament_arrows_v1",
     "name": "Tournament Arrows +2",
     "culture": "Neutral",
     "type": "Arrows",
@@ -140461,8 +141794,8 @@
     ]
   },
   {
-    "id": "crpg_tournament_arrows_h3",
-    "baseId": "crpg_tournament_arrows",
+    "id": "crpg_tournament_arrows_v1_h3",
+    "baseId": "crpg_tournament_arrows_v1",
     "name": "Tournament Arrows +3",
     "culture": "Neutral",
     "type": "Arrows",
@@ -140592,15 +141925,287 @@
     "weapons": []
   },
   {
-    "id": "crpg_training_bow_REFUND_h0",
-    "baseId": "crpg_training_bow_REFUND",
+    "id": "crpg_training_bow_h0",
+    "baseId": "crpg_training_bow",
+    "name": "Stick with a String",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 85,
+    "weight": 0.15,
+    "rank": 0,
+    "tier": 0.129214928,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 60,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 120,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 120,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 100
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 60,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 120,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 120,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 100
+      }
+    ]
+  },
+  {
+    "id": "crpg_training_bow_h1",
+    "baseId": "crpg_training_bow",
+    "name": "Stick with a String +1",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 87,
+    "weight": 0.15,
+    "rank": 1,
+    "tier": 0.132922381,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 122,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 122,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 122,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 122,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      }
+    ]
+  },
+  {
+    "id": "crpg_training_bow_h2",
+    "baseId": "crpg_training_bow",
+    "name": "Stick with a String +2",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 86,
+    "weight": 0.15,
+    "rank": 2,
+    "tier": 0.131758317,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 126,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 126,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 126,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 126,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      }
+    ]
+  },
+  {
+    "id": "crpg_training_bow_h3",
+    "baseId": "crpg_training_bow",
+    "name": "Stick with a String +3",
+    "culture": "Neutral",
+    "type": "Bow",
+    "price": 85,
+    "weight": 0.15,
+    "rank": 3,
+    "tier": 0.128157318,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 126,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 126,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 69,
+        "stackAmount": 1,
+        "length": 106,
+        "balance": 0.0,
+        "handling": 126,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 5,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 126,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 103
+      }
+    ]
+  },
+  {
+    "id": "crpg_training_longbow_h0",
+    "baseId": "crpg_training_longbow",
     "name": "Practice Bow",
-    "culture": "Neutral",
+    "culture": "Vlandia",
     "type": "Bow",
-    "price": 397,
-    "weight": 0.15,
+    "price": 556,
+    "weight": 0.5,
     "rank": 0,
-    "tier": 0.9398532,
+    "tier": 1.25025451,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -140608,13 +142213,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 85,
+        "itemUsage": "long_bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 115,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140624,22 +142229,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 115,
+        "thrustSpeed": 90,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 106
+        "swingSpeed": 85
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 85,
+        "itemUsage": "long_bow",
+        "accuracy": 130,
+        "missileSpeed": 80,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 115,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140650,25 +142255,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 115,
+        "thrustSpeed": 90,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 106
+        "swingSpeed": 85
       }
     ]
   },
   {
-    "id": "crpg_training_bow_REFUND_h1",
-    "baseId": "crpg_training_bow_REFUND",
+    "id": "crpg_training_longbow_h1",
+    "baseId": "crpg_training_longbow",
     "name": "Practice Bow +1",
-    "culture": "Neutral",
+    "culture": "Vlandia",
     "type": "Bow",
-    "price": 393,
-    "weight": 0.15,
+    "price": 522,
+    "weight": 0.5,
     "rank": 1,
-    "tier": 0.930182457,
+    "tier": 1.18655849,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -140676,13 +142281,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 94,
+        "itemUsage": "long_bow",
+        "accuracy": 132,
+        "missileSpeed": 82,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 117,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140692,22 +142297,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 117,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 88
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 131,
-        "missileSpeed": 94,
+        "itemUsage": "long_bow",
+        "accuracy": 132,
+        "missileSpeed": 82,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 117,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140718,25 +142323,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 117,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_training_bow_REFUND_h2",
-    "baseId": "crpg_training_bow_REFUND",
+    "id": "crpg_training_longbow_h2",
+    "baseId": "crpg_training_longbow",
     "name": "Practice Bow +2",
-    "culture": "Neutral",
+    "culture": "Vlandia",
     "type": "Bow",
-    "price": 391,
-    "weight": 0.15,
+    "price": 504,
+    "weight": 0.5,
     "rank": 2,
-    "tier": 0.9253162,
+    "tier": 1.15345848,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -140744,13 +142349,13 @@
     "weapons": [
       {
         "class": "Bow",
-        "itemUsage": "bow",
+        "itemUsage": "long_bow",
         "accuracy": 134,
-        "missileSpeed": 94,
+        "missileSpeed": 84,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140760,22 +142365,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 93,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 89
       },
       {
         "class": "Bow",
-        "itemUsage": "bow",
+        "itemUsage": "long_bow",
         "accuracy": 134,
-        "missileSpeed": 94,
+        "missileSpeed": 84,
         "stackAmount": 1,
-        "length": 106,
+        "length": 120,
         "balance": 0.0,
-        "handling": 121,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -140786,297 +142391,25 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 7,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
+        "thrustSpeed": 93,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 109
+        "swingSpeed": 89
       }
     ]
   },
   {
-    "id": "crpg_training_bow_REFUND_h3",
-    "baseId": "crpg_training_bow_REFUND",
+    "id": "crpg_training_longbow_h3",
+    "baseId": "crpg_training_longbow",
     "name": "Practice Bow +3",
-    "culture": "Neutral",
-    "type": "Bow",
-    "price": 378,
-    "weight": 0.15,
-    "rank": 3,
-    "tier": 0.899157345,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 140,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 121,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 7,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 109
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 140,
-        "missileSpeed": 94,
-        "stackAmount": 1,
-        "length": 106,
-        "balance": 0.0,
-        "handling": 121,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 7,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 121,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 109
-      }
-    ]
-  },
-  {
-    "id": "crpg_training_longbow_REFUND_h0",
-    "baseId": "crpg_training_longbow_REFUND",
-    "name": "Practice Longbow",
     "culture": "Vlandia",
     "type": "Bow",
-    "price": 980,
-    "weight": 0.5,
-    "rank": 0,
-    "tier": 1.92959785,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 95,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 92
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 115,
-        "missileSpeed": 87,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 95,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 95,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 92
-      }
-    ]
-  },
-  {
-    "id": "crpg_training_longbow_REFUND_h1",
-    "baseId": "crpg_training_longbow_REFUND",
-    "name": "Practice Longbow +1",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 912,
-    "weight": 0.5,
-    "rank": 1,
-    "tier": 1.8306061,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 117,
-        "missileSpeed": 89,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 96,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 117,
-        "missileSpeed": 89,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 96,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 96,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      }
-    ]
-  },
-  {
-    "id": "crpg_training_longbow_REFUND_h2",
-    "baseId": "crpg_training_longbow_REFUND",
-    "name": "Practice Longbow +2",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 877,
-    "weight": 0.5,
-    "rank": 2,
-    "tier": 1.77895355,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 119,
-        "missileSpeed": 91,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 96
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 119,
-        "missileSpeed": 91,
-        "stackAmount": 1,
-        "length": 120,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 11,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 96
-      }
-    ]
-  },
-  {
-    "id": "crpg_training_longbow_REFUND_h3",
-    "baseId": "crpg_training_longbow_REFUND",
-    "name": "Practice Longbow +3",
-    "culture": "Vlandia",
-    "type": "Bow",
-    "price": 1288,
+    "price": 751,
     "weight": 0.5,
     "rank": 3,
-    "tier": 2.34198046,
+    "tier": 1.58285546,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandPrimaryItemBone"
@@ -141085,12 +142418,12 @@
       {
         "class": "Bow",
         "itemUsage": "long_bow",
-        "accuracy": 119,
-        "missileSpeed": 91,
+        "accuracy": 134,
+        "missileSpeed": 84,
         "stackAmount": 1,
         "length": 120,
         "balance": 0.0,
-        "handling": 98,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -141100,22 +142433,22 @@
           "UnloadWhenSheathed",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
+        "thrustSpeed": 93,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 96
+        "swingSpeed": 89
       },
       {
         "class": "Bow",
         "itemUsage": "long_bow",
-        "accuracy": 119,
-        "missileSpeed": 91,
+        "accuracy": 134,
+        "missileSpeed": 84,
         "stackAmount": 1,
         "length": 120,
         "balance": 0.0,
-        "handling": 98,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -141126,12 +142459,12 @@
           "AutoReload",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 12,
+        "thrustDamage": 11,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
+        "thrustSpeed": 93,
         "swingDamage": 0,
         "swingDamageType": "Blunt",
-        "swingSpeed": 96
+        "swingSpeed": 89
       }
     ]
   },
@@ -141708,278 +143041,6 @@
         "swingDamage": 0,
         "swingDamageType": "Undefined",
         "swingSpeed": 34
-      }
-    ]
-  },
-  {
-    "id": "crpg_tribal_bow_REFUND_h0",
-    "baseId": "crpg_tribal_bow_REFUND",
-    "name": "Rokusun Yumi",
-    "culture": "Aserai",
-    "type": "Bow",
-    "price": 5048,
-    "weight": 0.6,
-    "rank": 0,
-    "tier": 5.582904,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 120,
-        "missileSpeed": 76,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 92,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 81
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 120,
-        "missileSpeed": 76,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 92,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 81
-      }
-    ]
-  },
-  {
-    "id": "crpg_tribal_bow_REFUND_h1",
-    "baseId": "crpg_tribal_bow_REFUND",
-    "name": "Rokusun Yumi +1",
-    "culture": "Aserai",
-    "type": "Bow",
-    "price": 5241,
-    "weight": 0.6,
-    "rank": 1,
-    "tier": 5.708138,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 120,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 94,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 120,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 94,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      }
-    ]
-  },
-  {
-    "id": "crpg_tribal_bow_REFUND_h2",
-    "baseId": "crpg_tribal_bow_REFUND",
-    "name": "Rokusun Yumi +2",
-    "culture": "Aserai",
-    "type": "Bow",
-    "price": 5469,
-    "weight": 0.6,
-    "rank": 2,
-    "tier": 5.85306835,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 123,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 123,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      }
-    ]
-  },
-  {
-    "id": "crpg_tribal_bow_REFUND_h3",
-    "baseId": "crpg_tribal_bow_REFUND",
-    "name": "Rokusun Yumi +3",
-    "culture": "Aserai",
-    "type": "Bow",
-    "price": 5312,
-    "weight": 0.6,
-    "rank": 3,
-    "tier": 5.75325,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 129,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "bow",
-        "accuracy": 129,
-        "missileSpeed": 85,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 98,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 13,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 98,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 84
       }
     ]
   },
@@ -146356,8 +147417,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_vlandic_arrows_h0",
-    "baseId": "crpg_vlandic_arrows",
+    "id": "crpg_vlandic_arrows_v2_h0",
+    "baseId": "crpg_vlandic_arrows_v2",
     "name": "Lowland Arrows",
     "culture": "Neutral",
     "type": "Arrows",
@@ -146382,111 +147443,6 @@
           "Consumable"
         ],
         "thrustDamage": 2,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandic_arrows_h1",
-    "baseId": "crpg_vlandic_arrows",
-    "name": "Lowland Arrows +1",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 3018,
-    "weight": 0.06,
-    "rank": 1,
-    "tier": 7.97891474,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_top",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 46,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandic_arrows_h2",
-    "baseId": "crpg_vlandic_arrows",
-    "name": "Lowland Arrows +2",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 2645,
-    "weight": 0.06,
-    "rank": 2,
-    "tier": 7.395425,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_top",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 52,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 2,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 0,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 0
-      }
-    ]
-  },
-  {
-    "id": "crpg_vlandic_arrows_h3",
-    "baseId": "crpg_vlandic_arrows",
-    "name": "Lowland Arrows +3",
-    "culture": "Neutral",
-    "type": "Arrows",
-    "price": 3498,
-    "weight": 0.06,
-    "rank": 3,
-    "tier": 8.679353,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "Arrow",
-        "itemUsage": "arrow_top",
-        "accuracy": 100,
-        "missileSpeed": 10,
-        "stackAmount": 52,
-        "length": 97,
-        "balance": 0.0,
-        "handling": 0,
-        "bodyArmor": 0,
-        "flags": [
-          "Consumable"
-        ],
-        "thrustDamage": 3,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 0,
         "swingDamage": 0,
@@ -150240,550 +151196,6 @@
     ]
   },
   {
-    "id": "crpg_woodland_longbow_REFUND_h0",
-    "baseId": "crpg_woodland_longbow_REFUND",
-    "name": "Woodland Longbow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 6090,
-    "weight": 0.7,
-    "rank": 0,
-    "tier": 6.233876,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 99,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 88,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 89
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 99,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 88,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 89
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_longbow_REFUND_h1",
-    "baseId": "crpg_woodland_longbow_REFUND",
-    "name": "Woodland Longbow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 5677,
-    "weight": 0.7,
-    "rank": 1,
-    "tier": 5.982888,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 101,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 92
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 101,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 89,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 92
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_longbow_REFUND_h2",
-    "baseId": "crpg_woodland_longbow_REFUND",
-    "name": "Woodland Longbow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 5527,
-    "weight": 0.7,
-    "rank": 2,
-    "tier": 5.889468,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 91,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 93
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 91,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 93
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_longbow_REFUND_h3",
-    "baseId": "crpg_woodland_longbow_REFUND",
-    "name": "Woodland Longbow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 7065,
-    "weight": 0.7,
-    "rank": 3,
-    "tier": 6.79511,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 91,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 93
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 92,
-        "stackAmount": 1,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 91,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 93
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_yew_bow_REFUND_h0",
-    "baseId": "crpg_woodland_yew_bow_REFUND",
-    "name": "Woodland Yew Bow",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 14000,
-    "weight": 0.7,
-    "rank": 0,
-    "tier": 10.0,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 101,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 101,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 91
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 101,
-        "missileSpeed": 86,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 101,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 91
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_yew_bow_REFUND_h1",
-    "baseId": "crpg_woodland_yew_bow_REFUND",
-    "name": "Woodland Yew Bow +1",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 12868,
-    "weight": 0.7,
-    "rank": 1,
-    "tier": 9.542654,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 94
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 103,
-        "missileSpeed": 88,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 102,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 102,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 94
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_yew_bow_REFUND_h2",
-    "baseId": "crpg_woodland_yew_bow_REFUND",
-    "name": "Woodland Yew Bow +2",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 12303,
-    "weight": 0.7,
-    "rank": 2,
-    "tier": 9.306863,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 105,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 104,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 105,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 104,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      }
-    ]
-  },
-  {
-    "id": "crpg_woodland_yew_bow_REFUND_h3",
-    "baseId": "crpg_woodland_yew_bow_REFUND",
-    "name": "Woodland Yew Bow +3",
-    "culture": "Battania",
-    "type": "Bow",
-    "price": 15925,
-    "weight": 0.7,
-    "rank": 3,
-    "tier": 10.73801,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandPrimaryItemBone"
-    ],
-    "weapons": [
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 105,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 104,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      },
-      {
-        "class": "Bow",
-        "itemUsage": "long_bow",
-        "accuracy": 105,
-        "missileSpeed": 90,
-        "stackAmount": 1,
-        "length": 115,
-        "balance": 0.0,
-        "handling": 104,
-        "bodyArmor": 0,
-        "flags": [
-          "RangedWeapon",
-          "NotUsableWithOneHand",
-          "HasString",
-          "StringHeldByHand",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 104,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 95
-      }
-    ]
-  },
-  {
     "id": "crpg_woodsman_two_handed_axe_h0",
     "baseId": "crpg_woodsman_two_handed_axe",
     "name": "Woodsman Two Handed Axe",
@@ -152928,6 +153340,278 @@
         "swingDamage": 40,
         "swingDamageType": "Cut",
         "swingSpeed": 98
+      }
+    ]
+  },
+  {
+    "id": "crpg_yonsun_yumi_h0",
+    "baseId": "crpg_yonsun_yumi",
+    "name": "Yonsun Yumi",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 3663,
+    "weight": 0.5,
+    "rank": 0,
+    "tier": 4.604545,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 107,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 107,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 76
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 77,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 107,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 107,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 76
+      }
+    ]
+  },
+  {
+    "id": "crpg_yonsun_yumi_h1",
+    "baseId": "crpg_yonsun_yumi",
+    "name": "Yonsun Yumi +1",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 3749,
+    "weight": 0.5,
+    "rank": 1,
+    "tier": 4.67036343,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 130,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 109,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 109,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
+      }
+    ]
+  },
+  {
+    "id": "crpg_yonsun_yumi_h2",
+    "baseId": "crpg_yonsun_yumi",
+    "name": "Yonsun Yumi +2",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 3765,
+    "weight": 0.5,
+    "rank": 2,
+    "tier": 4.682247,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 113,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 133,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 113,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
+      }
+    ]
+  },
+  {
+    "id": "crpg_yonsun_yumi_h3",
+    "baseId": "crpg_yonsun_yumi",
+    "name": "Yonsun Yumi +3",
+    "culture": "Vlandia",
+    "type": "Bow",
+    "price": 3597,
+    "weight": 0.5,
+    "rank": 3,
+    "tier": 4.554279,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandPrimaryItemBone"
+    ],
+    "weapons": [
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 113,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
+      },
+      {
+        "class": "Bow",
+        "itemUsage": "bow",
+        "accuracy": 139,
+        "missileSpeed": 86,
+        "stackAmount": 1,
+        "length": 120,
+        "balance": 0.0,
+        "handling": 113,
+        "bodyArmor": 0,
+        "flags": [
+          "RangedWeapon",
+          "NotUsableWithOneHand",
+          "HasString",
+          "StringHeldByHand",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 11,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 113,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 79
       }
     ]
   }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -1296,7 +1296,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_default_arrows_h0" name="{=gFtu0j4T}Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_arrows_h0" name="{=gFtu0j4T}Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="27" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1304,7 +1304,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_default_arrows_h1" name="{=gFtu0j4T}Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_arrows_h1" name="{=gFtu0j4T}Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="32" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1312,7 +1312,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_default_arrows_h2" name="{=gFtu0j4T}Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_arrows_h2" name="{=gFtu0j4T}Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="36" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1320,7 +1320,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_default_arrows_h3" name="{=gFtu0j4T}Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_arrows_h3" name="{=gFtu0j4T}Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="36" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1328,7 +1328,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_tournament_arrows_h0" name="{=bK03bqdA}Tournament Arrows" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_tournament_arrows_v1_h0" name="{=bK03bqdA}Tournament Arrows" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="30" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1336,7 +1336,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_tournament_arrows_h1" name="{=bK03bqdA}Tournament Arrows +1" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_tournament_arrows_v1_h1" name="{=bK03bqdA}Tournament Arrows +1" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="36" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1344,7 +1344,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_tournament_arrows_h2" name="{=bK03bqdA}Tournament Arrows +2" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_tournament_arrows_v1_h2" name="{=bK03bqdA}Tournament Arrows +2" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="0" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1352,7 +1352,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_tournament_arrows_h3" name="{=bK03bqdA}Tournament Arrows +3" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_tournament_arrows_v1_h3" name="{=bK03bqdA}Tournament Arrows +3" is_merchandise="false" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts:quiver_bolts_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1360,7 +1360,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_range_arrows_h0" name="{=Biq7t1xv}Range Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_range_arrows_v1_h0" name="{=Biq7t1xv}Range Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="27" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1368,7 +1368,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_range_arrows_h1" name="{=Biq7t1xv}Range Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_range_arrows_v1_h1" name="{=Biq7t1xv}Range Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="32" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1376,7 +1376,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_range_arrows_h2" name="{=Biq7t1xv}Range Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_range_arrows_v1_h2" name="{=Biq7t1xv}Range Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="36" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1384,7 +1384,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_range_arrows_h3" name="{=Biq7t1xv}Range Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_range_arrows_v1_h3" name="{=Biq7t1xv}Range Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_i" weight="0.043" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_i_quiver" holster_mesh_with_weapon="arrow_bl_i_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="36" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1392,7 +1392,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_barbed_arrows_h0" name="{=s7jkSgba}Barbed Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_barbed_arrows_v1_h0" name="{=s7jkSgba}Barbed Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1400,7 +1400,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_barbed_arrows_h1" name="{=s7jkSgba}Barbed Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_barbed_arrows_v1_h1" name="{=s7jkSgba}Barbed Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="23" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1408,7 +1408,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_barbed_arrows_h2" name="{=s7jkSgba}Barbed Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_barbed_arrows_v1_h2" name="{=s7jkSgba}Barbed Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="26" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1416,7 +1416,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_barbed_arrows_h3" name="{=s7jkSgba}Barbed Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_barbed_arrows_v1_h3" name="{=s7jkSgba}Barbed Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" weight="0.05" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_h_quiver" holster_mesh_with_weapon="arrow_bl_h_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="26" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1424,7 +1424,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_heavy_steppe_arrows_h0" name="{=NkV2c6YX}Stacked Steppe Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_stacked_steppe_arrows_h0" name="{=NkV2c6YX}Stacked Steppe Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="32" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0,00.05,-0.0" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1432,7 +1432,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_heavy_steppe_arrows_h1" name="{=NkV2c6YX}Stacked Steppe Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_stacked_steppe_arrows_h1" name="{=NkV2c6YX}Stacked Steppe Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="37" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0,00.05,-0.0" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1440,7 +1440,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_heavy_steppe_arrows_h2" name="{=NkV2c6YX}Stacked Steppe Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_stacked_steppe_arrows_h2" name="{=NkV2c6YX}Stacked Steppe Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0,00.05,-0.0" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1448,7 +1448,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_heavy_steppe_arrows_h3" name="{=NkV2c6YX}Stacked Steppe Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_stacked_steppe_arrows_h3" name="{=NkV2c6YX}Stacked Steppe Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_f" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_f_quiver" holster_mesh_with_weapon="arrow_bl_f_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="4" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0,00.05,-0.0" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1456,7 +1456,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_steppe_arrows_h0" name="{=XbwDj80t}Steppe Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_steppe_arrows_v1_h0" name="{=XbwDj80t}Steppe Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="24" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0.00,0.05,-0.00" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1464,7 +1464,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_steppe_arrows_h1" name="{=XbwDj80t}Steppe Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_steppe_arrows_v1_h1" name="{=XbwDj80t}Steppe Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="28" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0.00,0.05,-0.00" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1472,7 +1472,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_steppe_arrows_h2" name="{=XbwDj80t}Steppe Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_steppe_arrows_v1_h2" name="{=XbwDj80t}Steppe Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="32" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0.00,0.05,-0.00" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1480,7 +1480,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_steppe_arrows_h3" name="{=XbwDj80t}Steppe Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
+  <Item id="crpg_steppe_arrows_v1_h3" name="{=XbwDj80t}Steppe Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_e" culture="Culture.khuzait" weight="0.036" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_e_quiver" holster_mesh_with_weapon="arrow_bl_e_quiver" Type="Arrows" item_holsters="quiver_back_lower:quiver_back_lower_2" holster_position_shift="0.0,0.0,-0.0">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="32" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="-0.00,0.05,-0.00" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1488,7 +1488,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_b_h0" name="{=BqAUrOpn}Light Broad Head Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_broad_arrows_h0" name="{=BqAUrOpn}Light Broad Head Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="33" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="9" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1496,7 +1496,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_b_h1" name="{=BqAUrOpn}Light Broad Head Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_broad_arrows_h1" name="{=BqAUrOpn}Light Broad Head Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="9" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1504,7 +1504,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_b_h2" name="{=BqAUrOpn}Light Broad Head Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_broad_arrows_h2" name="{=BqAUrOpn}Light Broad Head Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="10" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1512,7 +1512,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_b_h3" name="{=BqAUrOpn}Light Broad Head Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_broad_arrows_h3" name="{=BqAUrOpn}Light Broad Head Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.078" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="42" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="11" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1520,7 +1520,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_a_h0" name="{=SbARa2gU}Broad Head Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_broad_head_arrows_h0" name="{=SbARa2gU}Broad Head Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="16" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="12" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1528,7 +1528,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_a_h1" name="{=SbARa2gU}Broad Head Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_broad_head_arrows_h1" name="{=SbARa2gU}Broad Head Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="12" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1536,7 +1536,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_a_h2" name="{=SbARa2gU}Broad Head Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_broad_head_arrows_h2" name="{=SbARa2gU}Broad Head Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="13" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1544,7 +1544,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_broad_arrows_a_h3" name="{=SbARa2gU}Broad Head Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_broad_head_arrows_h3" name="{=SbARa2gU}Broad Head Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.098" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="14" thrust_damage_type="Cut" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="false" AmmoBreaksOnBounceBack="true" />
@@ -1552,7 +1552,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_c_h0" name="{=BqAUrOpn}Light Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_bodkin_arrows_h0" name="{=BqAUrOpn}Light Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="21" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1560,7 +1560,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_c_h1" name="{=BqAUrOpn}Light Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_bodkin_arrows_h1" name="{=BqAUrOpn}Light Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="26" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1568,7 +1568,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_c_h2" name="{=BqAUrOpn}Light Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_bodkin_arrows_h2" name="{=BqAUrOpn}Light Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="30" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="1" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1576,7 +1576,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_c_h3" name="{=BqAUrOpn}Light Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_light_bodkin_arrows_h3" name="{=BqAUrOpn}Light Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_d" weight="0.048" appearance="1" flying_mesh="arrow_bl_flying" holster_mesh="arrow_bl_d_quiver" holster_mesh_with_weapon="arrow_bl_d_quiver" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="30" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1584,7 +1584,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_b_h0" name="{=SbARa2gU}Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_bodkin_arrows_h0" name="{=SbARa2gU}Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="16" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1592,7 +1592,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_b_h1" name="{=SbARa2gU}Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_bodkin_arrows_h1" name="{=SbARa2gU}Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1600,7 +1600,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_b_h2" name="{=SbARa2gU}Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_bodkin_arrows_h2" name="{=SbARa2gU}Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="23" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1608,7 +1608,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_b_h3" name="{=SbARa2gU}Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_bodkin_arrows_h3" name="{=SbARa2gU}Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_c" holster_mesh="arrow_bl_c_quiver" holster_mesh_with_weapon="arrow_bl_c_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="23" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="4" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1616,7 +1616,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_a_h0" name="{=DI9P2HDG}Stacked Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_stacked_bodkin_arrows_h0" name="{=DI9P2HDG}Stacked Bodkin Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="22" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1624,7 +1624,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_a_h1" name="{=DI9P2HDG}Stacked Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_stacked_bodkin_arrows_h1" name="{=DI9P2HDG}Stacked Bodkin Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="27" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1632,7 +1632,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_a_h2" name="{=DI9P2HDG}Stacked Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_stacked_bodkin_arrows_h2" name="{=DI9P2HDG}Stacked Bodkin Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="31" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1640,7 +1640,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_bodkin_arrows_a_h3" name="{=DI9P2HDG}Stacked Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_stacked_bodkin_arrows_h3" name="{=DI9P2HDG}Stacked Bodkin Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_b" holster_mesh="arrow_bl_b_quiver" holster_mesh_with_weapon="arrow_bl_b_quiver" weight="0.048" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="31" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Blunt" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1648,7 +1648,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_piercing_arrows_h0" name="{=rdKSIamN}Piercing Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_piercing_arrows_v1_h0" name="{=rdKSIamN}Piercing Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="15" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="5" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1656,7 +1656,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_piercing_arrows_h1" name="{=rdKSIamN}Piercing Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_piercing_arrows_v1_h1" name="{=rdKSIamN}Piercing Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="18" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="5" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1664,7 +1664,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_piercing_arrows_h2" name="{=rdKSIamN}Piercing Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_piercing_arrows_v1_h2" name="{=rdKSIamN}Piercing Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="5" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1672,7 +1672,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_piercing_arrows_h3" name="{=rdKSIamN}Piercing Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_piercing_arrows_v1_h3" name="{=rdKSIamN}Piercing Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_a" holster_mesh="arrow_bl_a_quiver" holster_mesh_with_weapon="arrow_bl_a_quiver" weight="0.041" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_middle:quiver_bolts_2:quiver_bolts" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="20" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="6" thrust_damage_type="Pierce" item_usage="arrow_right" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1680,7 +1680,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_arrow_emp_1_a_h0" name="{=K5XLb84w}Imperial Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_imperial_arrows_h0" name="{=K5XLb84w}Imperial Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="6" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="7" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1688,7 +1688,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_arrow_emp_1_a_h1" name="{=K5XLb84w}Imperial Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_imperial_arrows_h1" name="{=K5XLb84w}Imperial Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="7" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="7" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1696,7 +1696,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_arrow_emp_1_a_h2" name="{=K5XLb84w}Imperial Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_imperial_arrows_h2" name="{=K5XLb84w}Imperial Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="8" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="7" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1704,7 +1704,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_arrow_emp_1_a_h3" name="{=K5XLb84w}Imperial Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
+  <Item id="crpg_imperial_arrows_h3" name="{=K5XLb84w}Imperial Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_roman_a" holster_mesh="quiver_roman_a" holster_mesh_with_weapon="quiver_roman_a" culture="Culture.empire" weight="0.05" is_merchandise="false" flying_mesh="arrow_bl_flying" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0.0,0.0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="8" physics_material="missile" thrust_speed="0" speed_rating="0" missile_speed="10" weapon_length="97" thrust_damage="8" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1712,7 +1712,39 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_vlandic_arrows_h0" name="{=3daDQxwM}Lowland Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+  <Item id="crpg_rangers_arrows_h0" name="{=Caver}Rangers Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.05" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+    <ItemComponent>
+      <Weapon weapon_class="Arrow" stack_amount="20" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="4" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
+        <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_rangers_arrows_h1" name="{=Caver}Rangers Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.05" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+    <ItemComponent>
+      <Weapon weapon_class="Arrow" stack_amount="23" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="4" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
+        <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_rangers_arrows_h2" name="{=Caver}Rangers Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.05" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+    <ItemComponent>
+      <Weapon weapon_class="Arrow" stack_amount="26" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="4" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
+        <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_rangers_arrows_h3" name="{=Caver}Rangers Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.05" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+    <ItemComponent>
+      <Weapon weapon_class="Arrow" stack_amount="26" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="5" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
+        <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags />
+  </Item>
+  <Item id="crpg_vlandic_arrows_v2_h0" name="{=3daDQxwM}Lowland Arrows" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="40" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1720,7 +1752,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_vlandic_arrows_h1" name="{=3daDQxwM}Lowland Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+  <Item id="crpg_lowland_arrows_h1" name="{=3daDQxwM}Lowland Arrows +1" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="46" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1728,7 +1760,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_vlandic_arrows_h2" name="{=3daDQxwM}Lowland Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+  <Item id="crpg_lowland_arrows_h2" name="{=3daDQxwM}Lowland Arrows +2" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="52" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="2" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -1736,7 +1768,7 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <Item id="crpg_vlandic_arrows_h3" name="{=3daDQxwM}Lowland Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
+  <Item id="crpg_lowland_arrows_h3" name="{=3daDQxwM}Lowland Arrows +3" body_name="bo_capsule_arrow" holster_body_name="bo_axe_short" mesh="arrow_bl_g" holster_mesh="arrow_bl_g_quiver" holster_mesh_with_weapon="arrow_bl_g_quiver" subtype="arrows" flying_mesh="arrow_bl_flying" weight="0.06" difficulty="0" appearance="1" Type="Arrows" item_holsters="quiver_back_top:quiver_back_top_2" holster_position_shift="0,0,0.15">
     <ItemComponent>
       <Weapon weapon_class="Arrow" stack_amount="52" thrust_speed="0" speed_rating="0" physics_material="missile" missile_speed="10" weapon_length="97" thrust_damage="3" thrust_damage_type="Pierce" item_usage="arrow_top" passby_sound_code="event:/mission/combat/missile/passby" rotation="0, -80, 25" sticking_position="0,-0.97,0" sticking_rotation="90,0,0" center_of_mass="0,0.0,-0.13" modifier_group="arrow">
         <WeaponFlags Consumable="true" AmmoSticksWhenShot="true" AmmoBreaksOnBounceBack="true" />
@@ -2748,7 +2780,7 @@
       </Weapon>
     </ItemComponent>
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h0" name="Strong Tribal Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h0" name="Strong Tribal Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="76" speed_rating="70" missile_speed="88" weapon_length="116" accuracy="100" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2756,7 +2788,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h1" name="Strong Tribal Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h1" name="Strong Tribal Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="77" speed_rating="73" missile_speed="90" weapon_length="116" accuracy="102" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2764,7 +2796,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h2" name="Strong Tribal Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h2" name="Strong Tribal Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="79" speed_rating="74" missile_speed="92" weapon_length="116" accuracy="104" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2772,7 +2804,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h3" name="Strong Tribal Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h3" name="Strong Tribal Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="79" speed_rating="74" missile_speed="92" weapon_length="116" accuracy="104" thrust_damage="21" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2780,7 +2812,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h0" name="Strong Tribal Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h0" name="Strong Tribal Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="76" speed_rating="70" missile_speed="88" weapon_length="116" accuracy="100" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2788,7 +2820,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h1" name="Strong Tribal Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h1" name="Strong Tribal Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="77" speed_rating="73" missile_speed="90" weapon_length="116" accuracy="102" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2796,7 +2828,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h2" name="Strong Tribal Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h2" name="Strong Tribal Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="79" speed_rating="74" missile_speed="92" weapon_length="116" accuracy="104" thrust_damage="20" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2804,7 +2836,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_strong_tribal_long_bow_REFUND_h3" name="Strong Tribal Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_strong_tribal_long_bow_h3" name="Strong Tribal Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_i" culture="Culture.aserai" weight="0.9" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="79" speed_rating="74" missile_speed="92" weapon_length="116" accuracy="104" thrust_damage="21" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2812,7 +2844,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h0" name="{=WRqYWspc}Noble Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h0" name="{=WRqYWspc}Noble Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="86" speed_rating="88" missile_speed="90" weapon_length="118" accuracy="97" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2820,7 +2852,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h1" name="{=WRqYWspc}Noble Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h1" name="{=WRqYWspc}Noble Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="91" missile_speed="92" weapon_length="118" accuracy="99" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2828,7 +2860,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h2" name="{=WRqYWspc}Noble Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h2" name="{=WRqYWspc}Noble Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="94" weapon_length="118" accuracy="101" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2836,7 +2868,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h3" name="{=WRqYWspc}Noble Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h3" name="{=WRqYWspc}Noble Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="94" weapon_length="118" accuracy="101" thrust_damage="19" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2844,7 +2876,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h0" name="{=WRqYWspc}Noble Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h0" name="{=WRqYWspc}Noble Long Bow" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="86" speed_rating="88" missile_speed="90" weapon_length="118" accuracy="97" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2852,7 +2884,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h1" name="{=WRqYWspc}Noble Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h1" name="{=WRqYWspc}Noble Long Bow +1" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="91" missile_speed="92" weapon_length="118" accuracy="99" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2860,7 +2892,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h2" name="{=WRqYWspc}Noble Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h2" name="{=WRqYWspc}Noble Long Bow +2" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="94" weapon_length="118" accuracy="101" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2868,7 +2900,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_long_bow_REFUND_h3" name="{=WRqYWspc}Noble Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_long_bow_h3" name="{=WRqYWspc}Noble Long Bow +3" body_name="bo_composite_longbow_g" mesh="longbow_j" weight="0.8" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="94" weapon_length="118" accuracy="101" thrust_damage="19" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2876,7 +2908,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h0" name="{=EO7pCu1b}Noble Bow" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h0" name="{=EO7pCu1b}Noble Short Bow" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="98" missile_speed="76" weapon_length="116" accuracy="98" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2884,7 +2916,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h1" name="{=EO7pCu1b}Noble Bow +1" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h1" name="{=EO7pCu1b}Noble Short Bow +1" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="98" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2892,7 +2924,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h2" name="{=EO7pCu1b}Noble Bow +2" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h2" name="{=EO7pCu1b}Noble Short Bow +2" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="101" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2900,7 +2932,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h3" name="{=EO7pCu1b}Noble Bow +3" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h3" name="{=EO7pCu1b}Noble Short Bow +3" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="107" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -2908,7 +2940,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h0" name="{=EO7pCu1b}Noble Bow" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h0" name="{=EO7pCu1b}Noble Short Bow" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="98" missile_speed="76" weapon_length="116" accuracy="98" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2916,7 +2948,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h1" name="{=EO7pCu1b}Noble Bow +1" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h1" name="{=EO7pCu1b}Noble Short Bow +1" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="98" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2924,7 +2956,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h2" name="{=EO7pCu1b}Noble Bow +2" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h2" name="{=EO7pCu1b}Noble Short Bow +2" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="101" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2932,7 +2964,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_noble_bow_REFUND_h3" name="{=EO7pCu1b}Noble Bow +3" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_noble_short_bow_h3" name="{=EO7pCu1b}Noble Short Bow +3" body_name="bo_composite_shotbow_f" mesh="shortbow_f" weight="0.4" difficulty="70" appearance="0.1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="101" missile_speed="85" weapon_length="116" accuracy="107" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -2940,199 +2972,199 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h0" name="{=9YbFEaZ1}Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h0" name="{=9YbFEaZ1}Fine Ranger Bow" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="84" missile_speed="82" weapon_length="117" accuracy="111" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="92" missile_speed="84" weapon_length="117" accuracy="106" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h1" name="{=9YbFEaZ1}Yew Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h1" name="{=9YbFEaZ1}Fine Ranger Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="87" missile_speed="84" weapon_length="117" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="95" missile_speed="86" weapon_length="117" accuracy="108" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h2" name="{=9YbFEaZ1}Yew Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h2" name="{=9YbFEaZ1}Fine Ranger Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="88" missile_speed="86" weapon_length="117" accuracy="115" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="96" missile_speed="88" weapon_length="117" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h3" name="{=9YbFEaZ1}Yew Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h3" name="{=9YbFEaZ1}Fine Ranger Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="88" missile_speed="86" weapon_length="117" accuracy="115" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="96" missile_speed="88" weapon_length="117" accuracy="110" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h0" name="{=9YbFEaZ1}Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h0" name="{=9YbFEaZ1}Fine Ranger Bow" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="84" missile_speed="82" weapon_length="117" accuracy="111" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="92" missile_speed="84" weapon_length="117" accuracy="106" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h1" name="{=9YbFEaZ1}Yew Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h1" name="{=9YbFEaZ1}Fine Ranger Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="87" missile_speed="84" weapon_length="117" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="95" missile_speed="86" weapon_length="117" accuracy="108" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h2" name="{=9YbFEaZ1}Yew Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h2" name="{=9YbFEaZ1}Fine Ranger Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="88" missile_speed="86" weapon_length="117" accuracy="115" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="96" missile_speed="88" weapon_length="117" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_yew_bow_REFUND_h3" name="{=9YbFEaZ1}Yew Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_ranger_bow_h3" name="{=9YbFEaZ1}Fine Ranger Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_b" culture="Culture.vlandia" difficulty="50" weight="0.65" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="88" missile_speed="86" weapon_length="117" accuracy="115" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="96" missile_speed="88" weapon_length="117" accuracy="110" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h0" name="{=ifzgMcrK}Hassun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h0" name="{=ifzgMcrK}Hassun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="81" missile_speed="77" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="70" missile_speed="77" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h1" name="{=ifzgMcrK}Hassun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h1" name="{=ifzgMcrK}Hassun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="97" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h2" name="{=ifzgMcrK}Hassun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h2" name="{=ifzgMcrK}Hassun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h3" name="{=ifzgMcrK}Hassun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h3" name="{=ifzgMcrK}Hassun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h0" name="{=ifzgMcrK}Hassun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h0" name="{=ifzgMcrK}Hassun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="81" missile_speed="77" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="70" missile_speed="77" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h1" name="{=ifzgMcrK}Hassun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h1" name="{=ifzgMcrK}Hassun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="97" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="110" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h2" name="{=ifzgMcrK}Hassun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h2" name="{=ifzgMcrK}Hassun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="113" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nomad_bow_REFUND_h3" name="{=ifzgMcrK}Hassun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_hassun_yumi_h3" name="{=ifzgMcrK}Hassun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_g" culture="Culture.aserai" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="84" missile_speed="86" weapon_length="114" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="73" missile_speed="86" weapon_length="114" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h0" name="{=ZFwKlHIJ}Woodland Longbow" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h0" name="{=ZFwKlHIJ}Fine Long Bow" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="89" missile_speed="88" weapon_length="118" accuracy="99" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="89" missile_speed="88" weapon_length="118" accuracy="102" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h1" name="{=ZFwKlHIJ}Woodland Longbow +1" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h1" name="{=ZFwKlHIJ}Fine Long Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="90" weapon_length="118" accuracy="101" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="92" missile_speed="90" weapon_length="118" accuracy="104" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h2" name="{=ZFwKlHIJ}Woodland Longbow +2" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h2" name="{=ZFwKlHIJ}Fine Long Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="103" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="106" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h3" name="{=ZFwKlHIJ}Woodland Longbow +3" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h3" name="{=ZFwKlHIJ}Fine Long Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="103" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="106" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h0" name="{=ZFwKlHIJ}Woodland Longbow" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h0" name="{=ZFwKlHIJ}Fine Long Bow" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="89" missile_speed="88" weapon_length="118" accuracy="99" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="89" missile_speed="88" weapon_length="118" accuracy="102" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h1" name="{=ZFwKlHIJ}Woodland Longbow +1" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h1" name="{=ZFwKlHIJ}Fine Long Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="92" missile_speed="90" weapon_length="118" accuracy="101" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="92" missile_speed="90" weapon_length="118" accuracy="104" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h2" name="{=ZFwKlHIJ}Woodland Longbow +2" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h2" name="{=ZFwKlHIJ}Fine Long Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="103" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="106" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_longbow_REFUND_h3" name="{=ZFwKlHIJ}Woodland Longbow +3" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_fine_long_bow_h3" name="{=ZFwKlHIJ}Fine Long Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_c" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="103" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="93" missile_speed="92" weapon_length="118" accuracy="106" thrust_damage="18" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h0" name="{=RcCtV0aS}Woodland Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h0" name="{=RcCtV0aS}Noble Ranger Bow" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="91" missile_speed="86" weapon_length="115" accuracy="101" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3140,7 +3172,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h1" name="{=RcCtV0aS}Woodland Yew Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h1" name="{=RcCtV0aS}Noble Ranger Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="94" missile_speed="88" weapon_length="115" accuracy="103" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3148,7 +3180,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h2" name="{=RcCtV0aS}Woodland Yew Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h2" name="{=RcCtV0aS}Noble Ranger Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="95" missile_speed="90" weapon_length="115" accuracy="105" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3156,7 +3188,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h3" name="{=RcCtV0aS}Woodland Yew Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h3" name="{=RcCtV0aS}Noble Ranger Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="95" missile_speed="90" weapon_length="115" accuracy="105" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3164,7 +3196,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h0" name="{=RcCtV0aS}Woodland Yew Bow" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h0" name="{=RcCtV0aS}Noble Ranger Bow" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="101" speed_rating="91" missile_speed="86" weapon_length="115" accuracy="101" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3172,7 +3204,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h1" name="{=RcCtV0aS}Woodland Yew Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h1" name="{=RcCtV0aS}Noble Ranger Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="94" missile_speed="88" weapon_length="115" accuracy="103" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3180,7 +3212,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h2" name="{=RcCtV0aS}Woodland Yew Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h2" name="{=RcCtV0aS}Noble Ranger Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="95" missile_speed="90" weapon_length="115" accuracy="105" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3188,7 +3220,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_woodland_yew_bow_REFUND_h3" name="{=RcCtV0aS}Woodland Yew Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_noble_ranger_bow_h3" name="{=RcCtV0aS}Noble Ranger Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_d" culture="Culture.battania" weight="0.7" difficulty="50" appearance="0.3" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="95" missile_speed="90" weapon_length="115" accuracy="105" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3196,199 +3228,199 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h0" name="{=wfhHGTbl}Steppe War Bow" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h0" name="{=wfhHGTbl}Steppe War Bow" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="105" missile_speed="74" weapon_length="107" accuracy="98" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="123" speed_rating="84" missile_speed="73" weapon_length="107" accuracy="115" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h1" name="{=wfhHGTbl}Steppe War Bow +1" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h1" name="{=wfhHGTbl}Steppe War Bow +1" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="98" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="115" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h2" name="{=wfhHGTbl}Steppe War Bow +2" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h2" name="{=wfhHGTbl}Steppe War Bow +2" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="101" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="129" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="118" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h3" name="{=wfhHGTbl}Steppe War Bow +3" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h3" name="{=wfhHGTbl}Steppe War Bow +3" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="107" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="129" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="124" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h0" name="{=wfhHGTbl}Steppe War Bow" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h0" name="{=wfhHGTbl}Steppe War Bow" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="105" missile_speed="74" weapon_length="107" accuracy="98" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="123" speed_rating="84" missile_speed="73" weapon_length="107" accuracy="115" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h1" name="{=wfhHGTbl}Steppe War Bow +1" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h1" name="{=wfhHGTbl}Steppe War Bow +1" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="98" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="115" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h2" name="{=wfhHGTbl}Steppe War Bow +2" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h2" name="{=wfhHGTbl}Steppe War Bow +2" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="101" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="129" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="118" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_war_bow_REFUND_h3" name="{=wfhHGTbl}Steppe War Bow +3" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_steppe_war_bow_h3" name="{=wfhHGTbl}Steppe War Bow +3" body_name="bo_composite_shotbow_a" mesh="shortbow_a" culture="Culture.khuzait" weight="0.35" difficulty="50" appearance="0.25" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="108" missile_speed="83" weapon_length="107" accuracy="107" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="129" speed_rating="87" missile_speed="82" weapon_length="107" accuracy="124" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h0" name="{=ZQv5Bcl2}Rokusun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h0" name="{=ZQv5Bcl2}Rokusun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="81" missile_speed="76" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="72" missile_speed="77" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h1" name="{=ZQv5Bcl2}Rokusun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h1" name="{=ZQv5Bcl2}Rokusun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h2" name="{=ZQv5Bcl2}Rokusun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h2" name="{=ZQv5Bcl2}Rokusun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="123" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="123" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h3" name="{=ZQv5Bcl2}Rokusun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h3" name="{=ZQv5Bcl2}Rokusun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="129" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="129" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h0" name="{=ZQv5Bcl2}Rokusun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h0" name="{=ZQv5Bcl2}Rokusun Yumi" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="81" missile_speed="76" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="72" missile_speed="77" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h1" name="{=ZQv5Bcl2}Rokusun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h1" name="{=ZQv5Bcl2}Rokusun Yumi +1" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="120" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h2" name="{=ZQv5Bcl2}Rokusun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h2" name="{=ZQv5Bcl2}Rokusun Yumi +2" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="123" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="123" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_tribal_bow_REFUND_h3" name="{=ZQv5Bcl2}Rokusun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_rokusun_yumi_h3" name="{=ZQv5Bcl2}Rokusun Yumi +3" body_name="bo_composite_longbow_g" mesh="longbow_h" culture="Culture.aserai" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="84" missile_speed="85" weapon_length="115" accuracy="129" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="75" missile_speed="86" weapon_length="115" accuracy="129" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h0" name="{=A6llHL9s}Yonsun Yumi" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h0" name="{=A6llHL9s}Yonsun Yumi" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="82" missile_speed="77" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="76" missile_speed="77" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h1" name="{=A6llHL9s}Yonsun Yumi +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h1" name="{=A6llHL9s}Yonsun Yumi +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h2" name="{=A6llHL9s}Yonsun Yumi +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h2" name="{=A6llHL9s}Yonsun Yumi +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="99" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="133" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="133" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h3" name="{=A6llHL9s}Yonsun Yumi +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h3" name="{=A6llHL9s}Yonsun Yumi +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="99" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="139" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="139" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h0" name="{=A6llHL9s}Yonsun Yumi" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h0" name="{=A6llHL9s}Yonsun Yumi" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="82" missile_speed="77" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="76" missile_speed="77" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h1" name="{=A6llHL9s}Yonsun Yumi +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h1" name="{=A6llHL9s}Yonsun Yumi +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="130" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h2" name="{=A6llHL9s}Yonsun Yumi +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h2" name="{=A6llHL9s}Yonsun Yumi +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="99" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="133" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="133" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_lowland_longbow_REFUND_h3" name="{=A6llHL9s}Yonsun Yumi +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_yonsun_yumi_h3" name="{=A6llHL9s}Yonsun Yumi +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" subtype="bow" weight="0.5" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="99" speed_rating="85" missile_speed="86" weapon_length="120" accuracy="139" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="79" missile_speed="86" weapon_length="120" accuracy="139" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h0" name="{=tEimkEsU}Nordic Shortbow" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h0" name="{=tEimkEsU}Nordic Short Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="81" missile_speed="79" weapon_length="108" accuracy="121" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3396,7 +3428,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h1" name="{=tEimkEsU}Nordic Shortbow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h1" name="{=tEimkEsU}Nordic Short Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="121" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3404,7 +3436,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h2" name="{=tEimkEsU}Nordic Shortbow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h2" name="{=tEimkEsU}Nordic Short Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="112" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="124" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3412,7 +3444,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h3" name="{=tEimkEsU}Nordic Shortbow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h3" name="{=tEimkEsU}Nordic Short Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="112" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3420,7 +3452,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h0" name="{=tEimkEsU}Nordic Shortbow" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h0" name="{=tEimkEsU}Nordic Short Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="81" missile_speed="79" weapon_length="108" accuracy="121" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3428,7 +3460,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h1" name="{=tEimkEsU}Nordic Shortbow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h1" name="{=tEimkEsU}Nordic Short Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="108" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="121" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3436,7 +3468,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h2" name="{=tEimkEsU}Nordic Shortbow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h2" name="{=tEimkEsU}Nordic Short Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="112" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="124" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3444,7 +3476,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_nordic_shortbow_REFUND_h3" name="{=tEimkEsU}Nordic Shortbow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_nordic_short_bow_h3" name="{=tEimkEsU}Nordic Short Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_e" culture="Culture.sturgia" weight="0.6" difficulty="30" appearance="0.6" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="112" speed_rating="84" missile_speed="88" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3452,71 +3484,71 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h0" name="{=E7miRMw1}Light Recurve Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h0" name="{=E7miRMw1}Light Recurve Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="130" missile_speed="79" weapon_length="106" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="130" missile_speed="75" weapon_length="106" accuracy="100" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h1" name="{=E7miRMw1}Light Recurve Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h1" name="{=E7miRMw1}Light Recurve Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="100" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h2" name="{=E7miRMw1}Light Recurve Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h2" name="{=E7miRMw1}Light Recurve Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="131" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="103" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h3" name="{=E7miRMw1}Light Recurve Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h3" name="{=E7miRMw1}Light Recurve Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="137" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="109" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h0" name="{=E7miRMw1}Light Recurve Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h0" name="{=E7miRMw1}Light Recurve Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="130" missile_speed="79" weapon_length="106" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="130" missile_speed="75" weapon_length="106" accuracy="100" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h1" name="{=E7miRMw1}Light Recurve Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h1" name="{=E7miRMw1}Light Recurve Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="100" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h2" name="{=E7miRMw1}Light Recurve Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h2" name="{=E7miRMw1}Light Recurve Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="131" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="103" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_heavy_bow_REFUND_h3" name="{=E7miRMw1}Light Recurve Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_light_recurve_bow_h3" name="{=E7miRMw1}Light Recurve Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" culture="Culture.khuzait" weight="0.3" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="88" weapon_length="106" accuracy="137" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="128" speed_rating="133" missile_speed="84" weapon_length="106" accuracy="109" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h0" name="{=w6EU77OH}Steppe Recurve Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h0" name="{=w6EU77OH}Noble Steppe Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="83" missile_speed="74" weapon_length="108" accuracy="110" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3524,7 +3556,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h1" name="{=w6EU77OH}Steppe Recurve Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h1" name="{=w6EU77OH}Noble Steppe Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="123" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="110" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3532,7 +3564,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h2" name="{=w6EU77OH}Steppe Recurve Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h2" name="{=w6EU77OH}Noble Steppe Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="113" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3540,7 +3572,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h3" name="{=w6EU77OH}Steppe Recurve Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h3" name="{=w6EU77OH}Noble Steppe Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="119" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
@@ -3548,7 +3580,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h0" name="{=w6EU77OH}Steppe Recurve Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h0" name="{=w6EU77OH}Noble Steppe Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="83" missile_speed="74" weapon_length="108" accuracy="110" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3556,7 +3588,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h1" name="{=w6EU77OH}Steppe Recurve Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h1" name="{=w6EU77OH}Noble Steppe Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="123" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="110" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3564,7 +3596,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h2" name="{=w6EU77OH}Steppe Recurve Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h2" name="{=w6EU77OH}Noble Steppe Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="113" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3572,7 +3604,7 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_steppe_bow_REFUND_h3" name="{=w6EU77OH}Steppe Recurve Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_noble_steppe_bow_h3" name="{=w6EU77OH}Noble Steppe Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_d" culture="Culture.khuzait" weight="0.35" difficulty="30" appearance="0.4" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
       <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="86" missile_speed="83" weapon_length="108" accuracy="119" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
@@ -3580,385 +3612,577 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h0" name="{=h1jKICdp}Simple Short Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h0" name="{=h1jKICdp}Heavy Hunting Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="115" speed_rating="82" missile_speed="73" weapon_length="110" accuracy="116" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="80" missile_speed="72" weapon_length="110" accuracy="120" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h1" name="{=h1jKICdp}Simple Short Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h1" name="{=h1jKICdp}Heavy Hunting Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="117" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="116" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="120" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h2" name="{=h1jKICdp}Simple Short Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h2" name="{=h1jKICdp}Heavy Hunting Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="119" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="123" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h3" name="{=h1jKICdp}Simple Short Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h3" name="{=h1jKICdp}Heavy Hunting Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="125" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="129" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h0" name="{=h1jKICdp}Simple Short Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h0" name="{=h1jKICdp}Heavy Hunting Bow" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="115" speed_rating="82" missile_speed="73" weapon_length="110" accuracy="116" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="80" missile_speed="72" weapon_length="110" accuracy="120" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h1" name="{=h1jKICdp}Simple Short Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h1" name="{=h1jKICdp}Heavy Hunting Bow +1" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="117" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="116" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="120" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h2" name="{=h1jKICdp}Simple Short Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h2" name="{=h1jKICdp}Heavy Hunting Bow +2" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="119" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="123" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_composite_bow_REFUND_h3" name="{=h1jKICdp}Simple Short Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_heavy_hunting_bow_h3" name="{=h1jKICdp}Heavy Hunting Bow +3" body_name="bo_composite_shotbow_c" mesh="shortbow_c" weight="0.3" difficulty="30" appearance="0.5" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="85" missile_speed="82" weapon_length="110" accuracy="125" thrust_damage="12" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="129" thrust_damage="15" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h0" name="{=mTWvG1xz}Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h0" name="{=Caver}Simple Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="86" speed_rating="86" missile_speed="90" weapon_length="113" accuracy="131" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="93" missile_speed="80" weapon_length="113" accuracy="130" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h1" name="{=mTWvG1xz}Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h1" name="{=Caver}Simple Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="89" missile_speed="92" weapon_length="113" accuracy="133" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="96" missile_speed="82" weapon_length="113" accuracy="132" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h2" name="{=mTWvG1xz}Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h2" name="{=Caver}Simple Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="90" missile_speed="94" weapon_length="113" accuracy="135" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="84" weapon_length="113" accuracy="134" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h3" name="{=mTWvG1xz}Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h3" name="{=Caver}Simple Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="90" missile_speed="94" weapon_length="113" accuracy="135" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="84" weapon_length="113" accuracy="134" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h0" name="{=mTWvG1xz}Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h0" name="{=Caver}Simple Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="86" speed_rating="86" missile_speed="90" weapon_length="113" accuracy="131" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="93" missile_speed="80" weapon_length="113" accuracy="130" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h1" name="{=mTWvG1xz}Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h1" name="{=Caver}Simple Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="87" speed_rating="89" missile_speed="92" weapon_length="113" accuracy="133" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="96" missile_speed="82" weapon_length="113" accuracy="132" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h2" name="{=mTWvG1xz}Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h2" name="{=Caver}Simple Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="90" missile_speed="94" weapon_length="113" accuracy="135" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="84" weapon_length="113" accuracy="134" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_highland_ranger_bow_REFUND_h3" name="{=mTWvG1xz}Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_simple_ranger_bow_h3" name="{=Caver}Simple Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="90" missile_speed="94" weapon_length="113" accuracy="135" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="84" weapon_length="113" accuracy="134" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h0" name="{=KTegaNPW}Longbow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h0" name="{=mTWvG1xz}Common Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="97" missile_speed="83" weapon_length="111" accuracy="110" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="93" missile_speed="82" weapon_length="113" accuracy="115" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h1" name="{=KTegaNPW}Longbow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h1" name="{=mTWvG1xz}Common Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="100" missile_speed="85" weapon_length="111" accuracy="112" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="96" missile_speed="84" weapon_length="113" accuracy="117" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h2" name="{=KTegaNPW}Longbow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h2" name="{=mTWvG1xz}Common Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="101" missile_speed="87" weapon_length="111" accuracy="114" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="86" weapon_length="113" accuracy="119" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h3" name="{=KTegaNPW}Longbow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h3" name="{=mTWvG1xz}Common Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="101" missile_speed="87" weapon_length="111" accuracy="114" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="86" weapon_length="113" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h0" name="{=KTegaNPW}Longbow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h0" name="{=mTWvG1xz}Common Ranger Bow" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="102" speed_rating="97" missile_speed="83" weapon_length="111" accuracy="110" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="93" missile_speed="82" weapon_length="113" accuracy="115" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h1" name="{=KTegaNPW}Longbow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h1" name="{=mTWvG1xz}Common Ranger Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="103" speed_rating="100" missile_speed="85" weapon_length="111" accuracy="112" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="104" speed_rating="96" missile_speed="84" weapon_length="113" accuracy="117" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h2" name="{=KTegaNPW}Longbow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h2" name="{=mTWvG1xz}Common Ranger Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="101" missile_speed="87" weapon_length="111" accuracy="114" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="86" weapon_length="113" accuracy="119" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_glen_ranger_bow_REFUND_h3" name="{=KTegaNPW}Longbow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_common_ranger_bow_h3" name="{=mTWvG1xz}Common Ranger Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_e" culture="Culture.battania" weight="0.5" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="105" speed_rating="101" missile_speed="87" weapon_length="111" accuracy="114" thrust_damage="13" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="106" speed_rating="97" missile_speed="86" weapon_length="113" accuracy="119" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h0" name="{=steppebowitem}Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h0" name="{=Caver}Simple Long Bow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="118" speed_rating="81" missile_speed="72" weapon_length="110" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="90" missile_speed="84" weapon_length="111" accuracy="112" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h1" name="{=steppebowitem}Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h1" name="{=Caver}Simple Long Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="120" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="93" missile_speed="86" weapon_length="111" accuracy="114" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h2" name="{=steppebowitem}Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h2" name="{=Caver}Simple Long Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="131" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="88" weapon_length="111" accuracy="116" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h3" name="{=steppebowitem}Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h3" name="{=Caver}Simple Long Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="137" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="88" weapon_length="111" accuracy="116" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h0" name="{=steppebowitem}Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h0" name="{=Caver}Simple Long Bow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="118" speed_rating="81" missile_speed="72" weapon_length="110" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="90" missile_speed="84" weapon_length="111" accuracy="112" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h1" name="{=steppebowitem}Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h1" name="{=Caver}Simple Long Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="120" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="128" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="93" missile_speed="86" weapon_length="111" accuracy="114" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h2" name="{=steppebowitem}Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h2" name="{=Caver}Simple Long Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="131" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="88" weapon_length="111" accuracy="116" thrust_damage="14" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_steppe_bow_REFUND_h3" name="{=steppebowitem}Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_long_bow_h3" name="{=Caver}Simple Long Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="124" speed_rating="84" missile_speed="81" weapon_length="110" accuracy="137" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="88" weapon_length="111" accuracy="116" thrust_damage="15" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h0" name="{=YGQ6UXCo}Mountain Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h0" name="{=KTegaNPW}Common Long Bow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="125" missile_speed="71" weapon_length="108" accuracy="98" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="90" missile_speed="86" weapon_length="111" accuracy="107" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h1" name="{=YGQ6UXCo}Mountain Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h1" name="{=KTegaNPW}Common Long Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="98" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="93" missile_speed="88" weapon_length="111" accuracy="109" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h2" name="{=YGQ6UXCo}Mountain Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h2" name="{=KTegaNPW}Common Long Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="101" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="90" weapon_length="111" accuracy="111" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h3" name="{=YGQ6UXCo}Mountain Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h3" name="{=KTegaNPW}Common Long Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="107" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="90" weapon_length="111" accuracy="111" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h0" name="{=YGQ6UXCo}Mountain Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h0" name="{=KTegaNPW}Common Long Bow" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="107" speed_rating="125" missile_speed="71" weapon_length="108" accuracy="98" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="88" speed_rating="90" missile_speed="86" weapon_length="111" accuracy="107" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h1" name="{=YGQ6UXCo}Mountain Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h1" name="{=KTegaNPW}Common Long Bow +1" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="109" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="98" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="89" speed_rating="93" missile_speed="88" weapon_length="111" accuracy="109" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h2" name="{=YGQ6UXCo}Mountain Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h2" name="{=KTegaNPW}Common Long Bow +2" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="101" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="90" weapon_length="111" accuracy="111" thrust_damage="16" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_mountain_hunting_bow_REFUND_h3" name="{=YGQ6UXCo}Mountain Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_common_long_bow_h3" name="{=KTegaNPW}Common Long Bow +3" body_name="bo_composite_longbow_e" mesh="longbow_f" culture="Culture.battania" weight="0.45" difficulty="15" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="113" speed_rating="128" missile_speed="80" weapon_length="108" accuracy="107" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="94" missile_speed="90" weapon_length="111" accuracy="111" thrust_damage="17" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h0" name="{=wltdyF2j}Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h0" name="{=Caver}Simple Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="119" speed_rating="80" missile_speed="72" weapon_length="110" accuracy="135" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="85" missile_speed="71" weapon_length="110" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h1" name="{=wltdyF2j}Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h1" name="{=Caver}Simple Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="135" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h2" name="{=wltdyF2j}Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h2" name="{=Caver}Simple Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="138" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="133" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h3" name="{=wltdyF2j}Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h3" name="{=Caver}Simple Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="144" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="139" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h0" name="{=wltdyF2j}Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h0" name="{=Caver}Simple Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="119" speed_rating="80" missile_speed="72" weapon_length="110" accuracy="135" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="85" missile_speed="71" weapon_length="110" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h1" name="{=wltdyF2j}Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h1" name="{=Caver}Simple Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="135" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h2" name="{=wltdyF2j}Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h2" name="{=Caver}Simple Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="138" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="133" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_hunting_bow_REFUND_h3" name="{=wltdyF2j}Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+  <Item id="crpg_simple_steppe_bow_h3" name="{=Caver}Simple Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="83" missile_speed="81" weapon_length="110" accuracy="144" thrust_damage="9" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="80" weapon_length="110" accuracy="139" thrust_damage="10" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h0" name="{=steppebowitem}Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="85" missile_speed="72" weapon_length="110" accuracy="120" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h1" name="{=steppebowitem}Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="120" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h2" name="{=steppebowitem}Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="123" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h3" name="{=steppebowitem}Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="129" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h0" name="{=steppebowitem}Steppe Bow" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="125" speed_rating="85" missile_speed="72" weapon_length="110" accuracy="120" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h1" name="{=steppebowitem}Steppe Bow +1" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="127" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="120" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h2" name="{=steppebowitem}Steppe Bow +2" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="123" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_steppe_bow_h3" name="{=steppebowitem}Steppe Bow +3" body_name="bo_composite_shotbow_g" mesh="shortbow_g" culture="Culture.khuzait" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="131" speed_rating="88" missile_speed="81" weapon_length="110" accuracy="129" thrust_damage="11" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h0" name="{=YGQ6UXCo}Light Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="84" missile_speed="70" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h1" name="{=YGQ6UXCo}Light Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h2" name="{=YGQ6UXCo}Light Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="133" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h3" name="{=YGQ6UXCo}Light Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="139" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h0" name="{=YGQ6UXCo}Light Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="84" missile_speed="70" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h1" name="{=YGQ6UXCo}Light Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="130" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h2" name="{=YGQ6UXCo}Light Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="133" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="crpg_light_hunting_bow_h3" name="{=YGQ6UXCo}Light Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_i" culture="Culture.battania" weight="0.25" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="100" speed_rating="87" missile_speed="79" weapon_length="108" accuracy="139" thrust_damage="13" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h0" name="{=wltdyF2j}Common Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="82" missile_speed="71" weapon_length="110" accuracy="125" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h1" name="{=wltdyF2j}Common Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="125" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h2" name="{=wltdyF2j}Common Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="128" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h3" name="{=wltdyF2j}Common Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="134" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h0" name="{=wltdyF2j}Common Hunting Bow" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="92" speed_rating="82" missile_speed="71" weapon_length="110" accuracy="125" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="long_bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h1" name="{=wltdyF2j}Common Hunting Bow +1" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="94" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="125" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h2" name="{=wltdyF2j}Common Hunting Bow +2" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="128" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
+        <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
+      </Weapon>
+    </ItemComponent>
+    <Flags ForceAttachOffHandPrimaryItemBone="true" />
+  </Item>
+  <Item id="common_hunting_bow_h3" name="{=wltdyF2j}Common Hunting Bow +3" body_name="bo_composite_shotbow_h" mesh="shortbow_h" culture="Culture.battania" weight="0.2" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_hip:bow_hip_2:bow_back:bow_back_2">
+    <ItemComponent>
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="85" missile_speed="80" weapon_length="110" accuracy="134" thrust_damage="14" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.1,0,-0.15" modifier_group="bow">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
@@ -10676,129 +10900,129 @@
       <Piece id="crpg_wooden_sword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <Item id="crpg_training_longbow_REFUND_h0" name="{=cmuMaYGR}Practice Longbow" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h0" name="{=cmuMaYGR}Practice Bow" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="92" missile_speed="87" weapon_length="120" accuracy="115" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="85" missile_speed="80" weapon_length="120" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h1" name="{=cmuMaYGR}Practice Longbow +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h1" name="{=cmuMaYGR}Practice Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="95" missile_speed="89" weapon_length="120" accuracy="117" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="88" missile_speed="82" weapon_length="120" accuracy="132" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h2" name="{=cmuMaYGR}Practice Longbow +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h2" name="{=cmuMaYGR}Practice Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="96" missile_speed="91" weapon_length="120" accuracy="119" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="89" missile_speed="84" weapon_length="120" accuracy="134" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h3" name="{=cmuMaYGR}Practice Longbow +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h3" name="{=cmuMaYGR}Practice Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="96" missile_speed="91" weapon_length="120" accuracy="119" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="89" missile_speed="84" weapon_length="120" accuracy="134" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h0" name="{=cmuMaYGR}Practice Longbow" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h0" name="{=cmuMaYGR}Practice Bow" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="95" speed_rating="92" missile_speed="87" weapon_length="120" accuracy="115" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="90" speed_rating="85" missile_speed="80" weapon_length="120" accuracy="130" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h1" name="{=cmuMaYGR}Practice Longbow +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h1" name="{=cmuMaYGR}Practice Bow +1" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="96" speed_rating="95" missile_speed="89" weapon_length="120" accuracy="117" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="91" speed_rating="88" missile_speed="82" weapon_length="120" accuracy="132" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h2" name="{=cmuMaYGR}Practice Longbow +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h2" name="{=cmuMaYGR}Practice Bow +2" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="96" missile_speed="91" weapon_length="120" accuracy="119" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="89" missile_speed="84" weapon_length="120" accuracy="134" thrust_damage="10" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_longbow_REFUND_h3" name="{=cmuMaYGR}Practice Longbow +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
+  <Item id="crpg_training_longbow_h3" name="{=cmuMaYGR}Practice Bow +3" body_name="bo_composite_longbow_a" mesh="longbow_a" culture="Culture.vlandia" is_merchandise="false" subtype="bow" weight="0.5" difficulty="0" appearance="1" Type="Bow" item_holsters="bow_back:bow_back_2:bow_hip:bow_hip_2">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="98" speed_rating="96" missile_speed="91" weapon_length="120" accuracy="119" thrust_damage="12" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="93" speed_rating="89" missile_speed="84" weapon_length="120" accuracy="134" thrust_damage="11" thrust_damage_type="Pierce" item_usage="long_bow" physics_material="wood_weapon" center_of_mass="0.15,0,0">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h0" name="{=SUSbUAEl}Practice Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h0" name="{=SUSbUAEl}Stick with a String" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="115" speed_rating="106" missile_speed="85" weapon_length="106" accuracy="131" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="120" speed_rating="100" missile_speed="60" weapon_length="106" accuracy="130" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h1" name="{=SUSbUAEl}Practice Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h1" name="{=SUSbUAEl}Stick with a String +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="117" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="131" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="130" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h2" name="{=SUSbUAEl}Practice Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h2" name="{=SUSbUAEl}Stick with a String +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="134" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="126" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="133" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h3" name="{=SUSbUAEl}Practice Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h3" name="{=SUSbUAEl}Stick with a String +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="140" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="126" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="139" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h0" name="{=SUSbUAEl}Practice Bow" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h0" name="{=SUSbUAEl}Stick with a String" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="115" speed_rating="106" missile_speed="85" weapon_length="106" accuracy="131" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="120" speed_rating="100" missile_speed="60" weapon_length="106" accuracy="130" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h1" name="{=SUSbUAEl}Practice Bow +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h1" name="{=SUSbUAEl}Stick with a String +1" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="117" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="131" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="122" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="130" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h2" name="{=SUSbUAEl}Practice Bow +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h2" name="{=SUSbUAEl}Stick with a String +2" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="134" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="126" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="133" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <Item id="crpg_training_bow_REFUND_h3" name="{=SUSbUAEl}Practice Bow +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
+  <Item id="crpg_training_bow_h3" name="{=SUSbUAEl}Stick with a String +3" body_name="bo_composite_shotbow_b" mesh="shortbow_b" weight="0.15" difficulty="0" appearance="1" is_merchandise="false" Type="Bow" item_holsters="bow_back_2:bow_hip:bow_hip_2:bow_back">
     <ItemComponent>
-      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="121" speed_rating="109" missile_speed="94" weapon_length="106" accuracy="140" thrust_damage="7" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
+      <Weapon weapon_class="Bow" ammo_class="Arrow" ammo_limit="1" thrust_speed="126" speed_rating="103" missile_speed="69" weapon_length="106" accuracy="139" thrust_damage="5" thrust_damage_type="Pierce" item_usage="bow" physics_material="wood_weapon" center_of_mass="0.0,0,-0.1">
         <WeaponFlags RangedWeapon="true" HasString="true" StringHeldByHand="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" AutoReload="true" UnloadWhenSheathed="true" />
       </Weapon>
     </ItemComponent>


### PR DESCRIPTION
Bow-Rework

1. based on the 10% Missile Speed Nerf by namidaka
2. Created Bow Arche Types:
- Ranger Bows (More mobile, less damage, Version of Long Bows)
- War Bows (Original Long Bows)
- Horsearcher-Shortbows
- Footarcher-Shortbows
- Hunting Bows, dedicated Footarcher-Hybrid-Shortbows that cannot be used on Horse

- Renamed Bows to be easier distingushable (Noble > Fine > Common > Simple / Heavy > Common > Light) 
Unique Bows are unaffected.

- Reworked most of the low tier unused bows to fit into the newly created archetypes and created 3 new bows as Low-Tier bows
- Created 1 additional Arrow Type (Rangers Arrows)
- Yumis slightly reworked (less Reload Speed, more Aim Speed)
- Slight nerf to Light Recurve Bow
- Original Top-Tier Bows are unchanged (Except Noble Short Bow +1 Accuracy)
- Refunded all Bows and Arrows