### PR TITLE
Rebalance to Rondel & Shepherd's Axe

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -26012,10 +26012,10 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shepherd_axe_blade_h0" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.45">
+  <CraftingPiece id="crpg_shepherd_axe_blade_h0" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.55">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26025,10 +26025,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shepherd_axe_blade_h1" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.4">
+  <CraftingPiece id="crpg_shepherd_axe_blade_h1" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.53">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26038,10 +26038,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shepherd_axe_blade_h2" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.38">
+  <CraftingPiece id="crpg_shepherd_axe_blade_h2" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.52">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -26051,10 +26051,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shepherd_axe_blade_h3" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.38">
+  <CraftingPiece id="crpg_shepherd_axe_blade_h3" name="Sherpherd's Blade" tier="2" piece_type="Blade" mesh="sherpherds_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.50">
     <BuildData piece_offset="-10.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -129216,8 +129216,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_shepherd_axe_h0",
-    "baseId": "crpg_shepherd_axe",
+    "id": "crpg_shepherd_axe_v1_h0",
+    "baseId": "crpg_shepherd_axe_v1",
     "name": "Shepherd's Axe",
     "culture": "Battania",
     "type": "OneHandedWeapon",
@@ -129254,8 +129254,8 @@
     ]
   },
   {
-    "id": "crpg_shepherd_axe_h1",
-    "baseId": "crpg_shepherd_axe",
+    "id": "crpg_shepherd_axe_v1_h1",
+    "baseId": "crpg_shepherd_axe_v1",
     "name": "Shepherd's Axe +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
@@ -129292,8 +129292,8 @@
     ]
   },
   {
-    "id": "crpg_shepherd_axe_h2",
-    "baseId": "crpg_shepherd_axe",
+    "id": "crpg_shepherd_axe_v1_h2",
+    "baseId": "crpg_shepherd_axe_v1",
     "name": "Shepherd's Axe +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
@@ -129330,8 +129330,8 @@
     ]
   },
   {
-    "id": "crpg_shepherd_axe_h3",
-    "baseId": "crpg_shepherd_axe",
+    "id": "crpg_shepherd_axe_v1_h3",
+    "baseId": "crpg_shepherd_axe_v1",
     "name": "Shepherd's Axe +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",

--- a/items.json
+++ b/items.json
@@ -122803,10 +122803,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 4843,
-    "weight": 0.93,
+    "price": 6612,
+    "weight": 0.99,
     "rank": 0,
-    "tier": 8.12953,
+    "tier": 9.687575,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122818,9 +122818,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 41,
+        "length": 45,
         "balance": 1.0,
-        "handling": 115,
+        "handling": 114,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -122830,7 +122830,7 @@
         "thrustSpeed": 97,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 123
+        "swingSpeed": 120
       }
     ]
   },
@@ -122840,10 +122840,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 5116,
-    "weight": 0.93,
+    "price": 6993,
+    "weight": 0.99,
     "rank": 1,
-    "tier": 8.387259,
+    "tier": 9.99469948,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122855,9 +122855,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 41,
+        "length": 45,
         "balance": 1.0,
-        "handling": 115,
+        "handling": 114,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
@@ -122867,7 +122867,7 @@
         "thrustSpeed": 97,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 123
+        "swingSpeed": 120
       }
     ]
   },
@@ -122877,10 +122877,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 4959,
-    "weight": 0.75,
+    "price": 5866,
+    "weight": 0.81,
     "rank": 2,
-    "tier": 8.24008751,
+    "tier": 9.059749,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122892,19 +122892,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 41,
+        "length": 45,
         "balance": 1.0,
-        "handling": 117,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 39,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
+        "thrustSpeed": 98,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 125
+        "swingSpeed": 123
       }
     ]
   },
@@ -122914,10 +122914,10 @@
     "name": "Rondel",
     "culture": "Empire",
     "type": "OneHandedWeapon",
-    "price": 5476,
-    "weight": 0.75,
+    "price": 6484,
+    "weight": 0.81,
     "rank": 3,
-    "tier": 8.715819,
+    "tier": 9.582803,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -122929,19 +122929,19 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 41,
+        "length": 45,
         "balance": 1.0,
-        "handling": 117,
+        "handling": 116,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 40,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
+        "thrustSpeed": 98,
         "swingDamage": 0,
         "swingDamageType": "Undefined",
-        "swingSpeed": 125
+        "swingSpeed": 123
       }
     ]
   },
@@ -129218,13 +129218,13 @@
   {
     "id": "crpg_shepherd_axe_h0",
     "baseId": "crpg_shepherd_axe",
-    "name": "Shepherd Axe",
+    "name": "Shepherd's Axe",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1185,
-    "weight": 0.97,
+    "price": 4165,
+    "weight": 1.11,
     "rank": 0,
-    "tier": 3.47091436,
+    "tier": 7.458426,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -129236,9 +129236,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 88,
-        "balance": 0.75,
-        "handling": 88,
+        "length": 95,
+        "balance": 0.48,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -129246,23 +129246,23 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 96,
-        "swingDamage": 25,
+        "thrustSpeed": 94,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 92
+        "swingSpeed": 84
       }
     ]
   },
   {
     "id": "crpg_shepherd_axe_h1",
     "baseId": "crpg_shepherd_axe",
-    "name": "Shepherd Axe +1",
+    "name": "Shepherd's Axe +1",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1267,
-    "weight": 0.92,
+    "price": 4399,
+    "weight": 1.09,
     "rank": 1,
-    "tier": 3.625522,
+    "tier": 7.69586658,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -129274,9 +129274,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 88,
-        "balance": 0.82,
-        "handling": 90,
+        "length": 95,
+        "balance": 0.51,
+        "handling": 81,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -129284,23 +129284,23 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 25,
+        "thrustSpeed": 94,
+        "swingDamage": 37,
         "swingDamageType": "Cut",
-        "swingSpeed": 94
+        "swingSpeed": 85
       }
     ]
   },
   {
     "id": "crpg_shepherd_axe_h2",
     "baseId": "crpg_shepherd_axe",
-    "name": "Shepherd Axe +2",
+    "name": "Shepherd's Axe +2",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1504,
-    "weight": 0.9,
+    "price": 4140,
+    "weight": 1.08,
     "rank": 2,
-    "tier": 4.046478,
+    "tier": 7.43258762,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -129312,9 +129312,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 88,
-        "balance": 0.86,
-        "handling": 91,
+        "length": 95,
+        "balance": 0.52,
+        "handling": 82,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -129322,23 +129322,23 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 26,
+        "thrustSpeed": 94,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 95
+        "swingSpeed": 85
       }
     ]
   },
   {
     "id": "crpg_shepherd_axe_h3",
     "baseId": "crpg_shepherd_axe",
-    "name": "Shepherd Axe +3",
+    "name": "Shepherd's Axe +3",
     "culture": "Battania",
     "type": "OneHandedWeapon",
-    "price": 1940,
-    "weight": 0.9,
+    "price": 4553,
+    "weight": 1.06,
     "rank": 3,
-    "tier": 4.74184132,
+    "tier": 7.84917545,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -129350,9 +129350,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 88,
-        "balance": 0.86,
-        "handling": 91,
+        "length": 95,
+        "balance": 0.55,
+        "handling": 82,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -129360,10 +129360,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 28,
+        "thrustSpeed": 94,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 95
+        "swingSpeed": 86
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -552,25 +552,25 @@
       <Piece id="crpg_great_maul_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h0" name="{=}Shepherd's Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_v1_h0" name="{=}Shepherd's Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shepherd_axe_handle_h0" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h1" name="{=}Shepherd's Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_v1_h1" name="{=}Shepherd's Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shepherd_axe_handle_h1" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h2" name="{=}Shepherd's Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_v1_h2" name="{=}Shepherd's Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shepherd_axe_handle_h2" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h3" name="{=}Shepherd's Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_v1_h3" name="{=}Shepherd's Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shepherd_axe_handle_h3" Type="Handle" scale_factor="155" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -552,28 +552,28 @@
       <Piece id="crpg_great_maul_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h0" name="Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_h0" name="{=}Shepherd's Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h0" Type="Blade" scale_factor="105" />
-      <Piece id="crpg_shepherd_axe_handle_h0" Type="Handle" scale_factor="144" />
+      <Piece id="crpg_shepherd_axe_handle_h0" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h1" name="Shepherd Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_h1" name="{=}Shepherd's Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h1" Type="Blade" scale_factor="105" />
-      <Piece id="crpg_shepherd_axe_handle_h1" Type="Handle" scale_factor="144" />
+      <Piece id="crpg_shepherd_axe_handle_h1" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h2" name="Shepherd Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_h2" name="{=}Shepherd's Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h2" Type="Blade" scale_factor="105" />
-      <Piece id="crpg_shepherd_axe_handle_h2" Type="Handle" scale_factor="144" />
+      <Piece id="crpg_shepherd_axe_handle_h2" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shepherd_axe_h3" name="Shepherd Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_shepherd_axe_h3" name="{=}Shepherd's Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shepherd_axe_blade_h3" Type="Blade" scale_factor="105" />
-      <Piece id="crpg_shepherd_axe_handle_h3" Type="Handle" scale_factor="144" />
+      <Piece id="crpg_shepherd_axe_handle_h3" Type="Handle" scale_factor="155" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_kama_h0" name="{=}Kama" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
@@ -11562,7 +11562,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_rondel_v1_h0" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_rondel_blade_h0" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_rondel_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_rondel_guard_h0" Type="Guard" scale_factor="110" />
       <Piece id="crpg_rondel_handle_h0" Type="Handle" scale_factor="110" />
       <Piece id="crpg_rondel_pommel_h0" Type="Pommel" scale_factor="110" />
@@ -11570,7 +11570,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_rondel_v1_h1" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_rondel_blade_h1" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_rondel_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_rondel_guard_h1" Type="Guard" scale_factor="110" />
       <Piece id="crpg_rondel_handle_h1" Type="Handle" scale_factor="110" />
       <Piece id="crpg_rondel_pommel_h1" Type="Pommel" scale_factor="110" />
@@ -11578,7 +11578,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_rondel_v1_h2" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_rondel_blade_h2" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_rondel_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_rondel_guard_h2" Type="Guard" scale_factor="110" />
       <Piece id="crpg_rondel_handle_h2" Type="Handle" scale_factor="110" />
       <Piece id="crpg_rondel_pommel_h2" Type="Pommel" scale_factor="110" />
@@ -11586,7 +11586,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_rondel_v1_h3" name="{=Yeldur}Rondel" crafting_template="crpg_Dagger" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_rondel_blade_h3" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_rondel_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_rondel_guard_h3" Type="Guard" scale_factor="110" />
       <Piece id="crpg_rondel_handle_h3" Type="Handle" scale_factor="110" />
       <Piece id="crpg_rondel_pommel_h3" Type="Pommel" scale_factor="110" />


### PR DESCRIPTION
###Rondel Dagger###
Added 4 length to the Rondel (41 -> 45) 

###Shepherd's Axe###
- Added length to Shepherd Axe (88 -> 95)
- Increased damage (2.5 -> 3.6)
- Lowered speed (95 -> 84)
- Weight increased (0.97 -> 1.11)
- Name changed to Shepherd's Axe
- Refund issued due to rebalance changing the core of how this weapon functions