### PR TITLE
Giving stats to Cutlass & Pavise

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -27956,28 +27956,28 @@
   <CraftingPiece id="crpg_langes_messer_handle_h3" name="{=}Langes Messer Handle" tier="3" piece_type="Handle" mesh="langes_messer_handle" culture="Culture.khuzait" length="24.6" weight="1.27">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.0" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_cutlass_blade_h0" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.0">
+  <CraftingPiece id="crpg_cutlass_blade_h0" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cutlass_blade_h1" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.0">
+  <CraftingPiece id="crpg_cutlass_blade_h1" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.4">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cutlass_blade_h2" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.0">
+  <CraftingPiece id="crpg_cutlass_blade_h2" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_cutlass_blade_h3" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.0">
+  <CraftingPiece id="crpg_cutlass_blade_h3" name="{=}Cutlass Blade" tier="4" piece_type="Blade" mesh="cutlass_blade" culture="Culture.battania" length="67.4" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_cutlass_pommel_h0" name="{=}Cutlass Pommel" tier="4" piece_type="Pommel" mesh="cutlass_pommel" culture="Culture.battania" length="8.57" weight="0.12">

--- a/items.json
+++ b/items.json
@@ -32397,10 +32397,10 @@
     "name": "Cutlass",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 114,
-    "weight": 1.37,
+    "price": 4962,
+    "weight": 1.87,
     "rank": 0,
-    "tier": 0.415943563,
+    "tier": 8.242411,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32411,18 +32411,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.83,
-        "handling": 97,
+        "balance": 0.49,
+        "handling": 90,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 13,
+        "thrustSpeed": 88,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 84
       }
     ]
   },
@@ -32432,10 +32432,10 @@
     "name": "Cutlass",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 101,
-    "weight": 1.37,
+    "price": 5235,
+    "weight": 1.77,
     "rank": 1,
-    "tier": 0.343755066,
+    "tier": 8.497213,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32446,18 +32446,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.83,
-        "handling": 97,
+        "balance": 0.55,
+        "handling": 91,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 13,
+        "thrustSpeed": 89,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 86
       }
     ]
   },
@@ -32467,10 +32467,10 @@
     "name": "Cutlass",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 92,
-    "weight": 1.37,
+    "price": 5086,
+    "weight": 1.72,
     "rank": 2,
-    "tier": 0.288849622,
+    "tier": 8.359385,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32481,18 +32481,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.83,
-        "handling": 97,
+        "balance": 0.6,
+        "handling": 92,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 13,
+        "thrustSpeed": 89,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 87
       }
     ]
   },
@@ -32502,10 +32502,10 @@
     "name": "Cutlass",
     "culture": "Aserai",
     "type": "OneHandedWeapon",
-    "price": 85,
-    "weight": 1.37,
+    "price": 5576,
+    "weight": 1.62,
     "rank": 3,
-    "tier": 0.246120363,
+    "tier": 8.804898,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -32516,18 +32516,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 88,
-        "balance": 0.83,
-        "handling": 97,
+        "balance": 0.66,
+        "handling": 93,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 13,
+        "thrustSpeed": 90,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 89
       }
     ]
   },
@@ -113549,10 +113549,10 @@
     "name": "Pavise",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 109,
+    "price": 4956,
     "weight": 4.113909,
     "rank": 0,
-    "tier": 0.386680454,
+    "tier": 8.236979,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -113565,7 +113565,7 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 130,
+        "stackAmount": 600,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
@@ -113589,10 +113589,10 @@
     "name": "Pavise +1",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 112,
+    "price": 4953,
     "weight": 4.113909,
     "rank": 1,
-    "tier": 0.4060065,
+    "tier": 8.234594,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -113605,7 +113605,7 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 141,
+        "stackAmount": 635,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
@@ -113629,10 +113629,10 @@
     "name": "Pavise +2",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 110,
+    "price": 5139,
     "weight": 4.113909,
     "rank": 2,
-    "tier": 0.391265571,
+    "tier": 8.408405,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -113645,7 +113645,7 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 151,
+        "stackAmount": 700,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
@@ -113669,10 +113669,10 @@
     "name": "Pavise +3",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 108,
+    "price": 5424,
     "weight": 4.113909,
     "rank": 3,
-    "tier": 0.383728117,
+    "tier": 8.66912,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -113685,7 +113685,7 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 162,
+        "stackAmount": 770,
         "length": 118,
         "balance": 0.0,
         "handling": 80,

--- a/items/shields.xml
+++ b/items/shields.xml
@@ -2178,7 +2178,7 @@
   </Item>
   <Item id="crpg_pavise_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" culture="Culture.vlandia" using_tableau="true" weight="4.113909" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="1" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="130" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="1" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="600" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -2186,7 +2186,7 @@
   </Item>
   <Item id="crpg_pavise_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" culture="Culture.vlandia" using_tableau="true" weight="4.113909" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="141" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="635" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -2194,7 +2194,7 @@
   </Item>
   <Item id="crpg_pavise_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" culture="Culture.vlandia" using_tableau="true" weight="4.113909" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="151" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="700" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -2202,7 +2202,7 @@
   </Item>
   <Item id="crpg_pavise_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" culture="Culture.vlandia" using_tableau="true" weight="4.113909" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="162" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" physics_material="wood_shield" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="770" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>


### PR DESCRIPTION
Assigned stats to both the Cutlass and Pavise

Cutlass matching stats (relatively closely) to the cRPG 1 item, offering good speed/handling increases with upgraded state
Pavise being a HP focused shield, hefty upgrades to HP with each loom point, but extremely low armour and no upgrades.