### PR TITLE
Rework of Heavy Goedendag

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -26195,54 +26195,50 @@
   <CraftingPiece id="crpg_heavy_goedendag_blade_h0" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.1">
     <BuildData piece_offset="0" />
     <BladeData stack_amount="1" blade_length="30.5" blade_width="8.5" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+      <Swing damage_type="Blunt" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_goedendag_blade_h1" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.0">
+  <CraftingPiece id="crpg_heavy_goedendag_blade_h1" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.1">
     <BuildData piece_offset="0" />
     <BladeData stack_amount="1" blade_length="30.5" blade_width="8.5" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Blunt" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_goedendag_blade_h2" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.0">
+  <CraftingPiece id="crpg_heavy_goedendag_blade_h2" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.05">
     <BuildData piece_offset="0" />
     <BladeData stack_amount="1" blade_length="30.5" blade_width="8.5" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Blunt" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_goedendag_blade_h3" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.0">
+  <CraftingPiece id="crpg_heavy_goedendag_blade_h3" name="{=}Heavy Goedendag Head" tier="4" piece_type="Blade" mesh="goedendag_2h_head" distance_to_next_piece="0.0" distance_to_previous_piece="0.0" weight="1.00">
     <BuildData piece_offset="0" />
     <BladeData stack_amount="1" blade_length="30.5" blade_width="8.5" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Blunt" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="4" />

--- a/items.json
+++ b/items.json
@@ -59732,15 +59732,15 @@
     ]
   },
   {
-    "id": "crpg_heavy_goedendag_h0",
-    "baseId": "crpg_heavy_goedendag",
+    "id": "crpg_heavy_goedendag_v1_h0",
+    "baseId": "crpg_heavy_goedendag_v1",
     "name": "Heavy Goedendag",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 11449,
+    "price": 12008,
     "weight": 2.6,
     "rank": 0,
-    "tier": 8.939813,
+    "tier": 9.181516,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -59758,28 +59758,27 @@
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "MultiplePenetration"
+          "NotUsableWithOneHand"
         ],
-        "thrustDamage": 28,
+        "thrustDamage": 32,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 89,
-        "swingDamage": 24,
+        "swingDamage": 29,
         "swingDamageType": "Blunt",
         "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_heavy_goedendag_h1",
-    "baseId": "crpg_heavy_goedendag",
+    "id": "crpg_heavy_goedendag_v1_h1",
+    "baseId": "crpg_heavy_goedendag_v1",
     "name": "Heavy Goedendag +1",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 11812,
-    "weight": 2.5,
+    "price": 11462,
+    "weight": 2.6,
     "rank": 1,
-    "tier": 9.097779,
+    "tier": 8.945663,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -59792,33 +59791,32 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 74,
-        "balance": 0.68,
-        "handling": 85,
+        "balance": 0.61,
+        "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "MultiplePenetration"
+          "NotUsableWithOneHand"
         ],
-        "thrustDamage": 28,
+        "thrustDamage": 33,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 24,
+        "thrustSpeed": 89,
+        "swingDamage": 30,
         "swingDamageType": "Blunt",
-        "swingSpeed": 90
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_heavy_goedendag_h2",
-    "baseId": "crpg_heavy_goedendag",
+    "id": "crpg_heavy_goedendag_v1_h2",
+    "baseId": "crpg_heavy_goedendag_v1",
     "name": "Heavy Goedendag +2",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 11549,
-    "weight": 2.5,
+    "price": 12066,
+    "weight": 2.55,
     "rank": 2,
-    "tier": 8.983603,
+    "tier": 9.206301,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -59831,33 +59829,32 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 74,
-        "balance": 0.68,
-        "handling": 85,
+        "balance": 0.64,
+        "handling": 84,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "MultiplePenetration"
+          "NotUsableWithOneHand"
         ],
-        "thrustDamage": 28,
+        "thrustDamage": 33,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 25,
+        "thrustSpeed": 89,
+        "swingDamage": 31,
         "swingDamageType": "Blunt",
-        "swingSpeed": 90
+        "swingSpeed": 89
       }
     ]
   },
   {
-    "id": "crpg_heavy_goedendag_h3",
-    "baseId": "crpg_heavy_goedendag",
+    "id": "crpg_heavy_goedendag_v1_h3",
+    "baseId": "crpg_heavy_goedendag_v1",
     "name": "Heavy Goedendag +3",
     "culture": "Sturgia",
     "type": "TwoHandedWeapon",
-    "price": 11467,
+    "price": 13713,
     "weight": 2.5,
     "rank": 3,
-    "tier": 8.947878,
+    "tier": 9.885987,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -59875,13 +59872,12 @@
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "MultiplePenetration"
+          "NotUsableWithOneHand"
         ],
-        "thrustDamage": 28,
+        "thrustDamage": 33,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 26,
+        "swingDamage": 32,
         "swingDamageType": "Blunt",
         "swingSpeed": 90
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -192,25 +192,25 @@
       <Piece id="crpg_military_hammer_handle_h3" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_h0" name="{=}Heavy Goedendag" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v1_h0" name="{=}Heavy Goedendag" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_h1" name="{=}Heavy Goedendag +1" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v1_h1" name="{=}Heavy Goedendag +1" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_h2" name="{=}Heavy Goedendag +2" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v1_h2" name="{=}Heavy Goedendag +2" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_h3" name="{=}Heavy Goedendag +3" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v1_h3" name="{=}Heavy Goedendag +3" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h3" Type="Handle" scale_factor="100" />


### PR DESCRIPTION
Heavy Goedendag is one of our professionally designed weapons from gp - I believe in its current state it is underutilised because it has the Knockdown stat, which renders its stats incredibly low - Overall it doesn't gain any real benefit from knockdown at the stage it's at because of how low the damage is. 

This change does the following:
- Removed Knockdown from HGD
- Increased thrust/swing damage to compensate
- Tried to tiermatch as much as possible but did increase tier marginally. 
- Changed ID to push a refund of this item given the fundamental change in how it performs

**+0**
- Thrust damage 2.8 -> 3.2
- Swing damage 2.4 -> 2.9

**+1**
- TD 2.8  -> 3.3
- SD 2.4 -> 3.0
- weight 1.0 -> 1.1

**+2**
- TD 2.8 -> 3.3
- SD 2.5 -> 3.1
- wgt 1.1 -> 1.05

**+3** 
- TD 2.8 -> 3.3
- SD 2.6 -> 3.2
- wgt 1.05 -> 1.0