### PR TITLE
ReworkExecutionersSword

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -30552,37 +30552,33 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h0" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.61">
+  <CraftingPiece id="crpg_executionerssword_blade_h0" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="2.5"  excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h1" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.55">
+  <CraftingPiece id="crpg_executionerssword_blade_h1" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="2.35"  excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="blunt" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h2" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.51">
+  <CraftingPiece id="crpg_executionerssword_blade_h2" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="2.35"  excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Cut" damage_factor="4.1" />
+      <Swing damage_type="blunt" damage_factor="3.0" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_executionerssword_blade_h3" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="1.51">
+  <CraftingPiece id="crpg_executionerssword_blade_h3" name="{=}Executioners Blade" tier="4" piece_type="Blade" mesh="executionerssword_blade" culture="Culture.battania" length="95.5" weight="2.35"  excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="4.2" />
+      <Swing damage_type="blunt" damage_factor="3.1" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="4" />

--- a/items.json
+++ b/items.json
@@ -31450,6 +31450,150 @@
     ]
   },
   {
+    "id": "crpg_ceremonial_executioner_sword_h0",
+    "baseId": "crpg_ceremonial_executioner_sword",
+    "name": "Ceremonial Executioner's Sword",
+    "culture": "Neutral",
+    "type": "TwoHandedWeapon",
+    "price": 12597,
+    "weight": 2.84,
+    "rank": 0,
+    "tier": 9.430442,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 101,
+        "balance": 0.47,
+        "handling": 81,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 87,
+        "swingDamage": 29,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 84
+      }
+    ]
+  },
+  {
+    "id": "crpg_ceremonial_executioner_sword_h1",
+    "baseId": "crpg_ceremonial_executioner_sword",
+    "name": "Ceremonial Executioner's Sword +1",
+    "culture": "Neutral",
+    "type": "TwoHandedWeapon",
+    "price": 11276,
+    "weight": 2.69,
+    "rank": 1,
+    "tier": 8.864064,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 101,
+        "balance": 0.53,
+        "handling": 82,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 89,
+        "swingDamage": 29,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 85
+      }
+    ]
+  },
+  {
+    "id": "crpg_ceremonial_executioner_sword_h2",
+    "baseId": "crpg_ceremonial_executioner_sword",
+    "name": "Ceremonial Executioner's Sword +2",
+    "culture": "Neutral",
+    "type": "TwoHandedWeapon",
+    "price": 10723,
+    "weight": 2.69,
+    "rank": 2,
+    "tier": 8.617194,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 101,
+        "balance": 0.53,
+        "handling": 82,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 89,
+        "swingDamage": 30,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 85
+      }
+    ]
+  },
+  {
+    "id": "crpg_ceremonial_executioner_sword_h3",
+    "baseId": "crpg_ceremonial_executioner_sword",
+    "name": "Ceremonial Executioner's Sword +3",
+    "culture": "Neutral",
+    "type": "TwoHandedWeapon",
+    "price": 10365,
+    "weight": 2.69,
+    "rank": 3,
+    "tier": 8.454264,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 101,
+        "balance": 0.53,
+        "handling": 82,
+        "bodyArmor": 3,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 89,
+        "swingDamage": 31,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 85
+      }
+    ]
+  },
+  {
     "id": "crpg_cervelliere_over_arming_coif_v2_h0",
     "baseId": "crpg_cervelliere_over_arming_coif_v2",
     "name": "Cervelliere over Arming Coif",
@@ -51432,150 +51576,6 @@
       "familyType": 0
     },
     "weapons": []
-  },
-  {
-    "id": "crpg_executionerssword_h0",
-    "baseId": "crpg_executionerssword",
-    "name": "Executioner's Sword",
-    "culture": "Neutral",
-    "type": "TwoHandedWeapon",
-    "price": 13651,
-    "weight": 2.27,
-    "rank": 0,
-    "tier": 9.861127,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 120,
-        "balance": 0.57,
-        "handling": 83,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 21,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 91,
-        "swingDamage": 39,
-        "swingDamageType": "Cut",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_executionerssword_h1",
-    "baseId": "crpg_executionerssword",
-    "name": "Executioner's Sword +1",
-    "culture": "Neutral",
-    "type": "TwoHandedWeapon",
-    "price": 13295,
-    "weight": 2.2,
-    "rank": 1,
-    "tier": 9.717514,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 120,
-        "balance": 0.6,
-        "handling": 84,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 23,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 40,
-        "swingDamageType": "Cut",
-        "swingSpeed": 87
-      }
-    ]
-  },
-  {
-    "id": "crpg_executionerssword_h2",
-    "baseId": "crpg_executionerssword",
-    "name": "Executioner's Sword +2",
-    "culture": "Neutral",
-    "type": "TwoHandedWeapon",
-    "price": 13750,
-    "weight": 2.15,
-    "rank": 2,
-    "tier": 9.900779,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 120,
-        "balance": 0.62,
-        "handling": 84,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 23,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 41,
-        "swingDamageType": "Cut",
-        "swingSpeed": 88
-      }
-    ]
-  },
-  {
-    "id": "crpg_executionerssword_h3",
-    "baseId": "crpg_executionerssword",
-    "name": "Executioner's Sword +3",
-    "culture": "Neutral",
-    "type": "TwoHandedWeapon",
-    "price": 13481,
-    "weight": 2.15,
-    "rank": 3,
-    "tier": 9.792738,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing_thrust",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 120,
-        "balance": 0.62,
-        "handling": 84,
-        "bodyArmor": 3,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 25,
-        "thrustDamageType": "Pierce",
-        "thrustSpeed": 92,
-        "swingDamage": 42,
-        "swingDamageType": "Cut",
-        "swingSpeed": 88
-      }
-    ]
   },
   {
     "id": "crpg_eyepatch_1_v1_h0",

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12572,33 +12572,33 @@
       <Piece id="crpg_kriegsmesser_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h0" name="{=kaikaikai}Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_ceremonial_executioner_sword_h0" name="{=kaikaikai}Ceremonial Executioner's Sword" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_executionerssword_blade_h0" Type="Blade" scale_factor="120" />
+      <Piece id="crpg_executionerssword_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_executionerssword_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_executionerssword_handle_h0" Type="Handle" scale_factor="120" />
       <Piece id="crpg_executionerssword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h1" name="{=kaikaikai}Executioner's Sword +1" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_ceremonial_executioner_sword_h1" name="{=kaikaikai}Ceremonial Executioner's Sword +1" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_executionerssword_blade_h1" Type="Blade" scale_factor="120" />
+      <Piece id="crpg_executionerssword_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_executionerssword_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_executionerssword_handle_h1" Type="Handle" scale_factor="120" />
       <Piece id="crpg_executionerssword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h2" name="{=kaikaikai}Executioner's Sword +2" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_ceremonial_executioner_sword_h2" name="{=kaikaikai}Ceremonial Executioner's Sword +2" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_executionerssword_blade_h2" Type="Blade" scale_factor="120" />
+      <Piece id="crpg_executionerssword_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_executionerssword_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_executionerssword_handle_h2" Type="Handle" scale_factor="120" />
       <Piece id="crpg_executionerssword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_executionerssword_h3" name="{=kaikaikai}Executioner's Sword +3" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_ceremonial_executioner_sword_h3" name="{=kaikaikai}Ceremonial Executioner's Sword +3" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
-      <Piece id="crpg_executionerssword_blade_h3" Type="Blade" scale_factor="120" />
+      <Piece id="crpg_executionerssword_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_executionerssword_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_executionerssword_handle_h3" Type="Handle" scale_factor="120" />
       <Piece id="crpg_executionerssword_pommel_h3" Type="Pommel" scale_factor="100" />


### PR DESCRIPTION
Unable to confirm new model got in atm, will leave it here and ask for review for merge in after batch4

Rename Executioner's Sword to Ceremonial Executioner's Sword, rework is aiming at changing the purpose of this 2h sword from a sword with regular thrust ability and cut damage for swing into a similar position of Barmace. Therefore after the rework, thrust ability will be disabled, swing damage type will be changed to blunt. New stats at below:

 Ceremonial Executioner's Sword h0

    swing damage 29
    swing speed 84
    tier 9.39
    weight 2.82
    length 100
    handling 82

 Ceremonial Executioner's Sword h1

    swing damage 29
    swing speed 86
    tier 9.78
    weight 2.67
    length 100
    handling 83

 Ceremonial Executioner's Sword h2

    swing damage 30
    swing speed 86
    tier 9.51
    weight 2.67
    length 100
    handling 83

 Ceremonial Executioner's Sword h3

    swing damage 31
    swing speed 86
    tier 9.33
    weight 2.67
    length 100
    handling 83
