### PR TITLE
Elegant Shepherd's Axe v1.0

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31096,10 +31096,10 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shep_damast_blade_h0" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.45">
+  <CraftingPiece id="crpg_shep_damast_blade_h0" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.60">
     <BuildData piece_offset="-3.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31109,10 +31109,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shep_damast_blade_h1" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.45">
+  <CraftingPiece id="crpg_shep_damast_blade_h1" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.60">
     <BuildData piece_offset="-3.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31122,10 +31122,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shep_damast_blade_h2" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.45">
+  <CraftingPiece id="crpg_shep_damast_blade_h2" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.60">
     <BuildData piece_offset="-3.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -31135,10 +31135,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shep_damast_blade_h3" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.45">
+  <CraftingPiece id="crpg_shep_damast_blade_h3" name="{=}Elegant Shepherd Axe Blade" tier="2" piece_type="Blade" mesh="sherpas_damasc_blade" length="9.41" weight="0.59">
     <BuildData piece_offset="-3.0" />
     <BladeData stack_amount="2" blade_length="6.6" blade_width="24.7" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -141281,10 +141281,10 @@
     "name": "Elegant Shepherd Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 3558,
-    "weight": 0.92,
+    "price": 5881,
+    "weight": 1.2,
     "rank": 0,
-    "tier": 6.809275,
+    "tier": 9.073133,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -141296,9 +141296,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.99,
-        "handling": 96,
+        "length": 105,
+        "balance": 0.36,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -141306,10 +141306,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 25,
+        "thrustSpeed": 93,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 99
+        "swingSpeed": 80
       }
     ]
   },
@@ -141319,10 +141319,10 @@
     "name": "Elegant Shepherd Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 2574,
-    "weight": 0.92,
+    "price": 5064,
+    "weight": 1.2,
     "rank": 1,
-    "tier": 5.62749863,
+    "tier": 8.338434,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -141334,9 +141334,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.99,
-        "handling": 96,
+        "length": 105,
+        "balance": 0.36,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -141344,10 +141344,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 25,
+        "thrustSpeed": 93,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 99
+        "swingSpeed": 80
       }
     ]
   },
@@ -141357,10 +141357,10 @@
     "name": "Elegant Shepherd Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1931,
-    "weight": 0.92,
+    "price": 5347,
+    "weight": 1.2,
     "rank": 2,
-    "tier": 4.728662,
+    "tier": 8.599066,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -141372,9 +141372,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.99,
-        "handling": 96,
+        "length": 105,
+        "balance": 0.36,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -141382,10 +141382,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 25,
+        "thrustSpeed": 93,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 99
+        "swingSpeed": 80
       }
     ]
   },
@@ -141395,10 +141395,10 @@
     "name": "Elegant Shepherd Axe",
     "culture": "Sturgia",
     "type": "OneHandedWeapon",
-    "price": 1494,
-    "weight": 0.92,
+    "price": 5823,
+    "weight": 1.19,
     "rank": 3,
-    "tier": 4.02915525,
+    "tier": 9.022679,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -141410,9 +141410,9 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 82,
-        "balance": 0.99,
-        "handling": 96,
+        "length": 105,
+        "balance": 0.38,
+        "handling": 79,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
@@ -141420,10 +141420,10 @@
         ],
         "thrustDamage": 0,
         "thrustDamageType": "Undefined",
-        "thrustSpeed": 97,
-        "swingDamage": 25,
+        "thrustSpeed": 93,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 99
+        "swingSpeed": 81
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12378,29 +12378,29 @@
   </CraftedItem>
   <CraftedItem id="crpg_shep_damast_h0" name="Elegant Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_shep_damast_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_shep_damast_handle_h0" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_shep_damast_blade_h0" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_shep_damast_handle_h0" Type="Handle" scale_factor="131" />
       <Piece id="crpg_shep_damast_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_shep_damast_h1" name="Elegant Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_shep_damast_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_shep_damast_handle_h1" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_shep_damast_blade_h1" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_shep_damast_handle_h1" Type="Handle" scale_factor="131" />
       <Piece id="crpg_shep_damast_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_shep_damast_h2" name="Elegant Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_shep_damast_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_shep_damast_handle_h2" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_shep_damast_blade_h2" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_shep_damast_handle_h2" Type="Handle" scale_factor="131" />
       <Piece id="crpg_shep_damast_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_shep_damast_h3" name="Elegant Shepherd Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_shep_damast_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_shep_damast_handle_h3" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_shep_damast_blade_h3" Type="Blade" scale_factor="105" />
+      <Piece id="crpg_shep_damast_handle_h3" Type="Handle" scale_factor="131" />
       <Piece id="crpg_shep_damast_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>


### PR DESCRIPTION
Elegant Shepherd's Axe v1.0 Stats

**Elegant Shepherd Axe - h0**
-    Weight: 1.2
-    Length: 105
-    Handling: 79
-    Swing Damage: 40 (Cut)
-    Swing Speed: 80

**Elegant Shepherd Axe - h1**
-    Weight: 1.2
-    Length: 105
-    Handling: 79
-    Swing Damage: 41 (Cut) **(+1)**
-    Swing Speed: 80

**Elegant Shepherd Axe - h2**
-    Weight: 1.2
-    Length: 105
-    Handling: 79
-    Swing Damage: 43 (Cut) **(+2)**
-    Swing Speed: 80

**Elegant Shepherd Axe - h3**
-    Weight: 1.19 **(-0.01)**
-    Length: 105
-    Handling: 79
-    Swing Damage: 44 (Cut) **(+2)**
-    Swing Speed: 81 **(+1)**