### PR TITLE
Renamed stugian coat of plates

### DIFF
--- a/items.json
+++ b/items.json
@@ -117970,7 +117970,7 @@
   {
     "id": "crpg_northern_coat_of_plates_v2_h0",
     "baseId": "crpg_northern_coat_of_plates_v2",
-    "name": "Coat Of Plates",
+    "name": "Northern Coat Of Plates",
     "culture": "Sturgia",
     "type": "BodyArmor",
     "price": 10923,
@@ -117994,7 +117994,7 @@
   {
     "id": "crpg_northern_coat_of_plates_v2_h1",
     "baseId": "crpg_northern_coat_of_plates_v2",
-    "name": "Coat Of Plates +1",
+    "name": "Northern Coat Of Plates +1",
     "culture": "Sturgia",
     "type": "BodyArmor",
     "price": 10924,
@@ -118018,7 +118018,7 @@
   {
     "id": "crpg_northern_coat_of_plates_v2_h2",
     "baseId": "crpg_northern_coat_of_plates_v2",
-    "name": "Coat Of Plates +2",
+    "name": "Northern Coat Of Plates +2",
     "culture": "Sturgia",
     "type": "BodyArmor",
     "price": 10925,
@@ -118042,7 +118042,7 @@
   {
     "id": "crpg_northern_coat_of_plates_v2_h3",
     "baseId": "crpg_northern_coat_of_plates_v2",
-    "name": "Coat Of Plates +3",
+    "name": "Northern Coat Of Plates +3",
     "culture": "Sturgia",
     "type": "BodyArmor",
     "price": 10926,

--- a/items/body_armors.xml
+++ b/items/body_armors.xml
@@ -4992,25 +4992,25 @@
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
-  <Item id="crpg_northern_coat_of_plates_v2_h0" name="{=w4RuDABQ}Coat Of Plates" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
+  <Item id="crpg_northern_coat_of_plates_v2_h0" name="{=w4RuDABQ}Northern Coat Of Plates" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
     <ItemComponent>
       <Armor body_armor="50" leg_armor="13" arm_armor="13" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
-  <Item id="crpg_northern_coat_of_plates_v2_h1" name="{=w4RuDABQ}Coat Of Plates +1" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
+  <Item id="crpg_northern_coat_of_plates_v2_h1" name="{=w4RuDABQ}Northern Coat Of Plates +1" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
     <ItemComponent>
       <Armor body_armor="52" leg_armor="14" arm_armor="14" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
-  <Item id="crpg_northern_coat_of_plates_v2_h2" name="{=w4RuDABQ}Coat Of Plates +2" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
+  <Item id="crpg_northern_coat_of_plates_v2_h2" name="{=w4RuDABQ}Northern Coat Of Plates +2" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
     <ItemComponent>
       <Armor body_armor="54" leg_armor="15" arm_armor="15" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>
     <Flags UseTeamColor="true" />
   </Item>
-  <Item id="crpg_northern_coat_of_plates_v2_h3" name="{=w4RuDABQ}Coat Of Plates +3" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
+  <Item id="crpg_northern_coat_of_plates_v2_h3" name="{=w4RuDABQ}Northern Coat Of Plates +3" mesh="sturgia_plate_armor" culture="Culture.sturgia" weight="14.30302" appearance="2" Type="BodyArmor">
     <ItemComponent>
       <Armor body_armor="56" leg_armor="16" arm_armor="16" covers_body="true" modifier_group="plate" material_type="Plate" />
     </ItemComponent>


### PR DESCRIPTION
The new batch of Coat of Plates name clashes with old sturgian coat of plates

Renamed, chose name common with other sturgian items, (also same name as item id)