### PR TITLE
Throwing.update.nov2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -6441,8 +6441,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_pilum_blade_h0" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="pilum_blade" length="69.8" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.65" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="0.785" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6452,8 +6452,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_pilum_blade_h1" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="pilum_blade" length="69.8" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.66" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="0.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6463,8 +6463,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_pilum_blade_h2" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="pilum_blade" length="69.8" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.67" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="0.825" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6474,8 +6474,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_pilum_blade_h3" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="pilum_blade" length="69.8" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.71" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="0.855" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2880,22 +2880,22 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h0" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h0" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.65" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h1" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h1" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.65" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h2" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h2" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.65" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h3" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_jagged_throwing_spear_handle_h3" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.65" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
@@ -6529,8 +6529,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h0" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.71" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+      <Thrust damage_type="Pierce" damage_factor="0.89" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6540,8 +6540,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h1" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.74" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+      <Thrust damage_type="Pierce" damage_factor="0.93" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6551,8 +6551,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h2" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.78" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+      <Thrust damage_type="Pierce" damage_factor="0.962" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6562,8 +6562,8 @@
     </Flags>
   </CraftingPiece>
   <CraftingPiece id="crpg_jagged_throwing_spear_blade_h3" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
-    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="0.82" />
+    <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" >
+      <Thrust damage_type="Pierce" damage_factor="1.0" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2736,22 +2736,22 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fish_harpoon_handle_h0" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.8" excluded_item_usage_features="long" CraftingCost="90">
+  <CraftingPiece id="crpg_fish_harpoon_handle_h0" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.27" excluded_item_usage_features="long" CraftingCost="90">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fish_harpoon_handle_h1" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.8" excluded_item_usage_features="long" CraftingCost="90">
+  <CraftingPiece id="crpg_fish_harpoon_handle_h1" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.27" excluded_item_usage_features="long" CraftingCost="90">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fish_harpoon_handle_h2" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.8" excluded_item_usage_features="long" CraftingCost="90">
+  <CraftingPiece id="crpg_fish_harpoon_handle_h2" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.27" excluded_item_usage_features="long" CraftingCost="90">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fish_harpoon_handle_h3" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.8" excluded_item_usage_features="long" CraftingCost="90">
+  <CraftingPiece id="crpg_fish_harpoon_handle_h3" name="{=mcYSvJfA}Tree Branch" tier="2" piece_type="Handle" mesh="spear_handle_12" length="90" weight="0.27" excluded_item_usage_features="long" CraftingCost="90">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
@@ -5610,7 +5610,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fish_harpoon_blade_h0" name="{=Js1FKwrL}Javelin Head" tier="2" piece_type="Blade" mesh="spear_blade_16" length="23.328" weight="0.204" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="0.63" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -5618,7 +5618,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fish_harpoon_blade_h1" name="{=Js1FKwrL}Javelin Head" tier="2" piece_type="Blade" mesh="spear_blade_16" length="23.328" weight="0.204" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="0.67" />
+      <Thrust damage_type="Pierce" damage_factor="1.35" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -5626,7 +5626,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fish_harpoon_blade_h2" name="{=Js1FKwrL}Javelin Head" tier="2" piece_type="Blade" mesh="spear_blade_16" length="23.328" weight="0.204" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="0.72" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -5634,7 +5634,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fish_harpoon_blade_h3" name="{=Js1FKwrL}Javelin Head" tier="2" piece_type="Blade" mesh="spear_blade_16" length="23.328" weight="0.204" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="0.77" />
+      <Thrust damage_type="Pierce" damage_factor="1.45" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -27474,7 +27474,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_tri_shuriken_blade_h0" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.08">
     <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="11" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
+    <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="5" />
     </BladeData>
     <Flags>
@@ -27484,34 +27484,34 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tri_shuriken_blade_h1" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.07">
+  <CraftingPiece id="crpg_tri_shuriken_blade_h1" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.08">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="5.25" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tri_shuriken_blade_h2" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.08">
+    <BuildData piece_offset="0.0" />
+    <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
+      <Thrust damage_type="Pierce" damage_factor="5.25" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tri_shuriken_blade_h3" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.08">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
       <Thrust damage_type="Pierce" damage_factor="5.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tri_shuriken_blade_h2" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.05">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="6.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tri_shuriken_blade_h3" name="Trishaped Shuriken Blade" tier="2" piece_type="Blade" mesh="tri_shuriken" length="20" weight="0.06">
-    <BuildData piece_offset="0.0" />
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="6.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2984,25 +2984,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_javelin_handle_h0" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_simple_javelin_handle_h0" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.29" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_javelin_handle_h1" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_simple_javelin_handle_h1" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.29" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_javelin_handle_h2" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_simple_javelin_handle_h2" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.29" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_javelin_handle_h3" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_simple_javelin_handle_h3" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.29" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -6398,7 +6398,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_simple_javelin_blade_h0" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_1_1" holster_body_name="bo_throwing_spear_quiver_1_1" holster_mesh_length="68.9">
-      <Thrust damage_type="Pierce" damage_factor="0.833" />
+      <Thrust damage_type="Pierce" damage_factor="1.35" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6409,7 +6409,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_simple_javelin_blade_h1" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_1_1" holster_body_name="bo_throwing_spear_quiver_1_1" holster_mesh_length="68.9">
-      <Thrust damage_type="Pierce" damage_factor="0.89" />
+      <Thrust damage_type="Pierce" damage_factor="1.375" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6420,7 +6420,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_simple_javelin_blade_h2" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_1_1" holster_body_name="bo_throwing_spear_quiver_1_1" holster_mesh_length="68.9">
-      <Thrust damage_type="Pierce" damage_factor="0.96" />
+      <Thrust damage_type="Pierce" damage_factor="1.45" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -6431,7 +6431,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_simple_javelin_blade_h3" name="{=Y4tIQnS4}Short Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_15" length="22.862" weight="0.2136" excluded_item_usage_features="swing">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_1_1" holster_body_name="bo_throwing_spear_quiver_1_1" holster_mesh_length="68.9">
-      <Thrust damage_type="Pierce" damage_factor="1.1" />
+      <Thrust damage_type="Pierce" damage_factor="1.55" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -27523,7 +27523,7 @@
   <CraftingPiece id="crpg_square_shuriken_blade_h0" name="Squareshaped Shuriken Blade" tier="2" piece_type="Blade" mesh="square_shuriken" length="20" weight="0.03">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="5" />
+      <Thrust damage_type="Pierce" damage_factor="5.75" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27535,7 +27535,7 @@
   <CraftingPiece id="crpg_square_shuriken_blade_h1" name="Squareshaped Shuriken Blade" tier="2" piece_type="Blade" mesh="square_shuriken" length="20" weight="0.03">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="5.35" />
+      <Thrust damage_type="Pierce" damage_factor="6.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27547,7 +27547,7 @@
   <CraftingPiece id="crpg_square_shuriken_blade_h2" name="Squareshaped Shuriken Blade" tier="2" piece_type="Blade" mesh="square_shuriken" length="20" weight="0.03">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="5.75" />
+      <Thrust damage_type="Pierce" damage_factor="6.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -27559,7 +27559,7 @@
   <CraftingPiece id="crpg_square_shuriken_blade_h3" name="Squareshaped Shuriken Blade" tier="2" piece_type="Blade" mesh="square_shuriken" length="20" weight="0.03">
     <BuildData piece_offset="0.0" />
     <BladeData stack_amount="10" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="throwing_dagger_quiver_1" holster_mesh_length="35.8">
-      <Thrust damage_type="Pierce" damage_factor="6.2" />
+      <Thrust damage_type="Pierce" damage_factor="6.75" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2960,25 +2960,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_woodland_javelin_handle_h0" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_woodland_javelin_handle_h0" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.22" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_woodland_javelin_handle_h1" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_woodland_javelin_handle_h1" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.22" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_woodland_javelin_handle_h2" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_woodland_javelin_handle_h2" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.22" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_woodland_javelin_handle_h3" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.7" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
+  <CraftingPiece id="crpg_woodland_javelin_handle_h3" name="{=MCRppfbZ}Pine Javelin Shaft" tier="2" piece_type="Handle" mesh="spear_handle_2" length="85.1" weight="0.22" excluded_item_usage_features="long" CraftingCost="80" is_default="true">
     <BuildData piece_offset="0.0" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -6946,7 +6946,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_woodland_javelin_blade_h0" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="swing:TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.73" />
+      <Thrust damage_type="Pierce" damage_factor="1.17" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />
@@ -6957,7 +6957,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_woodland_javelin_blade_h1" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="swing:TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.76" />
+      <Thrust damage_type="Pierce" damage_factor="1.19" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />
@@ -6968,7 +6968,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_woodland_javelin_blade_h2" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="swing:TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.22" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />
@@ -6979,7 +6979,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_woodland_javelin_blade_h3" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="swing:TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.85" />
+      <Thrust damage_type="Pierce" damage_factor="1.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -2816,22 +2816,22 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lowland_javelin_handle_h0" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_lowland_javelin_handle_h0" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.1" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lowland_javelin_handle_h1" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_lowland_javelin_handle_h1" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.1" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lowland_javelin_handle_h2" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_lowland_javelin_handle_h2" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.1" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_lowland_javelin_handle_h3" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.866" excluded_item_usage_features="long" CraftingCost="80">
+  <CraftingPiece id="crpg_lowland_javelin_handle_h3" name="{=gIm5Lnh8}Mahogany Javelin Shaft" tier="3" piece_type="Handle" mesh="spear_handle_11" length="90" weight="0.1" excluded_item_usage_features="long" CraftingCost="80">
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
@@ -7622,7 +7622,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_lowland_javelin_blade_h0" name="{=Oxew9WCe}Imperial Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_1" length="48" weight="0.3384" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.58" />
+      <Thrust damage_type="Pierce" damage_factor="1.375" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7633,7 +7633,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_lowland_javelin_blade_h1" name="{=Oxew9WCe}Imperial Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_1" length="48" weight="0.3384" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.61" />
+      <Thrust damage_type="Pierce" damage_factor="1.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7644,7 +7644,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_lowland_javelin_blade_h2" name="{=Oxew9WCe}Imperial Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_1" length="48" weight="0.3384" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.66" />
+      <Thrust damage_type="Pierce" damage_factor="1.45" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
@@ -7655,7 +7655,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_lowland_javelin_blade_h3" name="{=Oxew9WCe}Imperial Simple Spear Head" tier="2" piece_type="Blade" mesh="spear_blade_1" length="48" weight="0.3384" excluded_item_usage_features="swing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="0.7" />
+      <Thrust damage_type="Pierce" damage_factor="1.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -11216,25 +11216,25 @@
       <Piece id="crpg_makeshift_sledgehammer_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tri_shuriken_v1_h0" name="{=Diggles}Throwing Star Triangle" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_tri_shuriken_v2_h0" name="{=Diggles}Throwing Star Triangle" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_tri_shuriken_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tri_shuriken_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tri_shuriken_v1_h1" name="{=Diggles}Throwing Star Triangle +1" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_tri_shuriken_v2_h1" name="{=Diggles}Throwing Star Triangle +1" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_tri_shuriken_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tri_shuriken_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tri_shuriken_v1_h2" name="{=Diggles}Throwing Star Triangle +2" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_tri_shuriken_v2_h2" name="{=Diggles}Throwing Star Triangle +2" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_tri_shuriken_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tri_shuriken_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tri_shuriken_v1_h3" name="{=Diggles}Throwing Star Triangle +3" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_tri_shuriken_v2_h3" name="{=Diggles}Throwing Star Triangle +3" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_tri_shuriken_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tri_shuriken_handle_h3" Type="Handle" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2144,7 +2144,7 @@
       <Piece id="crpg_horseman_javelin_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h0" name="{=ObGN145P}Woodland Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h0" name="{=Diggles}Woodland Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2152,7 +2152,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h1" name="{=ObGN145P}Woodland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h1" name="{=Diggles}Woodland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2160,7 +2160,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h2" name="{=ObGN145P}Woodland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h2" name="{=Diggles}Woodland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2168,7 +2168,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h3" name="{=ObGN145P}Woodland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h3" name="{=Diggles}Woodland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h3" Type="Guard" scale_factor="100" />
@@ -2208,7 +2208,7 @@
       <Piece id="crpg_harpoon_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h0" name="{=oV5AhcDl}Lowland Javelin" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h0" name="{=Diggles}Lowland Javelin" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2216,7 +2216,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h1" name="{=oV5AhcDl}Lowland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h1" name="{=DigglesLowland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2224,7 +2224,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h2" name="{=oV5AhcDl}Lowland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h2" name="{=Diggles}Lowland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2232,7 +2232,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h3" name="{=oV5AhcDl}Lowland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h3" name="{=Diggles}Lowland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2144,7 +2144,7 @@
       <Piece id="crpg_horseman_javelin_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h0" name="{=Diggles}Woodland Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h0" name="{=Diggles}Steel Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2152,7 +2152,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h1" name="{=Diggles}Woodland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h1" name="{=Diggles}Steel Skirmisher +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2160,7 +2160,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h2" name="{=Diggles}Woodland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h2" name="{=Diggles}Steel Skirmisher +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2168,7 +2168,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h3" name="{=Diggles}Woodland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v2_h3" name="{=Diggles}Steel Skirmisher +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2208,7 +2208,7 @@
       <Piece id="crpg_harpoon_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h0" name="{=Diggles}Militia Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v3_h0" name="{=Diggles}Militia Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2216,7 +2216,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h1" name="{=DigglesMilitia Skirmisher Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v3_h1" name="{=DigglesMilitia Skirmisher Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2224,7 +2224,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h2" name="{=Diggles}Militia Skirmisher Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v3_h2" name="{=Diggles}Militia Skirmisher Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2232,7 +2232,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h3" name="{=Diggles}Militia Skirmisher Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v3_h3" name="{=Diggles}Militia Skirmisher Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8776,7 +8776,7 @@
       <Piece id="crpg_wide_leaf_spear_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pilum_v4_h0" name="{=Diggles}Pilum Steel Throwing Spear" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_pilum_v5_h0" name="{=Diggles}Pilum Steel Throwing Spear" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pilum_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pilum_guard_h0" Type="Guard" scale_factor="100" />
@@ -8784,7 +8784,7 @@
       <Piece id="crpg_pilum_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pilum_v4_h1" name="{=Diggles}Pilum Steel Throwing Spear +1" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_pilum_v5_h1" name="{=Diggles}Pilum Steel Throwing Spear +1" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pilum_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pilum_guard_h1" Type="Guard" scale_factor="100" />
@@ -8792,7 +8792,7 @@
       <Piece id="crpg_pilum_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pilum_v4_h2" name="{=Diggles}Pilum Steel Throwing Spear +2" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_pilum_v5_h2" name="{=Diggles}Pilum Steel Throwing Spear +2" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pilum_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pilum_guard_h2" Type="Guard" scale_factor="100" />
@@ -8800,7 +8800,7 @@
       <Piece id="crpg_pilum_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_pilum_v4_h3" name="{=Diggles}Pilum Steel Throwing Spear +3" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_pilum_v5_h3" name="{=Diggles}Pilum Steel Throwing Spear +3" crafting_template="crpg_Javelin" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_pilum_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_pilum_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9024,32 +9024,32 @@
       <Piece id="crpg_triangular_headed_spear_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_throwing_spear_v2_h0" name="{=EgrNdBct}Jagged Throwing Spear" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_throwing_spear_v3_h0" name="{=Diggles}Skirmisher Throwing Spear" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_jagged_throwing_spear_blade_h0" Type="Blade" scale_factor="350" />
+      <Piece id="crpg_jagged_throwing_spear_blade_h0" Type="Blade" scale_factor="250" />
       <Piece id="crpg_jagged_throwing_spear_guard_h0" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_jagged_throwing_spear_handle_h0" Type="Handle" scale_factor="175" />
+      <Piece id="crpg_jagged_throwing_spear_handle_h0" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_throwing_spear_v2_h1" name="{=EgrNdBct}Jagged Throwing Spear +1" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_throwing_spear_v3_h1" name="{=Diggles}Skirmisher Throwing Spear +1" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_jagged_throwing_spear_blade_h1" Type="Blade" scale_factor="350" />
+      <Piece id="crpg_jagged_throwing_spear_blade_h1" Type="Blade" scale_factor="250" />
       <Piece id="crpg_jagged_throwing_spear_guard_h1" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_jagged_throwing_spear_handle_h1" Type="Handle" scale_factor="175" />
+      <Piece id="crpg_jagged_throwing_spear_handle_h1" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_throwing_spear_v2_h2" name="{=EgrNdBct}Jagged Throwing Spear +2" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_throwing_spear_v3_h2" name="{=Diggles}Skirmisher Throwing Spear +2" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_jagged_throwing_spear_blade_h2" Type="Blade" scale_factor="350" />
+      <Piece id="crpg_jagged_throwing_spear_blade_h2" Type="Blade" scale_factor="250" />
       <Piece id="crpg_jagged_throwing_spear_guard_h2" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_jagged_throwing_spear_handle_h2" Type="Handle" scale_factor="175" />
+      <Piece id="crpg_jagged_throwing_spear_handle_h2" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_throwing_spear_v2_h3" name="{=EgrNdBct}Jagged Throwing Spear +3" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_throwing_spear_v3_h3" name="{=Diggles}Skirmisher Throwing Spear +3" crafting_template="crpg_Javelin" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_jagged_throwing_spear_blade_h3" Type="Blade" scale_factor="350" />
+      <Piece id="crpg_jagged_throwing_spear_blade_h3" Type="Blade" scale_factor="250" />
       <Piece id="crpg_jagged_throwing_spear_guard_h3" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_jagged_throwing_spear_handle_h3" Type="Handle" scale_factor="175" />
+      <Piece id="crpg_jagged_throwing_spear_handle_h3" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_short_leaf_shaped_spear_v1_h0" name="{=xTyib5ms}Short Leaf Shaped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2208,7 +2208,7 @@
       <Piece id="crpg_harpoon_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h0" name="{=Diggles}Lowland Javelin" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h0" name="{=Diggles}Militia Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2216,7 +2216,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h1" name="{=DigglesLowland Javelin +1" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h1" name="{=DigglesMilitia Skirmisher Javelin +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2224,7 +2224,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h2" name="{=Diggles}Lowland Javelin +2" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h2" name="{=Diggles}Militia Skirmisher Javelin +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2232,7 +2232,7 @@
       <Piece id="crpg_lowland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_lowland_javelin_v2_h3" name="{=Diggles}Lowland Javelin +3" crafting_template="crpg_Javelin" culture="Culture.vlandia" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_lowland_javelin_v2_h3" name="{=Diggles}Militia Skirmisher Javelin +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_lowland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_lowland_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2304,7 +2304,7 @@
       <Piece id="crpg_fish_harpoon_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_javelin_v2_h0" name="{=0NLJnGfF}Simple Javelin" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_simple_javelin_v3_h0" name="{=Diggles}Simple Javelin" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_simple_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2312,7 +2312,7 @@
       <Piece id="crpg_simple_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_javelin_v2_h1" name="{=0NLJnGfF}Simple Javelin +1" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_simple_javelin_v3_h1" name="{=Diggles}Simple Javelin +1" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_simple_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2320,7 +2320,7 @@
       <Piece id="crpg_simple_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_javelin_v2_h2" name="{=0NLJnGfF}Simple Javelin +2" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_simple_javelin_v3_h2" name="{=Diggles}Simple Javelin +2" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_simple_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2328,7 +2328,7 @@
       <Piece id="crpg_simple_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_javelin_v2_h3" name="{=0NLJnGfF}Simple Javelin +3" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_simple_javelin_v3_h3" name="{=Diggles}Simple Javelin +3" crafting_template="crpg_Javelin" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_simple_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_simple_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -2144,7 +2144,7 @@
       <Piece id="crpg_horseman_javelin_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h0" name="{=Diggles}Steel Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v3_h0" name="{=Diggles}Steel Skirmisher Javelin" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h0" Type="Guard" scale_factor="100" />
@@ -2152,7 +2152,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h1" name="{=Diggles}Steel Skirmisher +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v3_h1" name="{=Diggles}Steel Skirmisher +1" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h1" Type="Guard" scale_factor="100" />
@@ -2160,7 +2160,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h2" name="{=Diggles}Steel Skirmisher +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v3_h2" name="{=Diggles}Steel Skirmisher +2" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h2" Type="Guard" scale_factor="100" />
@@ -2168,7 +2168,7 @@
       <Piece id="crpg_woodland_javelin_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_woodland_javelin_v2_h3" name="{=Diggles}Steel Skirmisher +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
+  <CraftedItem id="crpg_woodland_javelin_v3_h3" name="{=Diggles}Steel Skirmisher +3" crafting_template="crpg_Javelin" culture="Culture.battania" modifier_group="spear_dart_throwing">
     <Pieces>
       <Piece id="crpg_woodland_javelin_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_woodland_javelin_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -11264,25 +11264,25 @@
       <Piece id="crpg_throwing_spike_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_square_shuriken_v1_h0" name="{=Diggles}Throwing Star Diamond" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_square_shuriken_v2_h0" name="{=Diggles}Throwing Star Diamond" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_square_shuriken_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_square_shuriken_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_square_shuriken_v1_h1" name="{=Diggles}Throwing Star Diamond +1" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_square_shuriken_v2_h1" name="{=Diggles}Throwing Star Diamond +1" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_square_shuriken_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_square_shuriken_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_square_shuriken_v1_h2" name="{=Diggles}Throwing Star Diamond +2" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_square_shuriken_v2_h2" name="{=Diggles}Throwing Star Diamond +2" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_square_shuriken_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_square_shuriken_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_square_shuriken_v1_h3" name="{=Diggles}Throwing Star Diamond +3" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
+  <CraftedItem id="crpg_square_shuriken_v2_h3" name="{=Diggles}Throwing Star Diamond +3" crafting_template="crpg_ThrowingKnife" culture="Culture.aserai" modifier_group="knife_throwing">
     <Pieces>
       <Piece id="crpg_square_shuriken_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_square_shuriken_handle_h3" Type="Handle" scale_factor="100" />


### PR DESCRIPTION
Throwing.Update.NOV2023 (if accepted)
Mostly a pass on weight of some throwing items to make lighter versions for skirmishers

Lowland Javelin = Skirmsher Javelin:  -weight, +dmg
Woodland = Steel Skirmisher Javelin: -weight
Jagged Spear = Skirmsher Throwing Spear: -weight, -dmg
---------------------------------------------------------
Fish Harpoon: -weight, +2dmg
Simple Javelin: -weight
Throwing Star Diamond: +2 dmg
Throwing Star Triangle: consistent weight and stack amount
Pilum: switched back to single stack version to avoid unintended ammo bugs picking up other javelins 