### PR TITLE
NewTwoHanded swords stats input

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -30480,37 +30480,37 @@
   <CraftingPiece id="crpg_kriegsmesser_handle_h3" name="{=}Kriegsmesser Handle" tier="3" piece_type="Handle" mesh="kriegsmesser_handle" culture="Culture.khuzait" length="26.3" weight="0.1">
     <BuildData piece_offset="-6.5" previous_piece_offset="0.1" next_piece_offset="1" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_zweihander_blade_h0" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.0">
+  <CraftingPiece id="crpg_zweihander_blade_h0" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.93">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_zweihander_blade_h1" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.0">
+  <CraftingPiece id="crpg_zweihander_blade_h1" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_zweihander_blade_h2" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.0">
+  <CraftingPiece id="crpg_zweihander_blade_h2" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="4.8" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_zweihander_blade_h3" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.0">
+  <CraftingPiece id="crpg_zweihander_blade_h3" name="{=}Zweihander Blade" tier="4" piece_type="Blade" mesh="zweihander_blade" culture="Culture.battania" length="100" weight="1.88">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="5.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -30592,37 +30592,37 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h0" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.0">
+  <CraftingPiece id="crpg_executionerssword_blade_h0" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.61">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h1" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.0">
+  <CraftingPiece id="crpg_executionerssword_blade_h1" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.55">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h2" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.0">
+  <CraftingPiece id="crpg_executionerssword_blade_h2" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.51">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h3" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.0">
+  <CraftingPiece id="crpg_executionerssword_blade_h3" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.51">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
@@ -31252,28 +31252,28 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.0">
+  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.0">
+  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.0">
+  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.0">
+  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.47">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="1.015" />
-      <Swing damage_type="Cut" damage_factor="1.33" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_meowdao_pommel_h0" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31252,28 +31252,28 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
+  <CraftingPiece id="crpg_meowdao_blade_h0" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.7">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
-    </BladeData>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
-    </BladeData>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.57">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.47">
+  <CraftingPiece id="crpg_meowdao_blade_h1" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.64">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
+    </BladeData>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_meowdao_blade_h2" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.64">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.5" />
+    </BladeData>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_meowdao_blade_h3" name="{=}Meowdao Blade" tier="4" piece_type="Blade" mesh="meowdao_blade" culture="Culture.battania" length="118" weight="1.6">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
   </CraftingPiece>
   <CraftingPiece id="crpg_meowdao_pommel_h0" name="{=}Meowdao Pommel" tier="4" piece_type="Pommel" mesh="meowdao_pommel" culture="Culture.battania" length="2.5" weight="0.12">

--- a/items.json
+++ b/items.json
@@ -50759,10 +50759,10 @@
     "name": "Executioner's Sword",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 137,
-    "weight": 1.54,
+    "price": 13651,
+    "weight": 2.27,
     "rank": 0,
-    "tier": 0.294382274,
+    "tier": 9.861127,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -50773,19 +50773,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.96,
-        "handling": 89,
+        "balance": 0.57,
+        "handling": 83,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 13,
+        "thrustSpeed": 91,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 87
       }
     ]
   },
@@ -50795,10 +50795,10 @@
     "name": "Executioner's Sword",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 120,
-    "weight": 1.54,
+    "price": 13295,
+    "weight": 2.2,
     "rank": 1,
-    "tier": 0.24329114,
+    "tier": 9.717514,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -50809,19 +50809,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.96,
-        "handling": 89,
+        "balance": 0.6,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 13,
+        "thrustSpeed": 92,
+        "swingDamage": 40,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 87
       }
     ]
   },
@@ -50831,10 +50831,10 @@
     "name": "Executioner's Sword",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 108,
-    "weight": 1.54,
+    "price": 13750,
+    "weight": 2.15,
     "rank": 2,
-    "tier": 0.2044321,
+    "tier": 9.900779,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -50845,19 +50845,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.96,
-        "handling": 89,
+        "balance": 0.62,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 13,
+        "thrustSpeed": 92,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 88
       }
     ]
   },
@@ -50867,10 +50867,10 @@
     "name": "Executioner's Sword",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 99,
-    "weight": 1.54,
+    "price": 13481,
+    "weight": 2.15,
     "rank": 3,
-    "tier": 0.17419073,
+    "tier": 9.792738,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -50881,19 +50881,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 120,
-        "balance": 0.96,
-        "handling": 89,
+        "balance": 0.62,
+        "handling": 84,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 13,
+        "thrustSpeed": 92,
+        "swingDamage": 42,
         "swingDamageType": "Cut",
-        "swingSpeed": 98
+        "swingSpeed": 88
       }
     ]
   },
@@ -101829,10 +101829,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 167,
-    "weight": 1.15,
+    "price": 13400,
+    "weight": 1.98,
     "rank": 0,
-    "tier": 0.383891821,
+    "tier": 9.760066,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101842,20 +101842,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 121,
-        "balance": 1.0,
-        "handling": 88,
+        "length": 140,
+        "balance": 0.43,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 13,
+        "thrustSpeed": 93,
+        "swingDamage": 39,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 83
       }
     ]
   },
@@ -101865,10 +101865,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 145,
-    "weight": 1.15,
+    "price": 13607,
+    "weight": 1.98,
     "rank": 1,
-    "tier": 0.317265958,
+    "tier": 9.843613,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101878,20 +101878,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 121,
-        "balance": 1.0,
-        "handling": 88,
+        "length": 140,
+        "balance": 0.43,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 13,
+        "thrustSpeed": 93,
+        "swingDamage": 41,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 83
       }
     ]
   },
@@ -101901,10 +101901,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 128,
-    "weight": 1.15,
+    "price": 14032,
+    "weight": 1.98,
     "rank": 2,
-    "tier": 0.266591549,
+    "tier": 10.0128174,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101914,20 +101914,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 121,
-        "balance": 1.0,
-        "handling": 88,
+        "length": 140,
+        "balance": 0.43,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 13,
+        "thrustSpeed": 93,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 83
       }
     ]
   },
@@ -101937,10 +101937,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 115,
-    "weight": 1.15,
+    "price": 13846,
+    "weight": 1.87,
     "rank": 3,
-    "tier": 0.227155015,
+    "tier": 9.939166,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101950,20 +101950,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 121,
-        "balance": 1.0,
-        "handling": 88,
+        "length": 140,
+        "balance": 0.49,
+        "handling": 79,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 100,
-        "swingDamage": 13,
+        "thrustSpeed": 94,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 101
+        "swingSpeed": 84
       }
     ]
   },
@@ -181033,10 +181033,10 @@
     "name": "Zweihander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 224,
-    "weight": 1.32,
+    "price": 13812,
+    "weight": 2.67,
     "rank": 0,
-    "tier": 0.537871242,
+    "tier": 9.925501,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -181046,20 +181046,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 138,
-        "balance": 1.0,
-        "handling": 89,
+        "length": 160,
+        "balance": 0.15,
+        "handling": 75,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 13,
+        "thrustSpeed": 87,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 74
       }
     ]
   },
@@ -181069,10 +181069,10 @@
     "name": "Zweihander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 189,
-    "weight": 1.32,
+    "price": 13375,
+    "weight": 2.63,
     "rank": 1,
-    "tier": 0.444521427,
+    "tier": 9.74992752,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -181082,20 +181082,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 138,
-        "balance": 1.0,
-        "handling": 89,
+        "length": 160,
+        "balance": 0.17,
+        "handling": 75,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 13,
+        "thrustSpeed": 88,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 75
       }
     ]
   },
@@ -181105,10 +181105,10 @@
     "name": "Zweihander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 164,
-    "weight": 1.32,
+    "price": 14018,
+    "weight": 2.63,
     "rank": 2,
-    "tier": 0.373521566,
+    "tier": 10.007308,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -181118,20 +181118,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 138,
-        "balance": 1.0,
-        "handling": 89,
+        "length": 160,
+        "balance": 0.17,
+        "handling": 75,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 13,
+        "thrustSpeed": 88,
+        "swingDamage": 48,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 75
       }
     ]
   },
@@ -181141,10 +181141,10 @@
     "name": "Zweihander",
     "culture": "Neutral",
     "type": "TwoHandedWeapon",
-    "price": 145,
-    "weight": 1.32,
+    "price": 14094,
+    "weight": 2.61,
     "rank": 3,
-    "tier": 0.3182669,
+    "tier": 10.0371685,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -181154,20 +181154,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 138,
-        "balance": 1.0,
-        "handling": 89,
+        "length": 160,
+        "balance": 0.19,
+        "handling": 75,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 10,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 99,
-        "swingDamage": 13,
+        "thrustSpeed": 89,
+        "swingDamage": 50,
         "swingDamageType": "Cut",
-        "swingSpeed": 100
+        "swingSpeed": 75
       }
     ]
   }

--- a/items.json
+++ b/items.json
@@ -101829,10 +101829,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 13400,
-    "weight": 1.98,
+    "price": 13651,
+    "weight": 2.12,
     "rank": 0,
-    "tier": 9.760066,
+    "tier": 9.861121,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101843,19 +101843,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 140,
-        "balance": 0.43,
-        "handling": 78,
+        "balance": 0.36,
+        "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 39,
+        "thrustSpeed": 92,
+        "swingDamage": 43,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 80
       }
     ]
   },
@@ -101865,10 +101865,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 13607,
-    "weight": 1.98,
+    "price": 13842,
+    "weight": 2.06,
     "rank": 1,
-    "tier": 9.843613,
+    "tier": 9.937375,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101879,19 +101879,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 140,
-        "balance": 0.43,
-        "handling": 78,
+        "balance": 0.4,
+        "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 41,
+        "thrustSpeed": 92,
+        "swingDamage": 44,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 81
       }
     ]
   },
@@ -101901,10 +101901,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 14032,
-    "weight": 1.98,
+    "price": 12385,
+    "weight": 2.06,
     "rank": 2,
-    "tier": 10.0128174,
+    "tier": 9.341549,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101915,19 +101915,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 140,
-        "balance": 0.43,
-        "handling": 78,
+        "balance": 0.4,
+        "handling": 77,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 93,
-        "swingDamage": 43,
+        "thrustSpeed": 92,
+        "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 83
+        "swingSpeed": 81
       }
     ]
   },
@@ -101937,10 +101937,10 @@
     "name": "Meowdao",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 13846,
-    "weight": 1.87,
+    "price": 13749,
+    "weight": 2.01,
     "rank": 3,
-    "tier": 9.939166,
+    "tier": 9.900276,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -101951,19 +101951,19 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 140,
-        "balance": 0.49,
-        "handling": 79,
+        "balance": 0.42,
+        "handling": 78,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 21,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 94,
-        "swingDamage": 43,
+        "thrustSpeed": 92,
+        "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 82
       }
     ]
   },

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12406,34 +12406,34 @@
   </CraftedItem>
   <CraftedItem id="crpg_meowdao_h0" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_meowdao_blade_h0" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_meowdao_guard_h0" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_meowdao_handle_h0" Type="Handle" scale_factor="90" />
-      <Piece id="crpg_meowdao_pommel_h0" Type="Pommel" scale_factor="90" />
+      <Piece id="crpg_meowdao_blade_h0" Type="Blade" scale_factor="107" />
+      <Piece id="crpg_meowdao_guard_h0" Type="Guard" scale_factor="100" />
+      <Piece id="crpg_meowdao_handle_h0" Type="Handle" scale_factor="85" />
+      <Piece id="crpg_meowdao_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_meowdao_h1" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_meowdao_blade_h1" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_meowdao_guard_h1" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_meowdao_handle_h1" Type="Handle" scale_factor="90" />
-      <Piece id="crpg_meowdao_pommel_h1" Type="Pommel" scale_factor="90" />
+      <Piece id="crpg_meowdao_blade_h1" Type="Blade" scale_factor="107" />
+      <Piece id="crpg_meowdao_guard_h1" Type="Guard" scale_factor="100" />
+      <Piece id="crpg_meowdao_handle_h1" Type="Handle" scale_factor="85" />
+      <Piece id="crpg_meowdao_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_meowdao_h2" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_meowdao_blade_h2" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_meowdao_guard_h2" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_meowdao_handle_h2" Type="Handle" scale_factor="90" />
-      <Piece id="crpg_meowdao_pommel_h2" Type="Pommel" scale_factor="90" />
+      <Piece id="crpg_meowdao_blade_h2" Type="Blade" scale_factor="107" />
+      <Piece id="crpg_meowdao_guard_h2" Type="Guard" scale_factor="100" />
+      <Piece id="crpg_meowdao_handle_h2" Type="Handle" scale_factor="85" />
+      <Piece id="crpg_meowdao_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_meowdao_h3" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_meowdao_blade_h3" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_meowdao_guard_h3" Type="Guard" scale_factor="90" />
-      <Piece id="crpg_meowdao_handle_h3" Type="Handle" scale_factor="90" />
-      <Piece id="crpg_meowdao_pommel_h3" Type="Pommel" scale_factor="90" />
+      <Piece id="crpg_meowdao_blade_h3" Type="Blade" scale_factor="107" />
+      <Piece id="crpg_meowdao_guard_h3" Type="Guard" scale_factor="100" />
+      <Piece id="crpg_meowdao_handle_h3" Type="Handle" scale_factor="85" />
+      <Piece id="crpg_meowdao_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_meowaxe_h0" name="{=}Meowaxe" crafting_template="crpg_TwoHandedPolearm" is_merchandise="false" culture="Culture.battania">
@@ -12462,7 +12462,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_zweihander_h0" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_zweihander_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_zweihander_blade_h0" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_zweihander_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_zweihander_pommel_h0" Type="Pommel" scale_factor="100" />
@@ -12470,7 +12470,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_zweihander_h1" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_zweihander_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_zweihander_blade_h1" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_zweihander_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_zweihander_pommel_h1" Type="Pommel" scale_factor="100" />
@@ -12478,7 +12478,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_zweihander_h2" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_zweihander_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_zweihander_blade_h2" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_zweihander_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_zweihander_pommel_h2" Type="Pommel" scale_factor="100" />
@@ -12486,7 +12486,7 @@
   </CraftedItem>
   <CraftedItem id="crpg_zweihander_h3" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_zweihander_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_zweihander_blade_h3" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_zweihander_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_zweihander_pommel_h3" Type="Pommel" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12404,7 +12404,7 @@
       <Piece id="crpg_shep_damast_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_h0" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_h0" name="{=kaikaikai}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h0" Type="Guard" scale_factor="100" />
@@ -12412,7 +12412,7 @@
       <Piece id="crpg_meowdao_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_h1" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_h1" name="{=kaikaikai}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h1" Type="Guard" scale_factor="100" />
@@ -12420,7 +12420,7 @@
       <Piece id="crpg_meowdao_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_h2" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_h2" name="{=kaikaikai}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h2" Type="Guard" scale_factor="100" />
@@ -12428,7 +12428,7 @@
       <Piece id="crpg_meowdao_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_meowdao_h3" name="{=}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_meowdao_h3" name="{=kaikaikai}Meowdao" crafting_template="crpg_SideTwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_meowdao_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_meowdao_guard_h3" Type="Guard" scale_factor="100" />
@@ -12460,7 +12460,7 @@
       <Piece id="crpg_meowaxe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_zweihander_h0" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_zweihander_h0" name="{=kaikaikai}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_zweihander_blade_h0" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h0" Type="Guard" scale_factor="100" />
@@ -12468,7 +12468,7 @@
       <Piece id="crpg_zweihander_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_zweihander_h1" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_zweihander_h1" name="{=kaikaikai}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_zweihander_blade_h1" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h1" Type="Guard" scale_factor="100" />
@@ -12476,7 +12476,7 @@
       <Piece id="crpg_zweihander_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_zweihander_h2" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_zweihander_h2" name="{=kaikaikai}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_zweihander_blade_h2" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h2" Type="Guard" scale_factor="100" />
@@ -12484,7 +12484,7 @@
       <Piece id="crpg_zweihander_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_zweihander_h3" name="{=}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_zweihander_h3" name="{=kaikaikai}Zweihander" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_zweihander_blade_h3" Type="Blade" scale_factor="122" />
       <Piece id="crpg_zweihander_guard_h3" Type="Guard" scale_factor="100" />
@@ -12572,7 +12572,7 @@
       <Piece id="crpg_kriegsmesser_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h0" name="{=}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_executionerssword_h0" name="{=kaikaikai}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_executionerssword_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_executionerssword_guard_h0" Type="Guard" scale_factor="100" />
@@ -12580,7 +12580,7 @@
       <Piece id="crpg_executionerssword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h1" name="{=}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_executionerssword_h1" name="{=kaikaikai}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_executionerssword_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_executionerssword_guard_h1" Type="Guard" scale_factor="100" />
@@ -12588,7 +12588,7 @@
       <Piece id="crpg_executionerssword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h2" name="{=}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_executionerssword_h2" name="{=kaikaikai}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_executionerssword_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_executionerssword_guard_h2" Type="Guard" scale_factor="100" />
@@ -12596,7 +12596,7 @@
       <Piece id="crpg_executionerssword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h3" name="{=}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_executionerssword_h3" name="{=kaikaikai}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_executionerssword_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_executionerssword_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
stats input for three new 2h swords: Meowdao, Zweihander, Executioner's Sword
specific stats for each weapon:

Meowdao h0

-   swing damage 43
-   swing speed 80
-   thrust damage 20
-   thrust speed 92
-   tier 9.86
-   weight 2.12
-   length 140
-   handling 77

Meowdao h1

- swing damage 44
- swing speed 81
- thrust damage 20
- thrust speed 92
- tier 9.94
- weight 2.06
- length 140
- handling 77

Meowdao h2

- swing damage 45
- swing speed 81
- thrust damage 21
- thrust speed 92
- tier 9.34
- weight 2.06
- length 140
- handling 77

Meowdao h3

- swing damage 46
- swing speed 82
- thrust damage 21
- thrust speed 92
- tier 9.90
- weight 2.01
- length 140
- handling 78

Zweihander h0

- swing damage 46
- swing speed 74
- thrust damage 21
- thrust speed 87
- tier 9.93
- weight 2.67
- length 160
- handling 75

Zweihander h1

- swing damage 46
- swing speed 75
- thrust damage 23
- thrust speed 88
- tier 9.75
- weight 2.63
- length 160
- handling 75

Zweihander h2

- swing damage 48
- swing speed 75
- thrust damage 24
- thrust speed 88
- tier 10.01
- weight 2.63
- length 160
- handling 75

Zweihander h3

- swing damage 50
- swing speed 75
- thrust damage 24
- thrust speed 89
- tier 10.04
- weight 2.61
- length 160
- handling 75

Executioner's Sword h0

- swing damage 39
- swing speed 87
- thrust damage 21
- thrust speed 91
- tier 9.86
- weight 2.27
- length 120
- handling 83

Executioner's Sword h1

- swing damage 40
- swing speed 87
- thrust damage 23
- thrust speed 92
- tier 9.72
- weight 2.2
- length 120
- handling 84

Executioner's Sword h2

- swing damage 41
- swing speed 88
- thrust damage 23
- thrust speed 92
- tier 9.90
- weight 2.15
- length 120
- handling 84

Executioner's Sword h3

- swing damage 42
- swing speed 88
- thrust damage 25
- thrust speed 92
- tier 9.79
- weight 2.15
- length 120
- handling 84
