### PR TITLE
NewOneHandedSwords Kopesh, Narrow Sword

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -20608,10 +20608,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_sword_blade_h0" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_narrow_sword_blade_h0" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20620,10 +20620,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_sword_blade_h1" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_narrow_sword_blade_h1" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.3">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20632,10 +20632,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_sword_blade_h2" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_narrow_sword_blade_h2" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -20644,10 +20644,10 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_sword_blade_h3" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.2">
+  <CraftingPiece id="crpg_narrow_sword_blade_h3" name="{=ZJrqEfBF}Tapered Kaskara Blade" tier="3" piece_type="Blade" mesh="vlandian_blade_8" culture="Culture.aserai" length="80.3" weight="1.25">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="vlandian_blade_8_scabbard_8">
-      <Thrust damage_type="Pierce" damage_factor="0.945" />
-      <Swing damage_type="Cut" damage_factor="1.26" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31388,9 +31388,9 @@
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_kopesh_blade_h0" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.82">
+  <CraftingPiece id="crpg_kopesh_blade_h0" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
@@ -31400,10 +31400,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_kopesh_blade_h1" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.82">
+  <CraftingPiece id="crpg_kopesh_blade_h1" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.96">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31412,10 +31412,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_kopesh_blade_h2" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.82">
+  <CraftingPiece id="crpg_kopesh_blade_h2" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.9">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31424,10 +31424,10 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_kopesh_blade_h3" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.82">
+  <CraftingPiece id="crpg_kopesh_blade_h3" name="{=}Kopesh Blade" tier="5" piece_type="Blade" mesh="kopesh_blade" culture="Culture.vlandia" length="65.5" weight="0.84">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items.json
+++ b/items.json
@@ -88525,10 +88525,10 @@
     "name": "Kopesh",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 10650,
-    "weight": 1.98,
+    "price": 7001,
+    "weight": 2.12,
     "rank": 0,
-    "tier": 12.5985432,
+    "tier": 10.0011082,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -88541,31 +88541,31 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.8,
-        "handling": 89,
+        "balance": 0.72,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
+        "thrustSpeed": 85,
         "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 93
+        "swingSpeed": 91
       }
     ]
   },
   {
     "id": "crpg_kopesh_h1",
     "baseId": "crpg_kopesh",
-    "name": "Kopesh",
+    "name": "Kopesh +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 7528,
-    "weight": 1.98,
+    "price": 6445,
+    "weight": 2.12,
     "rank": 1,
-    "tier": 10.4120188,
+    "tier": 9.550359,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -88578,31 +88578,31 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.8,
-        "handling": 89,
+        "balance": 0.72,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 33,
+        "thrustSpeed": 85,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 93
+        "swingSpeed": 91
       }
     ]
   },
   {
     "id": "crpg_kopesh_h2",
     "baseId": "crpg_kopesh",
-    "name": "Kopesh",
+    "name": "Kopesh +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5513,
-    "weight": 1.98,
+    "price": 6952,
+    "weight": 2.06,
     "rank": 2,
-    "tier": 8.748986,
+    "tier": 9.9618,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -88615,31 +88615,31 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.8,
-        "handling": 89,
+        "balance": 0.75,
+        "handling": 88,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
         "thrustDamage": 22,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 87,
-        "swingDamage": 33,
+        "thrustSpeed": 86,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 93
+        "swingSpeed": 92
       }
     ]
   },
   {
     "id": "crpg_kopesh_h3",
     "baseId": "crpg_kopesh",
-    "name": "Kopesh",
+    "name": "Kopesh +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 4161,
-    "weight": 1.98,
+    "price": 6690,
+    "weight": 2.0,
     "rank": 3,
-    "tier": 7.45476,
+    "tier": 9.75137,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -88652,16 +88652,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 77,
-        "balance": 0.8,
+        "balance": 0.78,
         "handling": 89,
         "bodyArmor": 5,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 24,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 87,
-        "swingDamage": 33,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
         "swingSpeed": 93
       }
@@ -113049,10 +113049,10 @@
     "name": "Narrow Sword",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 76,
-    "weight": 1.52,
+    "price": 6473,
+    "weight": 1.67,
     "rank": 0,
-    "tier": 0.187024921,
+    "tier": 9.573423,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113065,18 +113065,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.54,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 90,
-        "swingDamage": 12,
+        "thrustSpeed": 89,
+        "swingDamage": 33,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 86
       }
     ]
   },
@@ -113086,10 +113086,10 @@
     "name": "Narrow Sword +1",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 71,
-    "weight": 1.52,
+    "price": 6883,
+    "weight": 1.62,
     "rank": 1,
-    "tier": 0.15456602,
+    "tier": 9.9071,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113102,18 +113102,18 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.58,
+        "handling": 89,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 12,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
-        "swingSpeed": 88
+        "swingSpeed": 87
       }
     ]
   },
@@ -113123,10 +113123,10 @@
     "name": "Narrow Sword +2",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 68,
-    "weight": 1.52,
+    "price": 6732,
+    "weight": 1.57,
     "rank": 2,
-    "tier": 0.129878387,
+    "tier": 9.785597,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113139,16 +113139,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.61,
+        "handling": 90,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 23,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 12,
+        "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 88
       }
@@ -113160,10 +113160,10 @@
     "name": "Narrow Sword +3",
     "culture": "Neutral",
     "type": "OneHandedWeapon",
-    "price": 65,
-    "weight": 1.52,
+    "price": 6678,
+    "weight": 1.57,
     "rank": 3,
-    "tier": 0.110665619,
+    "tier": 9.741187,
     "requirement": 0,
     "flags": [
       "Civilian"
@@ -113176,16 +113176,16 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 94,
-        "balance": 0.63,
-        "handling": 91,
+        "balance": 0.61,
+        "handling": 90,
         "bodyArmor": 3,
         "flags": [
           "MeleeWeapon"
         ],
-        "thrustDamage": 9,
+        "thrustDamage": 25,
         "thrustDamageType": "Pierce",
         "thrustSpeed": 90,
-        "swingDamage": 12,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
         "swingSpeed": 88
       }

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -6944,7 +6944,7 @@
       <Piece id="crpg_iron_cleaver_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_sword_h0" name="{=3YhwjpQ0}Narrow Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_narrow_sword_h0" name="{=kaikaikai}Narrow Sword" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_narrow_sword_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_narrow_sword_guard_h0" Type="Guard" scale_factor="100" />
@@ -6952,7 +6952,7 @@
       <Piece id="crpg_narrow_sword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_sword_h1" name="{=3YhwjpQ0}Narrow Sword +1" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_narrow_sword_h1" name="{=kaikaikai}Narrow Sword +1" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_narrow_sword_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_narrow_sword_guard_h1" Type="Guard" scale_factor="100" />
@@ -6960,7 +6960,7 @@
       <Piece id="crpg_narrow_sword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_sword_h2" name="{=3YhwjpQ0}Narrow Sword +2" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_narrow_sword_h2" name="{=kaikaikai}Narrow Sword +2" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_narrow_sword_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_narrow_sword_guard_h2" Type="Guard" scale_factor="100" />
@@ -6968,7 +6968,7 @@
       <Piece id="crpg_narrow_sword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_sword_h3" name="{=3YhwjpQ0}Narrow Sword +3" crafting_template="crpg_OneHandedSword" modifier_group="sword">
+  <CraftedItem id="crpg_narrow_sword_h3" name="{=kaikaikai}Narrow Sword +3" crafting_template="crpg_OneHandedSword" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_narrow_sword_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_narrow_sword_guard_h3" Type="Guard" scale_factor="100" />
@@ -12604,7 +12604,7 @@
       <Piece id="crpg_executionerssword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kopesh_h0" name="{=}Kopesh" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_kopesh_h0" name="{=kaikaikai}Kopesh" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_kopesh_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kopesh_guard_h0" Type="Guard" scale_factor="100" />
@@ -12612,7 +12612,7 @@
       <Piece id="crpg_kopesh_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kopesh_h1" name="{=}Kopesh" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_kopesh_h1" name="{=kaikaikai}Kopesh +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_kopesh_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kopesh_guard_h1" Type="Guard" scale_factor="100" />
@@ -12620,7 +12620,7 @@
       <Piece id="crpg_kopesh_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kopesh_h2" name="{=}Kopesh" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_kopesh_h2" name="{=kaikaikai}Kopesh +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_kopesh_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kopesh_guard_h2" Type="Guard" scale_factor="100" />
@@ -12628,7 +12628,7 @@
       <Piece id="crpg_kopesh_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_kopesh_h3" name="{=}Kopesh" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
+  <CraftedItem id="crpg_kopesh_h3" name="{=kaikaikai}Kopesh +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.vlandia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_kopesh_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_kopesh_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
stats input for two new 1h swords: Kopesh, Narrow Sword
specific stats for each weapon:

Kopesh h0

    swing damage 33
    swing speed 91
    thrust damage 20
    thrust speed 85
    tier 10
    weight 2.12
    length 77
    handling 88

Kopesh h1

    swing damage 34
    swing speed 91
    thrust damage 22
    thrust speed 85
    tier 9.55
    weight 2.12
    length 77
    handling 88

Kopesh h2

    swing damage 35
    swing speed 92
    thrust damage 22
    thrust speed 86
    tier 9.96
    weight 2.06
    length 77
    handling 88

Kopesh h3

    swing damage 35
    swing speed 93
    thrust damage 24
    thrust speed 87
    tier 9.75
    weight 2
    length 77
    handling 89

Narrow Sword h0

    swing damage 33
    swing speed 86
    thrust damage 20
    thrust speed 89
    tier 9.57
    weight 1.67
    length 94
    handling 89

Narrow Sword h1

    swing damage 34
    swing speed 87
    thrust damage 20
    thrust speed 90
    tier 9.91
    weight 1.62
    length 94
    handling 89

Narrow Sword h2

    swing damage 34
    swing speed 88
    thrust damage 23
    thrust speed 90
    tier 9.79
    weight 1.57
    length 94
    handling 90

Narrow Sword h3

    swing damage 35
    swing speed 88
    thrust damage 25
    thrust speed 90
    tier 9.74
    weight 1.57
    length 94
    handling 90
