### PR TITLE
Nodachi & Pavise changes v1.0

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -29324,17 +29324,17 @@
   <CraftingPiece id="crpg_gladius_republican_handle_h3" name="{=}Republican Gladius Handle" tier="3" piece_type="Handle" mesh="gladius_republican_handle" culture="Culture.khuzait" length="15.7" weight="0.02">
     <BuildData piece_offset="0" previous_piece_offset="1" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_red_nodachi_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.2" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_red_nodachi_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.08" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_red_nodachi_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.2" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_red_nodachi_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.08" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
@@ -29532,17 +29532,17 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_green_nodachi_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.2" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_green_nodachi_blade_h0" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.08" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="4.6" />
+      <Swing damage_type="Cut" damage_factor="4.4" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_green_nodachi_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.2" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_green_nodachi_blade_h1" name="{=}Katana Blade" tier="2" piece_type="Blade" mesh="katana_blade" culture="Culture.aserai" length="93.7" weight="1.08" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
-      <Swing damage_type="Cut" damage_factor="4.8" />
+      <Swing damage_type="Cut" damage_factor="4.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="3" />

--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -3920,31 +3920,31 @@
   </CraftingTemplate>
   <CraftingTemplate id="crpg_Dagger_Reverse" item_type="OneHandedWeapon" modifier_group="sword" item_holsters="dagger_reverse_left_hip:dagger_reverse_right_hip:sword_reverse_left_hip" default_item_holster_position_offset="0,0,-0.1" use_weapon_as_holster_mesh="true">
     <PieceDatas>
-    <PieceData piece_type="Handle" build_order="0" />
-    <PieceData piece_type="Guard" build_order="1" />
-    <PieceData piece_type="Blade" build_order="2" />
-    <PieceData piece_type="Pommel" build_order="-1" />
-  </PieceDatas>
-  <WeaponDescriptions>
-    <WeaponDescription id="crpg_Dagger" />
-    <WeaponDescription id="crpg_ThrowingKnife" />
-  </WeaponDescriptions>
-  <StatsData weapon_description="crpg_Dagger">
-    <StatData stat_type="Weight" max_value="7.0" />
-    <StatData stat_type="WeaponReach" max_value="300" />
-    <StatData stat_type="ThrustSpeed" max_value="200" />
-    <StatData stat_type="SwingSpeed" max_value="200" />
-    <StatData stat_type="ThrustDamage" max_value="500" />
-    <StatData stat_type="SwingDamage" max_value="500" />
-    <StatData stat_type="Handling" max_value="200" />
-  </StatsData>
-  <StatsData weapon_description="crpg_ThrowingKnife">
-    <StatData stat_type="Weight" max_value="2.0" />
-    <StatData stat_type="WeaponReach" max_value="100" />
-    <StatData stat_type="MissileSpeed" max_value="150" />
-    <StatData stat_type="MissileDamage" max_value="200" />
-    <StatData stat_type="Accuracy" max_value="100" />
-  </StatsData>
+      <PieceData piece_type="Handle" build_order="0" />
+      <PieceData piece_type="Guard" build_order="1" />
+      <PieceData piece_type="Blade" build_order="2" />
+      <PieceData piece_type="Pommel" build_order="-1" />
+    </PieceDatas>
+    <WeaponDescriptions>
+      <WeaponDescription id="crpg_Dagger" />
+      <WeaponDescription id="crpg_ThrowingKnife" />
+    </WeaponDescriptions>
+    <StatsData weapon_description="crpg_Dagger">
+      <StatData stat_type="Weight" max_value="7.0" />
+      <StatData stat_type="WeaponReach" max_value="300" />
+      <StatData stat_type="ThrustSpeed" max_value="200" />
+      <StatData stat_type="SwingSpeed" max_value="200" />
+      <StatData stat_type="ThrustDamage" max_value="500" />
+      <StatData stat_type="SwingDamage" max_value="500" />
+      <StatData stat_type="Handling" max_value="200" />
+    </StatsData>
+    <StatsData weapon_description="crpg_ThrowingKnife">
+      <StatData stat_type="Weight" max_value="2.0" />
+      <StatData stat_type="WeaponReach" max_value="100" />
+      <StatData stat_type="MissileSpeed" max_value="150" />
+      <StatData stat_type="MissileDamage" max_value="200" />
+      <StatData stat_type="Accuracy" max_value="100" />
+    </StatsData>
     <UsablePieces>
       <UsablePiece piece_id="crpg_rondel_reverse_blade_h0" />
       <UsablePiece piece_id="crpg_rondel_reverse_blade_h1" />
@@ -3964,7 +3964,6 @@
       <UsablePiece piece_id="crpg_rondel_reverse_pommel_h3" />
     </UsablePieces>
   </CraftingTemplate>
-
   <CraftingTemplate id="crpg_ThrowingKnife" item_type="Thrown" modifier_group="knife_throwing" item_holsters="throwing_knife_2:throwing_knife:throwing_stone:throwing_stone_2" piece_type_to_scale_holster_with="Blade" default_item_holster_position_offset="0,0,-0.1" always_show_holster_with_weapon="true">
     <PieceDatas>
       <PieceData piece_type="Handle" build_order="0" />

--- a/items.json
+++ b/items.json
@@ -124200,166 +124200,6 @@
     "weapons": []
   },
   {
-    "id": "crpg_pavise_h0",
-    "baseId": "crpg_pavise",
-    "name": "Pavise",
-    "culture": "Vlandia",
-    "type": "Shield",
-    "price": 6919,
-    "weight": 5.5696,
-    "rank": 0,
-    "tier": 9.935822,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandSecondaryItemBone",
-      "WoodenParry",
-      "HeldInOffHand"
-    ],
-    "weapons": [
-      {
-        "class": "LargeShield",
-        "itemUsage": "shield",
-        "accuracy": 100,
-        "missileSpeed": 0,
-        "stackAmount": 320,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 80,
-        "bodyArmor": 25,
-        "flags": [
-          "HasHitPoints",
-          "CanBlockRanged"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 80,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
-    "id": "crpg_pavise_h1",
-    "baseId": "crpg_pavise",
-    "name": "Pavise +1",
-    "culture": "Vlandia",
-    "type": "Shield",
-    "price": 7095,
-    "weight": 5.5696,
-    "rank": 1,
-    "tier": 10.0757523,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandSecondaryItemBone",
-      "WoodenParry",
-      "HeldInOffHand"
-    ],
-    "weapons": [
-      {
-        "class": "LargeShield",
-        "itemUsage": "shield",
-        "accuracy": 100,
-        "missileSpeed": 0,
-        "stackAmount": 346,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 80,
-        "bodyArmor": 26,
-        "flags": [
-          "HasHitPoints",
-          "CanBlockRanged"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 80,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
-    "id": "crpg_pavise_h2",
-    "baseId": "crpg_pavise",
-    "name": "Pavise +2",
-    "culture": "Vlandia",
-    "type": "Shield",
-    "price": 7338,
-    "weight": 5.5696,
-    "rank": 2,
-    "tier": 10.2655621,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandSecondaryItemBone",
-      "WoodenParry",
-      "HeldInOffHand"
-    ],
-    "weapons": [
-      {
-        "class": "LargeShield",
-        "itemUsage": "shield",
-        "accuracy": 100,
-        "missileSpeed": 0,
-        "stackAmount": 372,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 80,
-        "bodyArmor": 27,
-        "flags": [
-          "HasHitPoints",
-          "CanBlockRanged"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 80,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
-    "id": "crpg_pavise_h3",
-    "baseId": "crpg_pavise",
-    "name": "Pavise +3",
-    "culture": "Vlandia",
-    "type": "Shield",
-    "price": 7569,
-    "weight": 5.5696,
-    "rank": 3,
-    "tier": 10.4437256,
-    "requirement": 0,
-    "flags": [
-      "ForceAttachOffHandSecondaryItemBone",
-      "WoodenParry",
-      "HeldInOffHand"
-    ],
-    "weapons": [
-      {
-        "class": "LargeShield",
-        "itemUsage": "shield",
-        "accuracy": 100,
-        "missileSpeed": 0,
-        "stackAmount": 397,
-        "length": 118,
-        "balance": 0.0,
-        "handling": 80,
-        "bodyArmor": 28,
-        "flags": [
-          "HasHitPoints",
-          "CanBlockRanged"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Blunt",
-        "thrustSpeed": 80,
-        "swingDamage": 0,
-        "swingDamageType": "Blunt",
-        "swingSpeed": 80
-      }
-    ]
-  },
-  {
     "id": "crpg_pavise_shield_v2_h0",
     "baseId": "crpg_pavise_shield_v2",
     "name": "Pavise Shield",
@@ -124506,6 +124346,166 @@
         "balance": 0.0,
         "handling": 80,
         "bodyArmor": 20,
+        "flags": [
+          "HasHitPoints",
+          "CanBlockRanged"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 80,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_pavise_v1_h0",
+    "baseId": "crpg_pavise_v1",
+    "name": "Pavise",
+    "culture": "Vlandia",
+    "type": "Shield",
+    "price": 6919,
+    "weight": 5.5696,
+    "rank": 0,
+    "tier": 9.935822,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandSecondaryItemBone",
+      "WoodenParry",
+      "HeldInOffHand"
+    ],
+    "weapons": [
+      {
+        "class": "LargeShield",
+        "itemUsage": "shield",
+        "accuracy": 100,
+        "missileSpeed": 0,
+        "stackAmount": 320,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 80,
+        "bodyArmor": 25,
+        "flags": [
+          "HasHitPoints",
+          "CanBlockRanged"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 80,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_pavise_v1_h1",
+    "baseId": "crpg_pavise_v1",
+    "name": "Pavise +1",
+    "culture": "Vlandia",
+    "type": "Shield",
+    "price": 7095,
+    "weight": 5.5696,
+    "rank": 1,
+    "tier": 10.0757523,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandSecondaryItemBone",
+      "WoodenParry",
+      "HeldInOffHand"
+    ],
+    "weapons": [
+      {
+        "class": "LargeShield",
+        "itemUsage": "shield",
+        "accuracy": 100,
+        "missileSpeed": 0,
+        "stackAmount": 346,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 80,
+        "bodyArmor": 26,
+        "flags": [
+          "HasHitPoints",
+          "CanBlockRanged"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 80,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_pavise_v1_h2",
+    "baseId": "crpg_pavise_v1",
+    "name": "Pavise +2",
+    "culture": "Vlandia",
+    "type": "Shield",
+    "price": 7338,
+    "weight": 5.5696,
+    "rank": 2,
+    "tier": 10.2655621,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandSecondaryItemBone",
+      "WoodenParry",
+      "HeldInOffHand"
+    ],
+    "weapons": [
+      {
+        "class": "LargeShield",
+        "itemUsage": "shield",
+        "accuracy": 100,
+        "missileSpeed": 0,
+        "stackAmount": 372,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 80,
+        "bodyArmor": 27,
+        "flags": [
+          "HasHitPoints",
+          "CanBlockRanged"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Blunt",
+        "thrustSpeed": 80,
+        "swingDamage": 0,
+        "swingDamageType": "Blunt",
+        "swingSpeed": 80
+      }
+    ]
+  },
+  {
+    "id": "crpg_pavise_v1_h3",
+    "baseId": "crpg_pavise_v1",
+    "name": "Pavise +3",
+    "culture": "Vlandia",
+    "type": "Shield",
+    "price": 7569,
+    "weight": 5.5696,
+    "rank": 3,
+    "tier": 10.4437256,
+    "requirement": 0,
+    "flags": [
+      "ForceAttachOffHandSecondaryItemBone",
+      "WoodenParry",
+      "HeldInOffHand"
+    ],
+    "weapons": [
+      {
+        "class": "LargeShield",
+        "itemUsage": "shield",
+        "accuracy": 100,
+        "missileSpeed": 0,
+        "stackAmount": 397,
+        "length": 118,
+        "balance": 0.0,
+        "handling": 80,
+        "bodyArmor": 28,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -132158,8 +132158,8 @@
     "weapons": []
   },
   {
-    "id": "crpg_reinforcedpavise_h0",
-    "baseId": "crpg_reinforcedpavise",
+    "id": "crpg_reinforcedpavise_v1_h0",
+    "baseId": "crpg_reinforcedpavise_v1",
     "name": "Reinforced Pavise",
     "culture": "Vlandia",
     "type": "Shield",
@@ -132198,8 +132198,8 @@
     ]
   },
   {
-    "id": "crpg_reinforcedpavise_h1",
-    "baseId": "crpg_reinforcedpavise",
+    "id": "crpg_reinforcedpavise_v1_h1",
+    "baseId": "crpg_reinforcedpavise_v1",
     "name": "Reinforced Pavise +1",
     "culture": "Vlandia",
     "type": "Shield",
@@ -132238,8 +132238,8 @@
     ]
   },
   {
-    "id": "crpg_reinforcedpavise_h2",
-    "baseId": "crpg_reinforcedpavise",
+    "id": "crpg_reinforcedpavise_v1_h2",
+    "baseId": "crpg_reinforcedpavise_v1",
     "name": "Reinforced Pavise +2",
     "culture": "Vlandia",
     "type": "Shield",
@@ -132278,8 +132278,8 @@
     ]
   },
   {
-    "id": "crpg_reinforcedpavise_h3",
-    "baseId": "crpg_reinforcedpavise",
+    "id": "crpg_reinforcedpavise_v1_h3",
+    "baseId": "crpg_reinforcedpavise_v1",
     "name": "Reinforced Pavise +3",
     "culture": "Vlandia",
     "type": "Shield",

--- a/items.json
+++ b/items.json
@@ -63540,8 +63540,8 @@
     ]
   },
   {
-    "id": "crpg_green_nodachi_h0",
-    "baseId": "crpg_green_nodachi",
+    "id": "crpg_green_nodachi_v1_h0",
+    "baseId": "crpg_green_nodachi_v1",
     "name": "Green Nodachi",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -63576,8 +63576,8 @@
     ]
   },
   {
-    "id": "crpg_green_nodachi_h1",
-    "baseId": "crpg_green_nodachi",
+    "id": "crpg_green_nodachi_v1_h1",
+    "baseId": "crpg_green_nodachi_v1",
     "name": "Green Nodachi +1",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -63612,8 +63612,8 @@
     ]
   },
   {
-    "id": "crpg_green_nodachi_h2",
-    "baseId": "crpg_green_nodachi",
+    "id": "crpg_green_nodachi_v1_h2",
+    "baseId": "crpg_green_nodachi_v1",
     "name": "Green Nodachi +2",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
@@ -63648,8 +63648,8 @@
     ]
   },
   {
-    "id": "crpg_green_nodachi_h3",
-    "baseId": "crpg_green_nodachi",
+    "id": "crpg_green_nodachi_v1_h3",
+    "baseId": "crpg_green_nodachi_v1",
     "name": "Green Nodachi +3",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",

--- a/items.json
+++ b/items.json
@@ -63545,10 +63545,10 @@
     "name": "Green Nodachi",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11478,
-    "weight": 5.02,
+    "price": 12622,
+    "weight": 4.87,
     "rank": 0,
-    "tier": 8.952505,
+    "tier": 9.440838,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -63559,8 +63559,44 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 127,
-        "balance": 0.3,
-        "handling": 82,
+        "balance": 0.37,
+        "handling": 83,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 77,
+        "swingDamage": 44,
+        "swingDamageType": "Cut",
+        "swingSpeed": 81
+      }
+    ]
+  },
+  {
+    "id": "crpg_green_nodachi_h1",
+    "baseId": "crpg_green_nodachi",
+    "name": "Green Nodachi +1",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 12634,
+    "weight": 4.87,
+    "rank": 1,
+    "tier": 9.445772,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 127,
+        "balance": 0.37,
+        "handling": 83,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -63571,43 +63607,7 @@
         "thrustSpeed": 77,
         "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
-      }
-    ]
-  },
-  {
-    "id": "crpg_green_nodachi_h1",
-    "baseId": "crpg_green_nodachi",
-    "name": "Green Nodachi +1",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 11323,
-    "weight": 5.02,
-    "rank": 1,
-    "tier": 8.8846,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 127,
-        "balance": 0.3,
-        "handling": 82,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 77,
-        "swingDamage": 48,
-        "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -124205,10 +124205,10 @@
     "name": "Pavise",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4956,
-    "weight": 10.443,
+    "price": 6919,
+    "weight": 5.5696,
     "rank": 0,
-    "tier": 8.236979,
+    "tier": 9.935822,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -124221,11 +124221,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 600,
+        "stackAmount": 320,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 1,
+        "bodyArmor": 25,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -124245,10 +124245,10 @@
     "name": "Pavise +1",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5321,
-    "weight": 10.443,
+    "price": 7095,
+    "weight": 5.5696,
     "rank": 1,
-    "tier": 8.57521248,
+    "tier": 10.0757523,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -124261,11 +124261,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 648,
+        "stackAmount": 346,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 26,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -124285,10 +124285,10 @@
     "name": "Pavise +2",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 5036,
-    "weight": 10.443,
+    "price": 7338,
+    "weight": 5.5696,
     "rank": 2,
-    "tier": 8.312587,
+    "tier": 10.2655621,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -124301,11 +124301,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 696,
+        "stackAmount": 372,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 27,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -124325,10 +124325,10 @@
     "name": "Pavise +3",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 4805,
-    "weight": 10.443,
+    "price": 7569,
+    "weight": 5.5696,
     "rank": 3,
-    "tier": 8.093557,
+    "tier": 10.4437256,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -124341,11 +124341,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 744,
+        "stackAmount": 397,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 28,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -130763,10 +130763,10 @@
     "name": "Red Nodachi",
     "culture": "Aserai",
     "type": "TwoHandedWeapon",
-    "price": 11478,
-    "weight": 5.02,
+    "price": 12622,
+    "weight": 4.87,
     "rank": 0,
-    "tier": 8.952505,
+    "tier": 9.440838,
     "requirement": 0,
     "flags": [],
     "weapons": [
@@ -130777,8 +130777,44 @@
         "missileSpeed": 0,
         "stackAmount": 0,
         "length": 127,
-        "balance": 0.3,
-        "handling": 82,
+        "balance": 0.37,
+        "handling": 83,
+        "bodyArmor": 4,
+        "flags": [
+          "MeleeWeapon",
+          "NotUsableWithOneHand"
+        ],
+        "thrustDamage": 0,
+        "thrustDamageType": "Undefined",
+        "thrustSpeed": 77,
+        "swingDamage": 44,
+        "swingDamageType": "Cut",
+        "swingSpeed": 81
+      }
+    ]
+  },
+  {
+    "id": "crpg_red_nodachi_h1",
+    "baseId": "crpg_red_nodachi",
+    "name": "Red Nodachi +1",
+    "culture": "Aserai",
+    "type": "TwoHandedWeapon",
+    "price": 12634,
+    "weight": 4.87,
+    "rank": 1,
+    "tier": 9.445772,
+    "requirement": 0,
+    "flags": [],
+    "weapons": [
+      {
+        "class": "TwoHandedSword",
+        "itemUsage": "twohanded_block_swing",
+        "accuracy": 0,
+        "missileSpeed": 0,
+        "stackAmount": 0,
+        "length": 127,
+        "balance": 0.37,
+        "handling": 83,
         "bodyArmor": 4,
         "flags": [
           "MeleeWeapon",
@@ -130789,43 +130825,7 @@
         "thrustSpeed": 77,
         "swingDamage": 46,
         "swingDamageType": "Cut",
-        "swingSpeed": 79
-      }
-    ]
-  },
-  {
-    "id": "crpg_red_nodachi_h1",
-    "baseId": "crpg_red_nodachi",
-    "name": "Red Nodachi +1",
-    "culture": "Aserai",
-    "type": "TwoHandedWeapon",
-    "price": 11323,
-    "weight": 5.02,
-    "rank": 1,
-    "tier": 8.8846,
-    "requirement": 0,
-    "flags": [],
-    "weapons": [
-      {
-        "class": "TwoHandedSword",
-        "itemUsage": "twohanded_block_swing",
-        "accuracy": 0,
-        "missileSpeed": 0,
-        "stackAmount": 0,
-        "length": 127,
-        "balance": 0.3,
-        "handling": 82,
-        "bodyArmor": 4,
-        "flags": [
-          "MeleeWeapon",
-          "NotUsableWithOneHand"
-        ],
-        "thrustDamage": 0,
-        "thrustDamageType": "Undefined",
-        "thrustSpeed": 77,
-        "swingDamage": 48,
-        "swingDamageType": "Cut",
-        "swingSpeed": 79
+        "swingSpeed": 81
       }
     ]
   },
@@ -132163,10 +132163,10 @@
     "name": "Reinforced Pavise",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 109,
-    "weight": 2.26265,
+    "price": 6984,
+    "weight": 9.92085,
     "rank": 0,
-    "tier": 0.386680454,
+    "tier": 9.98756,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -132179,11 +132179,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 130,
+        "stackAmount": 570,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 1,
+        "bodyArmor": 5,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -132203,10 +132203,10 @@
     "name": "Reinforced Pavise +1",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 112,
-    "weight": 2.26265,
+    "price": 7420,
+    "weight": 9.92085,
     "rank": 1,
-    "tier": 0.4060065,
+    "tier": 10.32958,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -132219,11 +132219,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 141,
+        "stackAmount": 616,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 6,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -132243,10 +132243,10 @@
     "name": "Reinforced Pavise +2",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 110,
-    "weight": 2.26265,
+    "price": 7030,
+    "weight": 9.92085,
     "rank": 2,
-    "tier": 0.391265571,
+    "tier": 10.0244389,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -132259,11 +132259,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 151,
+        "stackAmount": 662,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 6,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"
@@ -132283,10 +132283,10 @@
     "name": "Reinforced Pavise +3",
     "culture": "Vlandia",
     "type": "Shield",
-    "price": 108,
-    "weight": 2.26265,
+    "price": 6679,
+    "weight": 9.92085,
     "rank": 3,
-    "tier": 0.383728117,
+    "tier": 9.742239,
     "requirement": 0,
     "flags": [
       "ForceAttachOffHandSecondaryItemBone",
@@ -132299,11 +132299,11 @@
         "itemUsage": "shield",
         "accuracy": 100,
         "missileSpeed": 0,
-        "stackAmount": 162,
+        "stackAmount": 707,
         "length": 118,
         "balance": 0.0,
         "handling": 80,
-        "bodyArmor": 2,
+        "bodyArmor": 6,
         "flags": [
           "HasHitPoints",
           "CanBlockRanged"

--- a/items/shields.xml
+++ b/items/shields.xml
@@ -1216,7 +1216,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="25" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="320" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1224,7 +1224,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="26" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="346" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1232,7 +1232,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="27" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="372" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1240,7 +1240,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="28" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="397" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1440,7 +1440,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="5" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="570" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1448,7 +1448,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="616" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1456,7 +1456,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="662" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1464,7 +1464,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="707" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />

--- a/items/shields.xml
+++ b/items/shields.xml
@@ -1216,33 +1216,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="10.443" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="1" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="600" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="25" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="320" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="10.443" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="648" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="26" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="346" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="10.443" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="696" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="27" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="372" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="10.443" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="744" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="28" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="397" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -1440,33 +1440,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="2.26265" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="1" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="130" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="5" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="570" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="2.26265" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="141" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="616" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="2.26265" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="151" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="662" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="2.26265" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="162" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="707" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12192,7 +12192,7 @@
       <Piece id="crpg_yellow_wakizashi_pommel_h3" Type="Pommel" scale_factor="70" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_nodachi_h0" name="{=Yeldur}Green Nodachi" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_nodachi_v1_h0" name="{=Yeldur}Green Nodachi" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_nodachi_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_green_nodachi_guard_h0" Type="Guard" scale_factor="100" />
@@ -12200,7 +12200,7 @@
       <Piece id="crpg_green_nodachi_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_nodachi_h1" name="{=Yeldur}Green Nodachi +1" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_nodachi_v1_h1" name="{=Yeldur}Green Nodachi +1" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_nodachi_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_green_nodachi_guard_h1" Type="Guard" scale_factor="100" />
@@ -12208,7 +12208,7 @@
       <Piece id="crpg_green_nodachi_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_nodachi_h2" name="{=Yeldur}Green Nodachi +2" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_nodachi_v1_h2" name="{=Yeldur}Green Nodachi +2" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_nodachi_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_green_nodachi_guard_h2" Type="Guard" scale_factor="100" />
@@ -12216,7 +12216,7 @@
       <Piece id="crpg_green_nodachi_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_green_nodachi_h3" name="{=Yeldur}Green Nodachi +3" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
+  <CraftedItem id="crpg_green_nodachi_v1_h3" name="{=Yeldur}Green Nodachi +3" crafting_template="crpg_TwoHandedSword" culture="Culture.aserai" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_green_nodachi_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_green_nodachi_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Changes the Green & Red Nodachi - Cuts off lower level damage but increases speed marginally due to weapon being too slow for what it is. Overall slight tier increase.

Changes x2 Pavise shields:

1) Reinforced Pavise - Turned this into the high health strong powerhouse shield that weighs a lot - Designed to be used by battlefield tanks who want to sacrifice movespeed for a powerful shield
2) Pavise - Turned this into a lighter but high armour variant of the shield, designed to be used by those who seek an anti-ranged strategy with lots of coverage but weaker in melee combat in contrast.

Refund issued for Pavise shields as they would be fundamentally changed
No refund issued for Nodachi as the tweak is slight and only serves to better the weapon overall.

