### PR TITLE
Yeldur-Dagger Rework

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11422,8 +11422,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_highland_dagger_blade_h0" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.4">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.68" />
-      <Swing damage_type="Cut" damage_factor="2.45" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="2.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11432,10 +11432,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_dagger_blade_h1" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.4">
+  <CraftingPiece id="crpg_highland_dagger_blade_h1" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.30">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="2.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11444,10 +11444,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_highland_dagger_blade_h2" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.3">
+  <CraftingPiece id="crpg_highland_dagger_blade_h2" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.25">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
+      <Swing damage_type="Cut" damage_factor="2.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11458,8 +11458,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_highland_dagger_blade_h3" name="{=5o5DaSHZ}Broad Dagger Blade" tier="2" piece_type="Blade" mesh="dagger_blade_13" length="29" weight="1.25">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
+      <Swing damage_type="Cut" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11612,19 +11612,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_xiphos_blade_h0" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.2">
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.61" />
-      <Swing damage_type="Cut" damage_factor="2.45" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_xiphos_blade_h1" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.15">
+  <CraftingPiece id="crpg_xiphos_blade_h0" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.15">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="1.7" />
       <Swing damage_type="Cut" damage_factor="2.5" />
@@ -11636,7 +11624,19 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_xiphos_blade_h2" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.08">
+  <CraftingPiece id="crpg_xiphos_blade_h1" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.15">
+    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_xiphos_blade_h2" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.0">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
       <Swing damage_type="Cut" damage_factor="2.6" />
@@ -11650,44 +11650,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_xiphos_blade_h3" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.0">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_pugio_blade_h0" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.45">
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.68" />
-      <Swing damage_type="Cut" damage_factor="2.45" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_pugio_blade_h1" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.45">
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="2.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_pugio_blade_h2" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.4">
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11696,10 +11660,42 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_pugio_blade_h3" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.35">
+  <CraftingPiece id="crpg_pugio_blade_h0" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="1.02" excluded_item_usage_features="swing">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_pugio_blade_h1" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="0.90" excluded_item_usage_features="swing">
+    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_pugio_blade_h2" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="0.845" excluded_item_usage_features="swing">
+    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_pugio_blade_h3" name="{=ykTYTbek}Throwing Knife Blade" tier="2" piece_type="Blade" mesh="dagger_blade_11" length="30" weight="0.8" excluded_item_usage_features="swing">
+    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -11758,6 +11754,39 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_falx_knife_blade_h0" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.2" excluded_item_usage_features="swing">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_falx_knife_blade_h1" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.01" excluded_item_usage_features="swing">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_falx_knife_blade_h2" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.01" excluded_item_usage_features="swing">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_falx_knife_blade_h3" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.01" excluded_item_usage_features="swing">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
       <Thrust damage_type="Pierce" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -11767,42 +11796,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_blade_h1" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.2" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_seax_blade_h0" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.75">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_blade_h2" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.2" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_blade_h3" name="{=SgJH5KtP}Sica Blade" tier="3" piece_type="Blade" mesh="dagger_blade_9" length="43" weight="0.2" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_seax_blade_h0" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="0.2" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
+       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11812,9 +11809,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_seax_blade_h1" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="0.05" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_seax_blade_h1" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.60">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
+       <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11824,9 +11822,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_seax_blade_h2" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="0.05" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_seax_blade_h2" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11836,9 +11835,10 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_seax_blade_h3" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="0.05" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_seax_blade_h3" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -13733,17 +13733,17 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_pommel_h1" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.12">
+  <CraftingPiece id="crpg_falx_knife_pommel_h1" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.01">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_pommel_h2" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.12">
+  <CraftingPiece id="crpg_falx_knife_pommel_h2" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.01">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_falx_knife_pommel_h3" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.12">
+  <CraftingPiece id="crpg_falx_knife_pommel_h3" name="{=aalvbENh}Desert Pommel" tier="3" piece_type="Pommel" mesh="aserai_pommel_3" culture="Culture.aserai" length="6.875" weight="0.01">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -28278,21 +28278,21 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_guard_h2" name="{=}Rondel Guard" tier="1" piece_type="Guard" mesh="rondel_guard" culture="Culture.battania" full_scale="true" length="1.1" weight="0.2">
+  <CraftingPiece id="crpg_rondel_guard_h2" name="{=}Rondel Guard" tier="1" piece_type="Guard" mesh="rondel_guard" culture="Culture.battania" full_scale="true" length="1.1" weight="0.13">
     <BuildData next_piece_offset="1.0" />
     <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_guard_h3" name="{=}Rondel Guard" tier="1" piece_type="Guard" mesh="rondel_guard" culture="Culture.battania" full_scale="true" length="1.1" weight="0.2">
+  <CraftingPiece id="crpg_rondel_guard_h3" name="{=}Rondel Guard" tier="1" piece_type="Guard" mesh="rondel_guard" culture="Culture.battania" full_scale="true" length="1.1" weight="0.13">
     <BuildData next_piece_offset="1.0" />
     <StatContributions armor_bonus="0" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_blade_h0" name="{=}Rondel Blade" tier="2" piece_type="Blade" mesh="rondel_blade" full_scale="true" length="31.4" weight="0.3" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_rondel_blade_h0" name="{=}Rondel Blade" tier="2" piece_type="Blade" mesh="rondel_blade" full_scale="true" length="31.4" weight="0.1" excluded_item_usage_features="swing">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="3.8" />
     </BladeData>
@@ -28303,7 +28303,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_blade_h1" name="{=}Rondel Blade" tier="2" piece_type="Blade" mesh="rondel_blade" full_scale="true" length="31.4" weight="0.3" excluded_item_usage_features="swing">
+  <CraftingPiece id="crpg_rondel_blade_h1" name="{=}Rondel Blade" tier="2" piece_type="Blade" mesh="rondel_blade" full_scale="true" length="31.4" weight="0.1" excluded_item_usage_features="swing">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_2" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="3.9" />
     </BladeData>
@@ -28346,12 +28346,12 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_pommel_h2" name="{=}Rondel Pommel" tier="4" piece_type="Pommel" mesh="rondel_pommel" culture="Culture.battania" full_scale="true" length="1.02" weight="0.2">
+  <CraftingPiece id="crpg_rondel_pommel_h2" name="{=}Rondel Pommel" tier="4" piece_type="Pommel" mesh="rondel_pommel" culture="Culture.battania" full_scale="true" length="1.02" weight="0.13">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_rondel_pommel_h3" name="{=}Rondel Pommel" tier="4" piece_type="Pommel" mesh="rondel_pommel" culture="Culture.battania" full_scale="true" length="1.02" weight="0.2">
+  <CraftingPiece id="crpg_rondel_pommel_h3" name="{=}Rondel Pommel" tier="4" piece_type="Pommel" mesh="rondel_pommel" culture="Culture.battania" full_scale="true" length="1.02" weight="0.13">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>

--- a/items.json
+++ b/items.json
@@ -44623,10 +44623,10 @@
     "name": "Falx Knife",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4086,
+    "price": 1716,
     "weight": 0.53,
     "rank": 0,
-    "tier": 7.377295,
+    "tier": 4.39590073,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44645,7 +44645,7 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 34,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 103,
         "swingDamage": 0,
@@ -44660,10 +44660,10 @@
     "name": "Falx Knife +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 4513,
-    "weight": 0.53,
+    "price": 1740,
+    "weight": 0.22,
     "rank": 1,
-    "tier": 7.809491,
+    "tier": 4.433961,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44677,17 +44677,17 @@
         "stackAmount": 0,
         "length": 54,
         "balance": 1.0,
-        "handling": 116,
+        "handling": 121,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 35,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 125
+        "swingSpeed": 131
       }
     ]
   },
@@ -44697,10 +44697,10 @@
     "name": "Falx Knife +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5073,
-    "weight": 0.53,
+    "price": 2010,
+    "weight": 0.22,
     "rank": 2,
-    "tier": 8.346952,
+    "tier": 4.84555,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44714,17 +44714,17 @@
         "stackAmount": 0,
         "length": 54,
         "balance": 1.0,
-        "handling": 116,
+        "handling": 121,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 36,
+        "thrustDamage": 33,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 125
+        "swingSpeed": 131
       }
     ]
   },
@@ -44734,10 +44734,10 @@
     "name": "Falx Knife +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 5783,
-    "weight": 0.53,
+    "price": 2350,
+    "weight": 0.22,
     "rank": 3,
-    "tier": 8.987175,
+    "tier": 5.327701,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -44751,17 +44751,17 @@
         "stackAmount": 0,
         "length": 54,
         "balance": 1.0,
-        "handling": 116,
+        "handling": 121,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 37,
+        "thrustDamage": 34,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
+        "thrustSpeed": 106,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 125
+        "swingSpeed": 131
       }
     ]
   },
@@ -63009,10 +63009,10 @@
     "name": "Highland Dagger",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 2143,
+    "price": 1014,
     "weight": 1.65,
     "rank": 0,
-    "tier": 5.038997,
+    "tier": 3.13152981,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -63031,10 +63031,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 24,
+        "swingDamage": 22,
         "swingDamageType": "Cut",
         "swingSpeed": 108
       },
@@ -63055,7 +63055,7 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 34,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
         "swingDamage": 0,
@@ -63070,10 +63070,10 @@
     "name": "Highland Dagger +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1810,
-    "weight": 1.65,
+    "price": 862,
+    "weight": 1.56,
     "rank": 1,
-    "tier": 4.5428915,
+    "tier": 2.80659032,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -63092,12 +63092,12 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 25,
+        "thrustSpeed": 91,
+        "swingDamage": 22,
         "swingDamageType": "Cut",
-        "swingSpeed": 108
+        "swingSpeed": 109
       },
       {
         "class": "ThrowingKnife",
@@ -63116,12 +63116,12 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 35,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 91,
         "swingDamage": 0,
         "swingDamageType": "Cut",
-        "swingSpeed": 108
+        "swingSpeed": 109
       }
     ]
   },
@@ -63131,71 +63131,10 @@
     "name": "Highland Dagger +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 2055,
-    "weight": 1.56,
-    "rank": 2,
-    "tier": 4.91145039,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 37,
-        "balance": 1.0,
-        "handling": 113,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 18,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 26,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
-      },
-      {
-        "class": "ThrowingKnife",
-        "itemUsage": "throwing_knife",
-        "accuracy": 95,
-        "missileSpeed": 30,
-        "stackAmount": 1,
-        "length": 37,
-        "balance": 1.0,
-        "handling": 113,
-        "bodyArmor": 3,
-        "flags": [
-          "RangedWeapon",
-          "Consumable",
-          "UnloadWhenSheathed",
-          "AutoReload",
-          "AmmoBreaksOnBounceBack"
-        ],
-        "thrustDamage": 35,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 0,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
-      }
-    ]
-  },
-  {
-    "id": "crpg_highland_dagger_h3",
-    "baseId": "crpg_highland_dagger",
-    "name": "Highland Dagger +3",
-    "culture": "Battania",
-    "type": "OneHandedWeapon",
-    "price": 3067,
+    "price": 995,
     "weight": 1.51,
-    "rank": 3,
-    "tier": 6.24297237,
+    "rank": 2,
+    "tier": 3.09329867,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -63214,10 +63153,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 10,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
-        "swingDamage": 28,
+        "swingDamage": 23,
         "swingDamageType": "Cut",
         "swingSpeed": 110
       },
@@ -63238,7 +63177,68 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 36,
+        "thrustDamage": 19,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 92,
+        "swingDamage": 0,
+        "swingDamageType": "Cut",
+        "swingSpeed": 110
+      }
+    ]
+  },
+  {
+    "id": "crpg_highland_dagger_h3",
+    "baseId": "crpg_highland_dagger",
+    "name": "Highland Dagger +3",
+    "culture": "Battania",
+    "type": "OneHandedWeapon",
+    "price": 1035,
+    "weight": 1.51,
+    "rank": 3,
+    "tier": 3.17529488,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "Dagger",
+        "itemUsage": "onehanded_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 37,
+        "balance": 1.0,
+        "handling": 113,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 13,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 92,
+        "swingDamage": 24,
+        "swingDamageType": "Cut",
+        "swingSpeed": 110
+      },
+      {
+        "class": "ThrowingKnife",
+        "itemUsage": "throwing_knife",
+        "accuracy": 95,
+        "missileSpeed": 30,
+        "stackAmount": 1,
+        "length": 37,
+        "balance": 1.0,
+        "handling": 113,
+        "bodyArmor": 3,
+        "flags": [
+          "RangedWeapon",
+          "Consumable",
+          "UnloadWhenSheathed",
+          "AutoReload",
+          "AmmoBreaksOnBounceBack"
+        ],
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 92,
         "swingDamage": 0,
@@ -117577,10 +117577,10 @@
     "name": "Pugio",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 2183,
-    "weight": 1.64,
+    "price": 3627,
+    "weight": 1.25,
     "rank": 0,
-    "tier": 5.096213,
+    "tier": 6.88583755,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -117588,33 +117588,33 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
+        "itemUsage": "onehanded_shield_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 35,
         "balance": 1.0,
-        "handling": 113,
+        "handling": 115,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 16,
+        "thrustDamage": 28,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 24,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
+        "thrustSpeed": 94,
+        "swingDamage": 0,
+        "swingDamageType": "Undefined",
+        "swingSpeed": 115
       },
       {
         "class": "ThrowingKnife",
         "itemUsage": "throwing_knife",
         "accuracy": 95,
-        "missileSpeed": 30,
+        "missileSpeed": 31,
         "stackAmount": 1,
         "length": 35,
         "balance": 1.0,
-        "handling": 113,
+        "handling": 115,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -117623,12 +117623,12 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 34,
+        "thrustDamage": 47,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 94,
         "swingDamage": 0,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
+        "swingDamageType": "Undefined",
+        "swingSpeed": 115
       }
     ]
   },
@@ -117638,10 +117638,10 @@
     "name": "Pugio +1",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1843,
-    "weight": 1.64,
+    "price": 3111,
+    "weight": 1.14,
     "rank": 1,
-    "tier": 4.594449,
+    "tier": 6.295926,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -117649,33 +117649,33 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
+        "itemUsage": "onehanded_shield_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 35,
         "balance": 1.0,
-        "handling": 113,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 31,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 25,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
+        "thrustSpeed": 95,
+        "swingDamage": 0,
+        "swingDamageType": "Undefined",
+        "swingSpeed": 117
       },
       {
         "class": "ThrowingKnife",
         "itemUsage": "throwing_knife",
         "accuracy": 95,
-        "missileSpeed": 30,
+        "missileSpeed": 31,
         "stackAmount": 1,
         "length": 35,
         "balance": 1.0,
-        "handling": 113,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -117684,12 +117684,12 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 34,
+        "thrustDamage": 48,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 95,
         "swingDamage": 0,
-        "swingDamageType": "Cut",
-        "swingSpeed": 109
+        "swingDamageType": "Undefined",
+        "swingSpeed": 117
       }
     ]
   },
@@ -117699,10 +117699,10 @@
     "name": "Pugio +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 2150,
-    "weight": 1.59,
+    "price": 3050,
+    "weight": 1.09,
     "rank": 2,
-    "tier": 5.049335,
+    "tier": 6.2236104,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -117710,33 +117710,33 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
+        "itemUsage": "onehanded_shield_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 35,
         "balance": 1.0,
-        "handling": 114,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 18,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 26,
-        "swingDamageType": "Cut",
-        "swingSpeed": 110
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Undefined",
+        "swingSpeed": 118
       },
       {
         "class": "ThrowingKnife",
         "itemUsage": "throwing_knife",
         "accuracy": 95,
-        "missileSpeed": 30,
+        "missileSpeed": 32,
         "stackAmount": 1,
         "length": 35,
         "balance": 1.0,
-        "handling": 114,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -117745,12 +117745,12 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 35,
+        "thrustDamage": 49,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
+        "thrustSpeed": 96,
         "swingDamage": 0,
-        "swingDamageType": "Cut",
-        "swingSpeed": 110
+        "swingDamageType": "Undefined",
+        "swingSpeed": 118
       }
     ]
   },
@@ -117760,10 +117760,10 @@
     "name": "Pugio +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 3210,
-    "weight": 1.55,
+    "price": 3221,
+    "weight": 1.05,
     "rank": 3,
-    "tier": 6.41317368,
+    "tier": 6.425602,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -117771,33 +117771,33 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
+        "itemUsage": "onehanded_shield_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 35,
         "balance": 1.0,
-        "handling": 114,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 35,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 28,
-        "swingDamageType": "Cut",
-        "swingSpeed": 111
+        "thrustSpeed": 96,
+        "swingDamage": 0,
+        "swingDamageType": "Undefined",
+        "swingSpeed": 118
       },
       {
         "class": "ThrowingKnife",
         "itemUsage": "throwing_knife",
         "accuracy": 95,
-        "missileSpeed": 30,
+        "missileSpeed": 32,
         "stackAmount": 1,
         "length": 35,
         "balance": 1.0,
-        "handling": 114,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "RangedWeapon",
@@ -117806,12 +117806,12 @@
           "AutoReload",
           "AmmoBreaksOnBounceBack"
         ],
-        "thrustDamage": 37,
+        "thrustDamage": 51,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
+        "thrustSpeed": 96,
         "swingDamage": 0,
-        "swingDamageType": "Cut",
-        "swingSpeed": 111
+        "swingDamageType": "Undefined",
+        "swingSpeed": 118
       }
     ]
   },
@@ -122155,10 +122155,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 3889,
-    "weight": 1.2,
+    "price": 4843,
+    "weight": 0.93,
     "rank": 0,
-    "tier": 7.16952038,
+    "tier": 8.12953,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122179,10 +122179,10 @@
         ],
         "thrustDamage": 38,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
+        "thrustSpeed": 97,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 118
+        "swingSpeed": 123
       }
     ]
   },
@@ -122192,10 +122192,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 4105,
-    "weight": 1.2,
+    "price": 5116,
+    "weight": 0.93,
     "rank": 1,
-    "tier": 7.396811,
+    "tier": 8.387259,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122216,10 +122216,10 @@
         ],
         "thrustDamage": 39,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
+        "thrustSpeed": 97,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 118
+        "swingSpeed": 123
       }
     ]
   },
@@ -122229,10 +122229,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 3775,
-    "weight": 0.93,
+    "price": 4959,
+    "weight": 0.75,
     "rank": 2,
-    "tier": 7.047624,
+    "tier": 8.24008751,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122246,17 +122246,17 @@
         "stackAmount": 0,
         "length": 41,
         "balance": 1.0,
-        "handling": 115,
+        "handling": 117,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 39,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
+        "thrustSpeed": 100,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 123
+        "swingSpeed": 125
       }
     ]
   },
@@ -122266,10 +122266,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 4161,
-    "weight": 0.93,
+    "price": 5476,
+    "weight": 0.75,
     "rank": 3,
-    "tier": 7.454511,
+    "tier": 8.715819,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122283,17 +122283,17 @@
         "stackAmount": 0,
         "length": 41,
         "balance": 1.0,
-        "handling": 115,
+        "handling": 117,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 40,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
+        "thrustSpeed": 100,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 123
+        "swingSpeed": 125
       }
     ]
   },
@@ -127537,10 +127537,10 @@
     "name": "Seax",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4870,
-    "weight": 0.63,
+    "price": 3285,
+    "weight": 2.07,
     "rank": 0,
-    "tier": 8.155311,
+    "tier": 6.49956369,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -127549,23 +127549,23 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_thrust",
+        "itemUsage": "onehanded_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 1.0,
-        "handling": 117,
+        "balance": 0.91,
+        "handling": 104,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 35,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 101,
-        "swingDamage": 0,
-        "swingDamageType": "Undefined",
-        "swingSpeed": 124
+        "thrustSpeed": 87,
+        "swingDamage": 30,
+        "swingDamageType": "Cut",
+        "swingSpeed": 97
       }
     ]
   },
@@ -127575,10 +127575,10 @@
     "name": "Seax +1",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4123,
-    "weight": 0.49,
+    "price": 3321,
+    "weight": 1.93,
     "rank": 1,
-    "tier": 7.41499329,
+    "tier": 6.54099655,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -127587,23 +127587,23 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_thrust",
+        "itemUsage": "onehanded_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 1.0,
-        "handling": 118,
+        "balance": 0.99,
+        "handling": 105,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 35,
+        "thrustDamage": 19,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Undefined",
-        "swingSpeed": 127
+        "thrustSpeed": 88,
+        "swingDamage": 30,
+        "swingDamageType": "Cut",
+        "swingSpeed": 99
       }
     ]
   },
@@ -127613,10 +127613,10 @@
     "name": "Seax +2",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 4631,
-    "weight": 0.49,
+    "price": 3264,
+    "weight": 1.9,
     "rank": 2,
-    "tier": 7.925307,
+    "tier": 6.47593975,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -127625,23 +127625,23 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_thrust",
+        "itemUsage": "onehanded_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 1.0,
-        "handling": 118,
+        "balance": 0.99,
+        "handling": 106,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 36,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Undefined",
-        "swingSpeed": 127
+        "thrustSpeed": 88,
+        "swingDamage": 31,
+        "swingDamageType": "Cut",
+        "swingSpeed": 99
       }
     ]
   },
@@ -127651,10 +127651,10 @@
     "name": "Seax +3",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 5275,
-    "weight": 0.49,
+    "price": 3911,
+    "weight": 1.9,
     "rank": 3,
-    "tier": 8.533185,
+    "tier": 7.193189,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse",
@@ -127663,23 +127663,23 @@
     "weapons": [
       {
         "class": "Dagger",
-        "itemUsage": "onehanded_shield_thrust",
+        "itemUsage": "onehanded_shield_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 52,
-        "balance": 1.0,
-        "handling": 118,
+        "balance": 0.99,
+        "handling": 106,
         "bodyArmor": 1,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 37,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 103,
-        "swingDamage": 0,
-        "swingDamageType": "Undefined",
-        "swingSpeed": 127
+        "thrustSpeed": 88,
+        "swingDamage": 33,
+        "swingDamageType": "Cut",
+        "swingSpeed": 99
       }
     ]
   },
@@ -165005,47 +165005,10 @@
     "name": "Xiphos",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1451,
-    "weight": 1.91,
-    "rank": 0,
-    "tier": 3.95441866,
-    "requirement": 0,
-    "flags": [
-      "Civilian"
-    ],
-    "weapons": [
-      {
-        "class": "Dagger",
-        "itemUsage": "onehanded_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 45,
-        "balance": 1.0,
-        "handling": 108,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon"
-        ],
-        "thrustDamage": 16,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 88,
-        "swingDamage": 24,
-        "swingDamageType": "Cut",
-        "swingSpeed": 103
-      }
-    ]
-  },
-  {
-    "id": "crpg_xiphos_h1",
-    "baseId": "crpg_xiphos",
-    "name": "Xiphos +1",
-    "culture": "Empire",
-    "type": "OneHandedWeapon",
-    "price": 1414,
+    "price": 1917,
     "weight": 1.86,
-    "rank": 1,
-    "tier": 3.89060736,
+    "rank": 0,
+    "tier": 4.707634,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -165074,15 +165037,52 @@
     ]
   },
   {
+    "id": "crpg_xiphos_h1",
+    "baseId": "crpg_xiphos",
+    "name": "Xiphos +1",
+    "culture": "Empire",
+    "type": "OneHandedWeapon",
+    "price": 1846,
+    "weight": 1.86,
+    "rank": 1,
+    "tier": 4.598617,
+    "requirement": 0,
+    "flags": [
+      "Civilian"
+    ],
+    "weapons": [
+      {
+        "class": "Dagger",
+        "itemUsage": "onehanded_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 45,
+        "balance": 1.0,
+        "handling": 108,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon"
+        ],
+        "thrustDamage": 17,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 88,
+        "swingDamage": 26,
+        "swingDamageType": "Cut",
+        "swingSpeed": 104
+      }
+    ]
+  },
+  {
     "id": "crpg_xiphos_h2",
     "baseId": "crpg_xiphos",
     "name": "Xiphos +2",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 1657,
-    "weight": 1.78,
+    "price": 1894,
+    "weight": 1.69,
     "rank": 2,
-    "tier": 4.299712,
+    "tier": 4.67189074,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -165103,10 +165103,10 @@
         ],
         "thrustDamage": 18,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 89,
+        "thrustSpeed": 90,
         "swingDamage": 26,
         "swingDamageType": "Cut",
-        "swingSpeed": 105
+        "swingSpeed": 106
       }
     ]
   },
@@ -165116,10 +165116,10 @@
     "name": "Xiphos +3",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 2465,
+    "price": 1896,
     "weight": 1.69,
     "rank": 3,
-    "tier": 5.482981,
+    "tier": 4.674758,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -165138,10 +165138,10 @@
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 19,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 28,
+        "swingDamage": 27,
         "swingDamageType": "Cut",
         "swingSpeed": 106
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -4868,7 +4868,7 @@
       <Piece id="crpg_spiked_mace_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_h0" name="{=AOZbTGOS}Xiphos" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h0" name="{=AOZbTGOS}Xiphos" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h0" Type="Guard" scale_factor="110" />
@@ -4876,7 +4876,7 @@
       <Piece id="crpg_xiphos_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_h1" name="{=AOZbTGOS}Xiphos +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h1" name="{=AOZbTGOS}Xiphos +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h1" Type="Guard" scale_factor="110" />
@@ -4884,7 +4884,7 @@
       <Piece id="crpg_xiphos_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_h2" name="{=AOZbTGOS}Xiphos +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h2" name="{=AOZbTGOS}Xiphos +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h2" Type="Guard" scale_factor="110" />
@@ -4892,7 +4892,7 @@
       <Piece id="crpg_xiphos_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_h3" name="{=AOZbTGOS}Xiphos +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h3" name="{=AOZbTGOS}Xiphos +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h3" Type="Guard" scale_factor="110" />
@@ -4900,7 +4900,7 @@
       <Piece id="crpg_xiphos_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_h0" name="{=elTXYb9f}Falx Knife" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h0" name="{=elTXYb9f}Falx Knife" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h0" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h0" Type="Guard" />
@@ -4908,7 +4908,7 @@
       <Piece id="crpg_falx_knife_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_h1" name="{=elTXYb9f}Falx Knife +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h1" name="{=elTXYb9f}Falx Knife +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h1" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h1" Type="Guard" />
@@ -4916,7 +4916,7 @@
       <Piece id="crpg_falx_knife_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_h2" name="{=elTXYb9f}Falx Knife +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h2" name="{=elTXYb9f}Falx Knife +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h2" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h2" Type="Guard" />
@@ -4924,7 +4924,7 @@
       <Piece id="crpg_falx_knife_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_h3" name="{=elTXYb9f}Falx Knife +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h3" name="{=elTXYb9f}Falx Knife +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h3" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h3" Type="Guard" />
@@ -4932,7 +4932,7 @@
       <Piece id="crpg_falx_knife_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_h0" name="{=bVzkrtUc}Pugio" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h0" name="{=bVzkrtUc}Pugio" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h0" Type="Guard" scale_factor="90" />
@@ -4940,7 +4940,7 @@
       <Piece id="crpg_pugio_pommel_h0" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_h1" name="{=bVzkrtUc}Pugio +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h1" name="{=bVzkrtUc}Pugio +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h1" Type="Guard" scale_factor="90" />
@@ -4948,7 +4948,7 @@
       <Piece id="crpg_pugio_pommel_h1" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_h2" name="{=bVzkrtUc}Pugio +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h2" name="{=bVzkrtUc}Pugio +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h2" Type="Guard" scale_factor="90" />
@@ -4956,7 +4956,7 @@
       <Piece id="crpg_pugio_pommel_h2" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_h3" name="{=bVzkrtUc}Pugio +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h3" name="{=bVzkrtUc}Pugio +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h3" Type="Guard" scale_factor="90" />
@@ -4964,7 +4964,7 @@
       <Piece id="crpg_pugio_pommel_h3" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_h0" name="{=vPXWpJTP}Highland Dagger" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h0" name="{=vPXWpJTP}Highland Dagger" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h0" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h0" Type="Guard" />
@@ -4972,7 +4972,7 @@
       <Piece id="crpg_highland_dagger_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_h1" name="{=vPXWpJTP}Highland Dagger +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h1" name="{=vPXWpJTP}Highland Dagger +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h1" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h1" Type="Guard" />
@@ -4980,7 +4980,7 @@
       <Piece id="crpg_highland_dagger_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_h2" name="{=vPXWpJTP}Highland Dagger +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h2" name="{=vPXWpJTP}Highland Dagger +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h2" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h2" Type="Guard" />
@@ -4988,7 +4988,7 @@
       <Piece id="crpg_highland_dagger_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_h3" name="{=vPXWpJTP}Highland Dagger +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h3" name="{=vPXWpJTP}Highland Dagger +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h3" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h3" Type="Guard" />
@@ -4996,7 +4996,7 @@
       <Piece id="crpg_highland_dagger_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_h0" name="{=3Pv0SlYj}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h0" name="{=3Pv0SlYj}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h0" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h0" Type="Guard" scale_factor="90" />
@@ -5004,7 +5004,7 @@
       <Piece id="crpg_seax_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_h1" name="{=3Pv0SlYj}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h1" name="{=3Pv0SlYj}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h1" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h1" Type="Guard" scale_factor="90" />
@@ -5012,7 +5012,7 @@
       <Piece id="crpg_seax_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_h2" name="{=3Pv0SlYj}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h2" name="{=3Pv0SlYj}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h2" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h2" Type="Guard" scale_factor="90" />
@@ -5020,7 +5020,7 @@
       <Piece id="crpg_seax_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_h3" name="{=3Pv0SlYj}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h3" name="{=3Pv0SlYj}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h3" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h3" Type="Guard" scale_factor="90" />
@@ -11664,7 +11664,7 @@
       <Piece id="crpg_broadshortsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_h0" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h0" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h0" Type="Guard" scale_factor="110" />
@@ -11672,7 +11672,7 @@
       <Piece id="crpg_rondel_pommel_h0" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_h1" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h1" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h1" Type="Guard" scale_factor="110" />
@@ -11680,7 +11680,7 @@
       <Piece id="crpg_rondel_pommel_h1" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_h2" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h2" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h2" Type="Guard" scale_factor="110" />
@@ -11688,7 +11688,7 @@
       <Piece id="crpg_rondel_pommel_h2" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_h3" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h3" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h3" Type="Guard" scale_factor="110" />


### PR DESCRIPTION
Reworked daggers from ground up following a pattern like so regarding tier:

**Rondel#⁠1-Stab 8.0**
_Seax#⁠1-Cut 6.5_ 
**Pugio#2-Stab 6.5**
_Xiphos#2-Cut 4.5_
**Falx#3-Stab 4.5**
_Highland#3-Cut 3.0_

The aim is to have 2 daggers at **high tier stab and cut**, 2 daggers at **mid-tier stab and cut**, 2 daggers at **low-tier stab and cut**

Given the deficits of stab, it has a higher tier compared to cut, as cut has less restrictions applied and more freedom as a weapon.