### PR TITLE
rebalance Norse Battle Axe

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31180,52 +31180,60 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowaxe_blade_h0" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.75">
+  <CraftingPiece id="crpg_meowaxe_blade_h0" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.82">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Blunt" damage_factor="2.0"/>
+      <Swing damage_type="Cut" damage_factor="4.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
+    </Flags>
+    <Materials>
+      <Material id="Iron5" count="3" />
+      <Material id="Iron4" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_meowaxe_blade_h1" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.78">
+    <BuildData piece_offset="-12" />
+    <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Blunt" damage_factor="2.0"/>
       <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron5" count="3" />
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowaxe_blade_h1" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.72">
+  <CraftingPiece id="crpg_meowaxe_blade_h2" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Blunt" damage_factor="2.2"/>
       <Swing damage_type="Cut" damage_factor="4.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron5" count="3" />
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_meowaxe_blade_h2" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.72">
+  <CraftingPiece id="crpg_meowaxe_blade_h3" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.75">
     <BuildData piece_offset="-12" />
     <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Blunt" damage_factor="2.2"/>
       <Swing damage_type="Cut" damage_factor="4.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron5" count="3" />
-      <Material id="Iron4" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_meowaxe_blade_h3" name="{=}Meowaxe Blade" tier="5" piece_type="Blade" mesh="meowaxe_blade" length="27.4" weight="0.72">
-    <BuildData piece_offset="-12" />
-    <BladeData stack_amount="2" blade_length="57.435" blade_width="23.337" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron5" count="3" />

--- a/items.json
+++ b/items.json
@@ -117965,10 +117965,92 @@
     "name": "Norse Battle Axe",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 12431,
-    "weight": 2.58,
+    "price": 13282,
+    "weight": 2.64,
     "rank": 0,
-    "tier": 9.360576,
+    "tier": 9.712137,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 110,
+        "balance": 0.41,
+        "handling": 72,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "BonusAgainstShield",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 20,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 89,
+        "swingDamage": 43,
+        "swingDamageType": "Cut",
+        "swingSpeed": 82
+      }
+    ]
+  },
+  {
+    "id": "crpg_Norse_Battle_Axe_h1",
+    "baseId": "crpg_Norse_Battle_Axe",
+    "name": "Norse Battle Axe",
+    "culture": "Battania",
+    "type": "Polearm",
+    "price": 13457,
+    "weight": 2.61,
+    "rank": 1,
+    "tier": 9.7831955,
+    "requirement": 0,
+    "flags": [
+      "CanBePickedUpFromCorpse"
+    ],
+    "weapons": [
+      {
+        "class": "TwoHandedPolearm",
+        "itemUsage": "polearm_block_long_shield_swing_thrust",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 110,
+        "balance": 0.43,
+        "handling": 72,
+        "bodyArmor": 0,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand",
+          "WideGrip",
+          "BonusAgainstShield",
+          "TwoHandIdleOnMount"
+        ],
+        "thrustDamage": 20,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 89,
+        "swingDamage": 44,
+        "swingDamageType": "Cut",
+        "swingSpeed": 83
+      }
+    ]
+  },
+  {
+    "id": "crpg_Norse_Battle_Axe_h2",
+    "baseId": "crpg_Norse_Battle_Axe",
+    "name": "Norse Battle Axe",
+    "culture": "Battania",
+    "type": "Polearm",
+    "price": 12990,
+    "weight": 2.58,
+    "rank": 2,
+    "tier": 9.59304,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -117988,94 +118070,15 @@
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
+          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 44,
-        "swingDamageType": "Cut",
-        "swingSpeed": 83
-      }
-    ]
-  },
-  {
-    "id": "crpg_Norse_Battle_Axe_h1",
-    "baseId": "crpg_Norse_Battle_Axe",
-    "name": "Norse Battle Axe",
-    "culture": "Battania",
-    "type": "Polearm",
-    "price": 12687,
-    "weight": 2.55,
-    "rank": 1,
-    "tier": 9.467926,
-    "requirement": 0,
-    "flags": [
-      "CanBePickedUpFromCorpse"
-    ],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 110,
-        "balance": 0.48,
-        "handling": 73,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
+        "thrustDamage": 22,
+        "thrustDamageType": "Blunt",
         "thrustSpeed": 89,
         "swingDamage": 45,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
-      }
-    ]
-  },
-  {
-    "id": "crpg_Norse_Battle_Axe_h2",
-    "baseId": "crpg_Norse_Battle_Axe",
-    "name": "Norse Battle Axe",
-    "culture": "Battania",
-    "type": "Polearm",
-    "price": 12986,
-    "weight": 2.55,
-    "rank": 2,
-    "tier": 9.591462,
-    "requirement": 0,
-    "flags": [
-      "CanBePickedUpFromCorpse"
-    ],
-    "weapons": [
-      {
-        "class": "TwoHandedPolearm",
-        "itemUsage": "polearm_block_long_shield_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 110,
-        "balance": 0.48,
-        "handling": 73,
-        "bodyArmor": 0,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand",
-          "WideGrip",
-          "TwoHandIdleOnMount"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 89,
-        "swingDamage": 47,
-        "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 83
       }
     ]
   },
@@ -118085,10 +118088,10 @@
     "name": "Norse Battle Axe",
     "culture": "Battania",
     "type": "Polearm",
-    "price": 13441,
-    "weight": 2.55,
+    "price": 13418,
+    "weight": 2.58,
     "rank": 3,
-    "tier": 9.77649,
+    "tier": 9.767394,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -118101,21 +118104,22 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 110,
-        "balance": 0.48,
+        "balance": 0.46,
         "handling": 73,
         "bodyArmor": 0,
         "flags": [
           "MeleeWeapon",
           "NotUsableWithOneHand",
           "WideGrip",
+          "BonusAgainstShield",
           "TwoHandIdleOnMount"
         ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
+        "thrustDamage": 22,
+        "thrustDamageType": "Blunt",
         "thrustSpeed": 89,
-        "swingDamage": 49,
+        "swingDamage": 47,
         "swingDamageType": "Cut",
-        "swingSpeed": 84
+        "swingSpeed": 83
       }
     ]
   },


### PR DESCRIPTION
Giving Norse Battle Axe BvS
Giving Norse Battle Axe thrust with blunt damage
Below are the stats:

Norse Battle Axe h0

    swing damage 43
    swing speed 82
    thrust damage 20
    thrust speed 89
    tier 9.71
    weight 2.64
    length 110
    handling 72

Norse Battle Axe h1

    swing damage 44
    swing speed 83
    thrust damage 20
    thrust speed 89
    tier 9.78
    weight 2.61
    length 110
    handling 72

Norse Battle Axe h2

    swing damage 45
    swing speed 83
    thrust damage 22
    thrust speed 89
    tier 9.59
    weight 2.58
    length 110
    handling 73

Norse Battle Axe h3

    swing damage 47
    swing speed 83
    thrust damage 22
    thrust speed 89
    tier 9.77
    weight 2.58
    length 110
    handling 73
