### PR TITLE
1h axe.update.oct2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -6485,7 +6485,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_triangular_throwing_spear_blade_h0" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.76" />
     </BladeData>
     <Materials>
@@ -6496,7 +6496,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_triangular_throwing_spear_blade_h1" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.79" />
     </BladeData>
     <Materials>
@@ -6507,7 +6507,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_triangular_throwing_spear_blade_h2" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.83" />
     </BladeData>
     <Materials>
@@ -6518,7 +6518,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_triangular_throwing_spear_blade_h3" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.86" />
     </BladeData>
     <Materials>
@@ -6529,7 +6529,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h0" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.71" />
     </BladeData>
     <Materials>
@@ -6540,7 +6540,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h1" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.74" />
     </BladeData>
     <Materials>
@@ -6551,7 +6551,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h2" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.78" />
     </BladeData>
     <Materials>
@@ -6562,7 +6562,7 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h3" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="0.82" />
     </BladeData>
     <Materials>
@@ -9052,25 +9052,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h0" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.2072" CraftingCost="75">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h0" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.75" CraftingCost="75">
     <BuildData piece_offset="21" next_piece_offset="1.5" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h1" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.2072" CraftingCost="75">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h1" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.75" CraftingCost="75">
     <BuildData piece_offset="21" next_piece_offset="1.5" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h2" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.2072" CraftingCost="75">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h2" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.75" CraftingCost="75">
     <BuildData piece_offset="21" next_piece_offset="1.5" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h3" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.2072" CraftingCost="75">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_handle_h3" name="{=VL00fQvj}Reinforced Axe handle" tier="4" piece_type="Handle" mesh="axe_craft_13_handle" length="74.7" weight="0.75" CraftingCost="75">
     <BuildData piece_offset="21" next_piece_offset="1.5" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -10444,6 +10444,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -10458,6 +10459,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -10472,6 +10474,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -10486,6 +10489,7 @@
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
@@ -10948,53 +10952,57 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h0" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.46">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h0" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h1" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h1" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Cut" damage_factor="3.4" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
-    <BuildData piece_offset="-8" />
-    <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.43">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
+    <BuildData piece_offset="-8" />
+    <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
     </Flags>
     <Materials>
       <Material id="Iron4" count="3" />

--- a/crafting_templates.xml
+++ b/crafting_templates.xml
@@ -3920,31 +3920,31 @@
   </CraftingTemplate>
   <CraftingTemplate id="crpg_Dagger_Reverse" item_type="OneHandedWeapon" modifier_group="sword" item_holsters="dagger_reverse_left_hip:dagger_reverse_right_hip:sword_reverse_left_hip" default_item_holster_position_offset="0,0,-0.1" use_weapon_as_holster_mesh="true">
     <PieceDatas>
-    <PieceData piece_type="Handle" build_order="0" />
-    <PieceData piece_type="Guard" build_order="1" />
-    <PieceData piece_type="Blade" build_order="2" />
-    <PieceData piece_type="Pommel" build_order="-1" />
-  </PieceDatas>
-  <WeaponDescriptions>
-    <WeaponDescription id="crpg_Dagger" />
-    <WeaponDescription id="crpg_ThrowingKnife" />
-  </WeaponDescriptions>
-  <StatsData weapon_description="crpg_Dagger">
-    <StatData stat_type="Weight" max_value="7.0" />
-    <StatData stat_type="WeaponReach" max_value="300" />
-    <StatData stat_type="ThrustSpeed" max_value="200" />
-    <StatData stat_type="SwingSpeed" max_value="200" />
-    <StatData stat_type="ThrustDamage" max_value="500" />
-    <StatData stat_type="SwingDamage" max_value="500" />
-    <StatData stat_type="Handling" max_value="200" />
-  </StatsData>
-  <StatsData weapon_description="crpg_ThrowingKnife">
-    <StatData stat_type="Weight" max_value="2.0" />
-    <StatData stat_type="WeaponReach" max_value="100" />
-    <StatData stat_type="MissileSpeed" max_value="150" />
-    <StatData stat_type="MissileDamage" max_value="200" />
-    <StatData stat_type="Accuracy" max_value="100" />
-  </StatsData>
+      <PieceData piece_type="Handle" build_order="0" />
+      <PieceData piece_type="Guard" build_order="1" />
+      <PieceData piece_type="Blade" build_order="2" />
+      <PieceData piece_type="Pommel" build_order="-1" />
+    </PieceDatas>
+    <WeaponDescriptions>
+      <WeaponDescription id="crpg_Dagger" />
+      <WeaponDescription id="crpg_ThrowingKnife" />
+    </WeaponDescriptions>
+    <StatsData weapon_description="crpg_Dagger">
+      <StatData stat_type="Weight" max_value="7.0" />
+      <StatData stat_type="WeaponReach" max_value="300" />
+      <StatData stat_type="ThrustSpeed" max_value="200" />
+      <StatData stat_type="SwingSpeed" max_value="200" />
+      <StatData stat_type="ThrustDamage" max_value="500" />
+      <StatData stat_type="SwingDamage" max_value="500" />
+      <StatData stat_type="Handling" max_value="200" />
+    </StatsData>
+    <StatsData weapon_description="crpg_ThrowingKnife">
+      <StatData stat_type="Weight" max_value="2.0" />
+      <StatData stat_type="WeaponReach" max_value="100" />
+      <StatData stat_type="MissileSpeed" max_value="150" />
+      <StatData stat_type="MissileDamage" max_value="200" />
+      <StatData stat_type="Accuracy" max_value="100" />
+    </StatsData>
     <UsablePieces>
       <UsablePiece piece_id="crpg_rondel_reverse_blade_h0" />
       <UsablePiece piece_id="crpg_rondel_reverse_blade_h1" />
@@ -3964,7 +3964,6 @@
       <UsablePiece piece_id="crpg_rondel_reverse_pommel_h3" />
     </UsablePieces>
   </CraftingTemplate>
-
   <CraftingTemplate id="crpg_ThrowingKnife" item_type="Thrown" modifier_group="knife_throwing" item_holsters="throwing_knife_2:throwing_knife:throwing_stone:throwing_stone_2" piece_type_to_scale_holster_with="Blade" default_item_holster_position_offset="0,0,-0.1" always_show_holster_with_weapon="true">
     <PieceDatas>
       <PieceData piece_type="Handle" build_order="0" />
@@ -8994,6 +8993,14 @@
       <UsablePiece piece_id="crpg_short_western_mace_handle_h1" />
       <UsablePiece piece_id="crpg_short_western_mace_handle_h2" />
       <UsablePiece piece_id="crpg_short_western_mace_handle_h3" />
+      <UsablePiece piece_id="crpg_steel_round_axe_blade_h0" />
+      <UsablePiece piece_id="crpg_steel_round_axe_handle_h0" />
+      <UsablePiece piece_id="crpg_steel_round_axe_blade_h1" />
+      <UsablePiece piece_id="crpg_steel_round_axe_handle_h1" />
+      <UsablePiece piece_id="crpg_steel_round_axe_blade_h2" />
+      <UsablePiece piece_id="crpg_steel_round_axe_handle_h2" />
+      <UsablePiece piece_id="crpg_steel_round_axe_blade_h3" />
+      <UsablePiece piece_id="crpg_steel_round_axe_handle_h3" />
     </UsablePieces>
   </CraftingTemplate>
   <CraftingTemplate id="crpg_TwoHandedMace" item_type="TwoHandedWeapon" modifier_group="mace" item_holsters="axe_back:axe_back_2:axe_back_3:axe_back_4" default_item_holster_position_offset="0,0,-0.75" use_weapon_as_holster_mesh="true">

--- a/items.json
+++ b/items.json
@@ -87328,15 +87328,15 @@
     ]
   },
   {
-    "id": "crpg_knightly_spiked_battle_axe_h0",
-    "baseId": "crpg_knightly_spiked_battle_axe",
+    "id": "crpg_knightly_spiked_battle_axe_v1_h0",
+    "baseId": "crpg_knightly_spiked_battle_axe_v1",
     "name": "Knightly Spiked Battle Axe",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5070,
-    "weight": 0.91,
+    "price": 6710,
+    "weight": 1.45,
     "rank": 0,
-    "tier": 8.343891,
+    "tier": 9.767649,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87348,16 +87348,17 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 93,
-        "balance": 0.63,
-        "handling": 85,
+        "length": 89,
+        "balance": 0.62,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
-          "MeleeWeapon"
+          "MeleeWeapon",
+          "BonusAgainstShield"
         ],
-        "thrustDamage": 21,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
+        "thrustSpeed": 91,
         "swingDamage": 34,
         "swingDamageType": "Cut",
         "swingSpeed": 88
@@ -87365,15 +87366,15 @@
     ]
   },
   {
-    "id": "crpg_knightly_spiked_battle_axe_h1",
-    "baseId": "crpg_knightly_spiked_battle_axe",
+    "id": "crpg_knightly_spiked_battle_axe_v1_h1",
+    "baseId": "crpg_knightly_spiked_battle_axe_v1",
     "name": "Knightly Spiked Battle Axe +1",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5665,
-    "weight": 0.87,
+    "price": 5927,
+    "weight": 1.45,
     "rank": 1,
-    "tier": 8.884193,
+    "tier": 9.112844,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87385,32 +87386,33 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 93,
-        "balance": 0.69,
-        "handling": 87,
+        "length": 89,
+        "balance": 0.62,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
-          "MeleeWeapon"
+          "MeleeWeapon",
+          "BonusAgainstShield"
         ],
-        "thrustDamage": 22,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 34,
+        "thrustSpeed": 91,
+        "swingDamage": 35,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_knightly_spiked_battle_axe_h2",
-    "baseId": "crpg_knightly_spiked_battle_axe",
+    "id": "crpg_knightly_spiked_battle_axe_v1_h2",
+    "baseId": "crpg_knightly_spiked_battle_axe_v1",
     "name": "Knightly Spiked Battle Axe +2",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 5311,
-    "weight": 0.87,
+    "price": 5366,
+    "weight": 1.45,
     "rank": 2,
-    "tier": 8.566359,
+    "tier": 8.616418,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87422,32 +87424,33 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 93,
-        "balance": 0.69,
-        "handling": 87,
+        "length": 89,
+        "balance": 0.62,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
-          "MeleeWeapon"
+          "MeleeWeapon",
+          "BonusAgainstShield"
         ],
-        "thrustDamage": 23,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 35,
+        "thrustSpeed": 91,
+        "swingDamage": 36,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 88
       }
     ]
   },
   {
-    "id": "crpg_knightly_spiked_battle_axe_h3",
-    "baseId": "crpg_knightly_spiked_battle_axe",
+    "id": "crpg_knightly_spiked_battle_axe_v1_h3",
+    "baseId": "crpg_knightly_spiked_battle_axe_v1",
     "name": "Knightly Spiked Battle Axe +3",
     "culture": "Vlandia",
     "type": "OneHandedWeapon",
-    "price": 6186,
-    "weight": 0.87,
+    "price": 6043,
+    "weight": 1.45,
     "rank": 3,
-    "tier": 9.333597,
+    "tier": 9.212533,
     "requirement": 0,
     "flags": [
       "CanBePickedUpFromCorpse"
@@ -87459,19 +87462,20 @@
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
-        "length": 93,
-        "balance": 0.69,
-        "handling": 87,
+        "length": 89,
+        "balance": 0.62,
+        "handling": 89,
         "bodyArmor": 0,
         "flags": [
-          "MeleeWeapon"
+          "MeleeWeapon",
+          "BonusAgainstShield"
         ],
-        "thrustDamage": 24,
+        "thrustDamage": 20,
         "thrustDamageType": "Pierce",
-        "thrustSpeed": 97,
-        "swingDamage": 37,
+        "thrustSpeed": 91,
+        "swingDamage": 38,
         "swingDamageType": "Cut",
-        "swingSpeed": 90
+        "swingSpeed": 88
       }
     ]
   },
@@ -153831,8 +153835,8 @@
     ],
     "weapons": [
       {
-        "class": "OneHandedAxe",
-        "itemUsage": "onehanded_shield_axe",
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
@@ -153869,8 +153873,8 @@
     ],
     "weapons": [
       {
-        "class": "OneHandedAxe",
-        "itemUsage": "onehanded_shield_axe",
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
@@ -153907,8 +153911,8 @@
     ],
     "weapons": [
       {
-        "class": "OneHandedAxe",
-        "itemUsage": "onehanded_shield_axe",
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,
@@ -153945,8 +153949,8 @@
     ],
     "weapons": [
       {
-        "class": "OneHandedAxe",
-        "itemUsage": "onehanded_shield_axe",
+        "class": "Mace",
+        "itemUsage": "onehanded_block_shield_tipdraw_swing_thrust",
         "accuracy": 0,
         "missileSpeed": 0,
         "stackAmount": 0,

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9692,25 +9692,25 @@
       <Piece id="crpg_woodsman_two_handed_axe_handle_h3" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h0" name="{=pP0GacSW}Steel Round Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_h0" name="{=Diggles}Steel Round Axe" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h0" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h1" name="{=pP0GacSW}Steel Round Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_h1" name="{=Diggles}Steel Round Axe +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h1" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h2" name="{=pP0GacSW}Steel Round Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_h2" name="{=Diggles}Steel Round Axe +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h2" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h3" name="{=pP0GacSW}Steel Round Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_h3" name="{=Diggles}Steel Round Axe +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h3" Type="Handle" scale_factor="91" />
@@ -9836,28 +9836,28 @@
       <Piece id="crpg_steel_pillager_axe_handle_h3" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_h0" name="{=SDBvC0ON}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h0" name="{=Diggles}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_knightly_spiked_battle_axe_blade_h0" Type="Blade" scale_factor="135" />
-      <Piece id="crpg_knightly_spiked_battle_axe_handle_h0" Type="Handle" scale_factor="140" />
+      <Piece id="crpg_knightly_spiked_battle_axe_blade_h0" Type="Blade" scale_factor="125" />
+      <Piece id="crpg_knightly_spiked_battle_axe_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_h1" name="{=SDBvC0ON}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h1" name="{=Diggles}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_knightly_spiked_battle_axe_blade_h1" Type="Blade" scale_factor="135" />
-      <Piece id="crpg_knightly_spiked_battle_axe_handle_h1" Type="Handle" scale_factor="140" />
+      <Piece id="crpg_knightly_spiked_battle_axe_blade_h1" Type="Blade" scale_factor="125" />
+      <Piece id="crpg_knightly_spiked_battle_axe_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_h2" name="{=SDBvC0ON}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h2" name="{=Diggles}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_knightly_spiked_battle_axe_blade_h2" Type="Blade" scale_factor="135" />
-      <Piece id="crpg_knightly_spiked_battle_axe_handle_h2" Type="Handle" scale_factor="140" />
+      <Piece id="crpg_knightly_spiked_battle_axe_blade_h2" Type="Blade" scale_factor="125" />
+      <Piece id="crpg_knightly_spiked_battle_axe_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_h3" name="{=SDBvC0ON}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h3" name="{=Diggles}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
-      <Piece id="crpg_knightly_spiked_battle_axe_blade_h3" Type="Blade" scale_factor="135" />
-      <Piece id="crpg_knightly_spiked_battle_axe_handle_h3" Type="Handle" scale_factor="140" />
+      <Piece id="crpg_knightly_spiked_battle_axe_blade_h3" Type="Blade" scale_factor="125" />
+      <Piece id="crpg_knightly_spiked_battle_axe_handle_h3" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_long_franziska_axe_h0" name="{=KRhIG1cw}Long Franziska Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -13290,6 +13290,14 @@
       <AvailablePiece id="crpg_short_western_mace_handle_h1" />
       <AvailablePiece id="crpg_short_western_mace_handle_h2" />
       <AvailablePiece id="crpg_short_western_mace_handle_h3" />
+      <AvailablePiece id="crpg_steel_round_axe_blade_h0" />
+      <AvailablePiece id="crpg_steel_round_axe_handle_h0" />
+      <AvailablePiece id="crpg_steel_round_axe_blade_h1" />
+      <AvailablePiece id="crpg_steel_round_axe_handle_h1" />
+      <AvailablePiece id="crpg_steel_round_axe_blade_h2" />
+      <AvailablePiece id="crpg_steel_round_axe_handle_h2" />
+      <AvailablePiece id="crpg_steel_round_axe_blade_h3" />
+      <AvailablePiece id="crpg_steel_round_axe_handle_h3" />
     </AvailablePieces>
   </WeaponDescription>
   <WeaponDescription id="crpg_TwoHandedMace" weapon_class="TwoHandedMace" item_usage_features="twohanded:axe">


### PR DESCRIPTION
- Moved Steel Round Axe to mace group to enable thrust
- Added BvS tag to Steel Round & Knightly Spiked in mace group
- Lowered thrust dmg on Knightly Spiked Axe to get within budget