### PR TITLE
Yeldur Katana Rework

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -26852,7 +26852,7 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_red_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.32">
+  <CraftingPiece id="crpg_red_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -26861,46 +26861,46 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_red_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_red_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.30">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
       <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_red_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_red_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_red_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_red_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.25">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_red">
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blue_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.3">
+  <CraftingPiece id="crpg_blue_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.31">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_blue">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blue_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_blue_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.30">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_blue">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -26908,8 +26908,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_blue_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_blue">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -26918,50 +26918,14 @@
   <CraftingPiece id="crpg_blue_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_blue">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_green_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.3">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
-      <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_green_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_green_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_green_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_green_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_yellow_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.3">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
       <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
@@ -26969,10 +26933,46 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_yellow_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
+  <CraftingPiece id="crpg_green_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.30">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
       <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_green_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.25">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_green_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.25">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_green">
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_yellow_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.31">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_yellow_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.30">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -26980,8 +26980,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_yellow_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -26990,34 +26990,34 @@
   <CraftingPiece id="crpg_yellow_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_yellow">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_black_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.3">
+  <CraftingPiece id="crpg_black_katana_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_black">
       <Thrust damage_type="Pierce" damage_factor="1.5" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_black_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_black_katana_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.30">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_black">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_black_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
+  <CraftingPiece id="crpg_black_katana_blade_h2" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_black">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -27026,7 +27026,7 @@
   <CraftingPiece id="crpg_black_katana_blade_h3" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="0.2">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="katana_sheath_black">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />

--- a/items.json
+++ b/items.json
@@ -18067,10 +18067,10 @@
     "name": "Black Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 14027,
-    "weight": 2.91,
+    "price": 6371,
+    "weight": 2.93,
     "rank": 0,
-    "tier": 10.0109644,
+    "tier": 6.3999567,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18080,9 +18080,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.9,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.94,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -18091,9 +18091,9 @@
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 98
       }
     ]
   },
@@ -18103,10 +18103,10 @@
     "name": "Black Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11927,
-    "weight": 2.81,
+    "price": 6612,
+    "weight": 2.89,
     "rank": 1,
-    "tier": 9.14709949,
+    "tier": 6.539037,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18116,20 +18116,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.97,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 17,
+        "thrustDamage": 15,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -18139,10 +18139,10 @@
     "name": "Black Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11406,
-    "weight": 2.81,
+    "price": 6219,
+    "weight": 2.84,
     "rank": 2,
-    "tier": 8.92118,
+    "tier": 6.31047153,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18152,20 +18152,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.98,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 18,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 38,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -18175,10 +18175,10 @@
     "name": "Black Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 12569,
-    "weight": 2.81,
+    "price": 7029,
+    "weight": 2.79,
     "rank": 3,
-    "tier": 9.418371,
+    "tier": 6.77471,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18188,9 +18188,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 1.0,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -18199,9 +18199,9 @@
         "thrustDamage": 21,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 40,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 100
       }
     ]
   },
@@ -18755,10 +18755,10 @@
     "name": "Blue Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 14027,
-    "weight": 2.91,
+    "price": 7892,
+    "weight": 2.9,
     "rank": 0,
-    "tier": 10.0109644,
+    "tier": 7.241481,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18768,9 +18768,81 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.9,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.96,
+        "handling": 78,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 98
+      }
+    ]
+  },
+  {
+    "id": "crpg_blue_katana_h1",
+    "baseId": "crpg_blue_katana",
+    "name": "Blue Katana +1",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 8146,
+    "weight": 2.89,
+    "rank": 1,
+    "tier": 7.37393665,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 95,
+        "balance": 0.97,
+        "handling": 78,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 36,
+        "swingDamageType": "Cut",
+        "swingSpeed": 99
+      }
+    ]
+  },
+  {
+    "id": "crpg_blue_katana_h2",
+    "baseId": "crpg_blue_katana",
+    "name": "Blue Katana +2",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 8596,
+    "weight": 2.79,
+    "rank": 2,
+    "tier": 7.603887,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 95,
+        "balance": 1.0,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -18781,20 +18853,20 @@
         "thrustSpeed": 87,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 100
       }
     ]
   },
   {
-    "id": "crpg_blue_katana_h1",
+    "id": "crpg_blue_katana_h3",
     "baseId": "crpg_blue_katana",
-    "name": "Blue Katana +1",
+    "name": "Blue Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11927,
-    "weight": 2.81,
-    "rank": 1,
-    "tier": 9.14709949,
+    "price": 8536,
+    "weight": 2.79,
+    "rank": 3,
+    "tier": 7.573396,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -18804,45 +18876,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 37,
-        "swingDamageType": "Cut",
-        "swingSpeed": 98
-      }
-    ]
-  },
-  {
-    "id": "crpg_blue_katana_h2",
-    "baseId": "crpg_blue_katana",
-    "name": "Blue Katana +2",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 11406,
-    "weight": 2.81,
-    "rank": 2,
-    "tier": 8.92118,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 1.0,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -18853,43 +18889,7 @@
         "thrustSpeed": 87,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
-      }
-    ]
-  },
-  {
-    "id": "crpg_blue_katana_h3",
-    "baseId": "crpg_blue_katana",
-    "name": "Blue Katana +3",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 12569,
-    "weight": 2.81,
-    "rank": 3,
-    "tier": 9.418371,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 21,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 40,
-        "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 100
       }
     ]
   },
@@ -55517,10 +55517,10 @@
     "name": "Green Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 14027,
-    "weight": 2.91,
+    "price": 12000,
+    "weight": 2.93,
     "rank": 0,
-    "tier": 10.0109644,
+    "tier": 9.178157,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55530,9 +55530,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.9,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.94,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -55543,7 +55543,7 @@
         "thrustSpeed": 87,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 98
       }
     ]
   },
@@ -55553,10 +55553,10 @@
     "name": "Green Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11927,
-    "weight": 2.81,
+    "price": 12475,
+    "weight": 2.89,
     "rank": 1,
-    "tier": 9.14709949,
+    "tier": 9.379419,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55566,9 +55566,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.97,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -55577,9 +55577,9 @@
         "thrustDamage": 17,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -55589,10 +55589,10 @@
     "name": "Green Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11406,
-    "weight": 2.81,
+    "price": 12051,
+    "weight": 2.84,
     "rank": 2,
-    "tier": 8.92118,
+    "tier": 9.200023,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55602,20 +55602,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.98,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 38,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -55625,10 +55625,10 @@
     "name": "Green Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 12569,
-    "weight": 2.81,
+    "price": 12249,
+    "weight": 2.84,
     "rank": 3,
-    "tier": 9.418371,
+    "tier": 9.283962,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -55638,20 +55638,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.98,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -120275,10 +120275,10 @@
     "name": "Red Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11915,
+    "price": 12000,
     "weight": 2.93,
     "rank": 0,
-    "tier": 9.141764,
+    "tier": 9.178157,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -120288,9 +120288,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.88,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.94,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -120298,10 +120298,10 @@
         ],
         "thrustDamage": 15,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 86,
+        "thrustSpeed": 87,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 96
+        "swingSpeed": 98
       }
     ]
   },
@@ -120311,10 +120311,10 @@
     "name": "Red Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11927,
-    "weight": 2.81,
+    "price": 12475,
+    "weight": 2.89,
     "rank": 1,
-    "tier": 9.14709949,
+    "tier": 9.379419,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -120324,9 +120324,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.97,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -120335,9 +120335,9 @@
         "thrustDamage": 17,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 37,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -120347,10 +120347,10 @@
     "name": "Red Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11406,
-    "weight": 2.81,
+    "price": 12051,
+    "weight": 2.84,
     "rank": 2,
-    "tier": 8.92118,
+    "tier": 9.200023,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -120360,20 +120360,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.98,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 38,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -120383,10 +120383,10 @@
     "name": "Red Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 12569,
-    "weight": 2.81,
+    "price": 12249,
+    "weight": 2.84,
     "rank": 3,
-    "tier": 9.418371,
+    "tier": 9.283962,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -120396,20 +120396,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.98,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 26,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
         "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 99
       }
     ]
   },
@@ -166641,10 +166641,10 @@
     "name": "Yellow Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 14027,
-    "weight": 2.91,
+    "price": 7892,
+    "weight": 2.9,
     "rank": 0,
-    "tier": 10.0109644,
+    "tier": 7.241481,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -166654,9 +166654,81 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.9,
-        "handling": 77,
+        "length": 95,
+        "balance": 0.96,
+        "handling": 78,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 35,
+        "swingDamageType": "Cut",
+        "swingSpeed": 98
+      }
+    ]
+  },
+  {
+    "id": "crpg_yellow_katana_h1",
+    "baseId": "crpg_yellow_katana",
+    "name": "Yellow Katana +1",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 8146,
+    "weight": 2.89,
+    "rank": 1,
+    "tier": 7.37393665,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 95,
+        "balance": 0.97,
+        "handling": 78,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 15,
+        "thrustDamageType": "Pierce",
+        "thrustSpeed": 87,
+        "swingDamage": 36,
+        "swingDamageType": "Cut",
+        "swingSpeed": 99
+      }
+    ]
+  },
+  {
+    "id": "crpg_yellow_katana_h2",
+    "baseId": "crpg_yellow_katana",
+    "name": "Yellow Katana +2",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 8596,
+    "weight": 2.79,
+    "rank": 2,
+    "tier": 7.603887,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 95,
+        "balance": 1.0,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -166667,20 +166739,20 @@
         "thrustSpeed": 87,
         "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 97
+        "swingSpeed": 100
       }
     ]
   },
   {
-    "id": "crpg_yellow_katana_h1",
+    "id": "crpg_yellow_katana_h3",
     "baseId": "crpg_yellow_katana",
-    "name": "Yellow Katana +1",
+    "name": "Yellow Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11927,
-    "weight": 2.81,
-    "rank": 1,
-    "tier": 9.14709949,
+    "price": 8536,
+    "weight": 2.79,
+    "rank": 3,
+    "tier": 7.573396,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -166690,45 +166762,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 17,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 37,
-        "swingDamageType": "Cut",
-        "swingSpeed": 98
-      }
-    ]
-  },
-  {
-    "id": "crpg_yellow_katana_h2",
-    "baseId": "crpg_yellow_katana",
-    "name": "Yellow Katana +2",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 11406,
-    "weight": 2.81,
-    "rank": 2,
-    "tier": 8.92118,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
+        "length": 95,
+        "balance": 1.0,
+        "handling": 78,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -166739,43 +166775,7 @@
         "thrustSpeed": 87,
         "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
-      }
-    ]
-  },
-  {
-    "id": "crpg_yellow_katana_h3",
-    "baseId": "crpg_yellow_katana",
-    "name": "Yellow Katana +3",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 12569,
-    "weight": 2.81,
-    "rank": 3,
-    "tier": 9.418371,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 102,
-        "balance": 0.94,
-        "handling": 77,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 21,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 40,
-        "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 100
       }
     ]
   },

--- a/items.json
+++ b/items.json
@@ -18062,8 +18062,8 @@
     ]
   },
   {
-    "id": "crpg_black_katana_h0",
-    "baseId": "crpg_black_katana",
+    "id": "crpg_black_katana_v1_h0",
+    "baseId": "crpg_black_katana_v1",
     "name": "Black Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18098,8 +18098,8 @@
     ]
   },
   {
-    "id": "crpg_black_katana_h1",
-    "baseId": "crpg_black_katana",
+    "id": "crpg_black_katana_v1_h1",
+    "baseId": "crpg_black_katana_v1",
     "name": "Black Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18134,8 +18134,8 @@
     ]
   },
   {
-    "id": "crpg_black_katana_h2",
-    "baseId": "crpg_black_katana",
+    "id": "crpg_black_katana_v1_h2",
+    "baseId": "crpg_black_katana_v1",
     "name": "Black Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18170,8 +18170,8 @@
     ]
   },
   {
-    "id": "crpg_black_katana_h3",
-    "baseId": "crpg_black_katana",
+    "id": "crpg_black_katana_v1_h3",
+    "baseId": "crpg_black_katana_v1",
     "name": "Black Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18750,8 +18750,8 @@
     ]
   },
   {
-    "id": "crpg_blue_katana_h0",
-    "baseId": "crpg_blue_katana",
+    "id": "crpg_blue_katana_v1_h0",
+    "baseId": "crpg_blue_katana_v1",
     "name": "Blue Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18786,8 +18786,8 @@
     ]
   },
   {
-    "id": "crpg_blue_katana_h1",
-    "baseId": "crpg_blue_katana",
+    "id": "crpg_blue_katana_v1_h1",
+    "baseId": "crpg_blue_katana_v1",
     "name": "Blue Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18822,8 +18822,8 @@
     ]
   },
   {
-    "id": "crpg_blue_katana_h2",
-    "baseId": "crpg_blue_katana",
+    "id": "crpg_blue_katana_v1_h2",
+    "baseId": "crpg_blue_katana_v1",
     "name": "Blue Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -18858,8 +18858,8 @@
     ]
   },
   {
-    "id": "crpg_blue_katana_h3",
-    "baseId": "crpg_blue_katana",
+    "id": "crpg_blue_katana_v1_h3",
+    "baseId": "crpg_blue_katana_v1",
     "name": "Blue Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -55512,8 +55512,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_green_katana_h0",
-    "baseId": "crpg_green_katana",
+    "id": "crpg_green_katana_v1_h0",
+    "baseId": "crpg_green_katana_v1",
     "name": "Green Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -55548,8 +55548,8 @@
     ]
   },
   {
-    "id": "crpg_green_katana_h1",
-    "baseId": "crpg_green_katana",
+    "id": "crpg_green_katana_v1_h1",
+    "baseId": "crpg_green_katana_v1",
     "name": "Green Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -55584,8 +55584,8 @@
     ]
   },
   {
-    "id": "crpg_green_katana_h2",
-    "baseId": "crpg_green_katana",
+    "id": "crpg_green_katana_v1_h2",
+    "baseId": "crpg_green_katana_v1",
     "name": "Green Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -55620,8 +55620,8 @@
     ]
   },
   {
-    "id": "crpg_green_katana_h3",
-    "baseId": "crpg_green_katana",
+    "id": "crpg_green_katana_v1_h3",
+    "baseId": "crpg_green_katana_v1",
     "name": "Green Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -120270,8 +120270,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_red_katana_h0",
-    "baseId": "crpg_red_katana",
+    "id": "crpg_red_katana_v1_h0",
+    "baseId": "crpg_red_katana_v1",
     "name": "Red Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -120306,8 +120306,8 @@
     ]
   },
   {
-    "id": "crpg_red_katana_h1",
-    "baseId": "crpg_red_katana",
+    "id": "crpg_red_katana_v1_h1",
+    "baseId": "crpg_red_katana_v1",
     "name": "Red Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -120342,8 +120342,8 @@
     ]
   },
   {
-    "id": "crpg_red_katana_h2",
-    "baseId": "crpg_red_katana",
+    "id": "crpg_red_katana_v1_h2",
+    "baseId": "crpg_red_katana_v1",
     "name": "Red Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -120378,8 +120378,8 @@
     ]
   },
   {
-    "id": "crpg_red_katana_h3",
-    "baseId": "crpg_red_katana",
+    "id": "crpg_red_katana_v1_h3",
+    "baseId": "crpg_red_katana_v1",
     "name": "Red Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -166636,8 +166636,8 @@
     ]
   },
   {
-    "id": "crpg_yellow_katana_h0",
-    "baseId": "crpg_yellow_katana",
+    "id": "crpg_yellow_katana_v1_h0",
+    "baseId": "crpg_yellow_katana_v1",
     "name": "Yellow Katana",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -166672,8 +166672,8 @@
     ]
   },
   {
-    "id": "crpg_yellow_katana_h1",
-    "baseId": "crpg_yellow_katana",
+    "id": "crpg_yellow_katana_v1_h1",
+    "baseId": "crpg_yellow_katana_v1",
     "name": "Yellow Katana +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -166708,8 +166708,8 @@
     ]
   },
   {
-    "id": "crpg_yellow_katana_h2",
-    "baseId": "crpg_yellow_katana",
+    "id": "crpg_yellow_katana_v1_h2",
+    "baseId": "crpg_yellow_katana_v1",
     "name": "Yellow Katana +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -166744,8 +166744,8 @@
     ]
   },
   {
-    "id": "crpg_yellow_katana_h3",
-    "baseId": "crpg_yellow_katana",
+    "id": "crpg_yellow_katana_v1_h3",
+    "baseId": "crpg_yellow_katana_v1",
     "name": "Yellow Katana +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -264,7 +264,7 @@
       <Piece id="crpg_light_goedendag_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_katana_h0" name="{=}Black Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_black_katana_v1_h0" name="{=}Black Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h0" Type="Guard" scale_factor="100" />
@@ -272,7 +272,7 @@
       <Piece id="crpg_black_katana_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_katana_h1" name="{=}Black Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_black_katana_v1_h1" name="{=}Black Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h1" Type="Guard" scale_factor="100" />
@@ -280,7 +280,7 @@
       <Piece id="crpg_black_katana_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_katana_h2" name="{=}Black Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_black_katana_v1_h2" name="{=}Black Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h2" Type="Guard" scale_factor="100" />
@@ -288,7 +288,7 @@
       <Piece id="crpg_black_katana_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_katana_h3" name="{=}Black Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_black_katana_v1_h3" name="{=}Black Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h3" Type="Guard" scale_factor="100" />
@@ -296,7 +296,7 @@
       <Piece id="crpg_black_katana_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_yellow_katana_h0" name="{=}Yellow Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_yellow_katana_v1_h0" name="{=}Yellow Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_yellow_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h0" Type="Guard" scale_factor="100" />
@@ -304,7 +304,7 @@
       <Piece id="crpg_yellow_katana_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_yellow_katana_h1" name="{=}Yellow Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_yellow_katana_v1_h1" name="{=}Yellow Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_yellow_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h1" Type="Guard" scale_factor="100" />
@@ -312,7 +312,7 @@
       <Piece id="crpg_yellow_katana_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_yellow_katana_h2" name="{=}Yellow Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_yellow_katana_v1_h2" name="{=}Yellow Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_yellow_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h2" Type="Guard" scale_factor="100" />
@@ -320,7 +320,7 @@
       <Piece id="crpg_yellow_katana_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_yellow_katana_h3" name="{=}Yellow Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_yellow_katana_v1_h3" name="{=}Yellow Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_yellow_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h3" Type="Guard" scale_factor="100" />
@@ -328,7 +328,7 @@
       <Piece id="crpg_yellow_katana_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_katana_h0" name="{=}Green Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_katana_v1_h0" name="{=}Green Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h0" Type="Guard" scale_factor="100" />
@@ -336,7 +336,7 @@
       <Piece id="crpg_green_katana_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_katana_h1" name="{=}Green Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_katana_v1_h1" name="{=}Green Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h1" Type="Guard" scale_factor="100" />
@@ -344,7 +344,7 @@
       <Piece id="crpg_green_katana_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_katana_h2" name="{=}Green Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_katana_v1_h2" name="{=}Green Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h2" Type="Guard" scale_factor="100" />
@@ -352,7 +352,7 @@
       <Piece id="crpg_green_katana_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_katana_h3" name="{=}Green Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_katana_v1_h3" name="{=}Green Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h3" Type="Guard" scale_factor="100" />
@@ -360,7 +360,7 @@
       <Piece id="crpg_green_katana_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blue_katana_h0" name="{=}Blue Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_blue_katana_v1_h0" name="{=}Blue Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_blue_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h0" Type="Guard" scale_factor="100" />
@@ -368,7 +368,7 @@
       <Piece id="crpg_blue_katana_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blue_katana_h1" name="{=}Blue Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_blue_katana_v1_h1" name="{=}Blue Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_blue_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h1" Type="Guard" scale_factor="100" />
@@ -376,7 +376,7 @@
       <Piece id="crpg_blue_katana_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blue_katana_h2" name="{=}Blue Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_blue_katana_v1_h2" name="{=}Blue Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_blue_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h2" Type="Guard" scale_factor="100" />
@@ -384,7 +384,7 @@
       <Piece id="crpg_blue_katana_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blue_katana_h3" name="{=}Blue Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_blue_katana_v1_h3" name="{=}Blue Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_blue_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h3" Type="Guard" scale_factor="100" />
@@ -392,7 +392,7 @@
       <Piece id="crpg_blue_katana_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_red_katana_h0" name="{=}Red Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_red_katana_v1_h0" name="{=}Red Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_red_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h0" Type="Guard" scale_factor="100" />
@@ -400,7 +400,7 @@
       <Piece id="crpg_red_katana_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_red_katana_h1" name="{=}Red Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_red_katana_v1_h1" name="{=}Red Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_red_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h1" Type="Guard" scale_factor="100" />
@@ -408,7 +408,7 @@
       <Piece id="crpg_red_katana_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_red_katana_h2" name="{=}Red Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_red_katana_v1_h2" name="{=}Red Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_red_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h2" Type="Guard" scale_factor="100" />
@@ -416,7 +416,7 @@
       <Piece id="crpg_red_katana_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_red_katana_h3" name="{=}Red Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_red_katana_v1_h3" name="{=}Red Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_red_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -266,7 +266,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_black_katana_h0" name="{=}Black Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_black_katana_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_black_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_black_katana_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_black_katana_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -274,7 +274,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_black_katana_h1" name="{=}Black Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_black_katana_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_black_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_black_katana_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_black_katana_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -282,7 +282,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_black_katana_h2" name="{=}Black Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_black_katana_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_black_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_black_katana_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_black_katana_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -290,7 +290,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_black_katana_h3" name="{=}Black Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_black_katana_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_black_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_black_katana_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_black_katana_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_black_katana_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -298,7 +298,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_yellow_katana_h0" name="{=}Yellow Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_yellow_katana_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_yellow_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_yellow_katana_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_yellow_katana_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -306,7 +306,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_yellow_katana_h1" name="{=}Yellow Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_yellow_katana_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_yellow_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_yellow_katana_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_yellow_katana_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -314,7 +314,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_yellow_katana_h2" name="{=}Yellow Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_yellow_katana_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_yellow_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_yellow_katana_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_yellow_katana_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -322,7 +322,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_yellow_katana_h3" name="{=}Yellow Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_yellow_katana_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_yellow_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_yellow_katana_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_yellow_katana_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_yellow_katana_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -330,7 +330,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_green_katana_h0" name="{=}Green Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_green_katana_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_green_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_green_katana_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_green_katana_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -338,7 +338,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_green_katana_h1" name="{=}Green Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_green_katana_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_green_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_green_katana_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_green_katana_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -346,7 +346,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_green_katana_h2" name="{=}Green Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_green_katana_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_green_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_green_katana_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_green_katana_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -354,7 +354,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_green_katana_h3" name="{=}Green Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_green_katana_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_green_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_green_katana_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_green_katana_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_green_katana_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -362,7 +362,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_blue_katana_h0" name="{=}Blue Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_blue_katana_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_blue_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_blue_katana_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_blue_katana_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -370,7 +370,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_blue_katana_h1" name="{=}Blue Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_blue_katana_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_blue_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_blue_katana_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_blue_katana_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -378,7 +378,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_blue_katana_h2" name="{=}Blue Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_blue_katana_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_blue_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_blue_katana_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_blue_katana_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -386,7 +386,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_blue_katana_h3" name="{=}Blue Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_blue_katana_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_blue_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_blue_katana_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_blue_katana_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_blue_katana_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -394,7 +394,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_red_katana_h0" name="{=}Red Katana" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_red_katana_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_red_katana_blade_h0" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_red_katana_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_red_katana_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -402,7 +402,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_red_katana_h1" name="{=}Red Katana +1" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_red_katana_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_red_katana_blade_h1" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_red_katana_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_red_katana_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -410,7 +410,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_red_katana_h2" name="{=}Red Katana +2" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_red_katana_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_red_katana_blade_h2" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_red_katana_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_red_katana_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -418,7 +418,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_red_katana_h3" name="{=}Red Katana +3" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_red_katana_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_red_katana_blade_h3" Type="Blade" scale_factor="92" />
       <Piece id="crpg_red_katana_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_red_katana_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_red_katana_pommel_h3" Type="Pommel" scale_factor="100" />
@@ -4872,7 +4872,7 @@
       <Piece id="crpg_spiked_mace_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_v1_h0" name="{=AOZbTGOS}Xiphos" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h0" name="{=Yeldur}Xiphos" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h0" Type="Guard" scale_factor="110" />
@@ -4880,7 +4880,7 @@
       <Piece id="crpg_xiphos_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_v1_h1" name="{=AOZbTGOS}Xiphos +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h1" name="{=Yeldur}Xiphos +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h1" Type="Guard" scale_factor="110" />
@@ -4888,7 +4888,7 @@
       <Piece id="crpg_xiphos_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_v1_h2" name="{=AOZbTGOS}Xiphos +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h2" name="{=Yeldur}Xiphos +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h2" Type="Guard" scale_factor="110" />
@@ -4896,7 +4896,7 @@
       <Piece id="crpg_xiphos_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_xiphos_v1_h3" name="{=AOZbTGOS}Xiphos +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_xiphos_v1_h3" name="{=Yeldur}Xiphos +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_xiphos_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_xiphos_guard_h3" Type="Guard" scale_factor="110" />
@@ -4904,7 +4904,7 @@
       <Piece id="crpg_xiphos_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_v1_h0" name="{=elTXYb9f}Falx Knife" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h0" name="{=Yeldur}Falx Knife" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h0" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h0" Type="Guard" />
@@ -4912,7 +4912,7 @@
       <Piece id="crpg_falx_knife_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_v1_h1" name="{=elTXYb9f}Falx Knife +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h1" name="{=Yeldur}Falx Knife +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h1" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h1" Type="Guard" />
@@ -4920,7 +4920,7 @@
       <Piece id="crpg_falx_knife_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_v1_h2" name="{=elTXYb9f}Falx Knife +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h2" name="{=Yeldur}Falx Knife +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h2" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h2" Type="Guard" />
@@ -4928,7 +4928,7 @@
       <Piece id="crpg_falx_knife_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_falx_knife_v1_h3" name="{=elTXYb9f}Falx Knife +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_falx_knife_v1_h3" name="{=Yeldur}Falx Knife +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_falx_knife_blade_h3" Type="Blade" scale_factor="106" />
       <Piece id="crpg_falx_knife_guard_h3" Type="Guard" />
@@ -4936,7 +4936,7 @@
       <Piece id="crpg_falx_knife_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_v1_h0" name="{=bVzkrtUc}Pugio" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h0" name="{=Yeldur}Pugio" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h0" Type="Guard" scale_factor="90" />
@@ -4944,7 +4944,7 @@
       <Piece id="crpg_pugio_pommel_h0" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_v1_h1" name="{=bVzkrtUc}Pugio +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h1" name="{=Yeldur}Pugio +1" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h1" Type="Guard" scale_factor="90" />
@@ -4952,7 +4952,7 @@
       <Piece id="crpg_pugio_pommel_h1" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_v1_h2" name="{=bVzkrtUc}Pugio +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h2" name="{=Yeldur}Pugio +2" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h2" Type="Guard" scale_factor="90" />
@@ -4960,7 +4960,7 @@
       <Piece id="crpg_pugio_pommel_h2" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pugio_v1_h3" name="{=bVzkrtUc}Pugio +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_pugio_v1_h3" name="{=Yeldur}Pugio +3" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_pugio_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_pugio_guard_h3" Type="Guard" scale_factor="90" />
@@ -4968,7 +4968,7 @@
       <Piece id="crpg_pugio_pommel_h3" Type="Pommel" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_v1_h0" name="{=vPXWpJTP}Highland Dagger" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h0" name="{=Yeldur}Highland Dagger" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h0" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h0" Type="Guard" />
@@ -4976,7 +4976,7 @@
       <Piece id="crpg_highland_dagger_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_v1_h1" name="{=vPXWpJTP}Highland Dagger +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h1" name="{=Yeldur}Highland Dagger +1" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h1" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h1" Type="Guard" />
@@ -4984,7 +4984,7 @@
       <Piece id="crpg_highland_dagger_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_v1_h2" name="{=vPXWpJTP}Highland Dagger +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h2" name="{=Yeldur}Highland Dagger +2" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h2" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h2" Type="Guard" />
@@ -4992,7 +4992,7 @@
       <Piece id="crpg_highland_dagger_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_dagger_v1_h3" name="{=vPXWpJTP}Highland Dagger +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
+  <CraftedItem id="crpg_highland_dagger_v1_h3" name="{=Yeldur}Highland Dagger +3" crafting_template="crpg_Dagger" culture="Culture.battania" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_highland_dagger_blade_h3" Type="Blade" scale_factor="94" />
       <Piece id="crpg_highland_dagger_guard_h3" Type="Guard" />
@@ -5000,7 +5000,7 @@
       <Piece id="crpg_highland_dagger_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v1_h0" name="{=3Pv0SlYj}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h0" name="{=Yeldur}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h0" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h0" Type="Guard" scale_factor="90" />
@@ -5008,7 +5008,7 @@
       <Piece id="crpg_seax_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v1_h1" name="{=3Pv0SlYj}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h1" name="{=Yeldur}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h1" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h1" Type="Guard" scale_factor="90" />
@@ -5016,7 +5016,7 @@
       <Piece id="crpg_seax_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v1_h2" name="{=3Pv0SlYj}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h2" name="{=Yeldur}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h2" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h2" Type="Guard" scale_factor="90" />
@@ -5024,7 +5024,7 @@
       <Piece id="crpg_seax_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v1_h3" name="{=3Pv0SlYj}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v1_h3" name="{=Yeldur}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h3" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h3" Type="Guard" scale_factor="90" />
@@ -11664,7 +11664,7 @@
       <Piece id="crpg_broadshortsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_v1_h0" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h0" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h0" Type="Guard" scale_factor="110" />
@@ -11672,7 +11672,7 @@
       <Piece id="crpg_rondel_pommel_h0" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_v1_h1" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h1" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h1" Type="Guard" scale_factor="110" />
@@ -11680,7 +11680,7 @@
       <Piece id="crpg_rondel_pommel_h1" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_v1_h2" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h2" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h2" Type="Guard" scale_factor="110" />
@@ -11688,7 +11688,7 @@
       <Piece id="crpg_rondel_pommel_h2" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rondel_v1_h3" name="{=}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_rondel_v1_h3" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_rondel_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rondel_guard_h3" Type="Guard" scale_factor="110" />


### PR DESCRIPTION
Revamp of the Katana's, offering unique tiers for each one 

- Shortened length of all to 95 from 102 (Feels more logical to push them further into a shorter region)
- Set tier for Green and Red to be focused around 9.0 (stats slightly increased due to lower length)
- Set tier for Blue and Yellow to be focused around 7.5 (stats slightly decreased due to lower length but lower tier)
- Set tier for Black to be focused around 6.5 (stats slightly increased due to lower tier)
- Changed weapons.xml to force a refund to all Katana tiers

- Set all Daggers to host my name alongside them given that I am managing daggers from a crafting perspective (commented like kaikaikai's against polearms)