### PR TITLE
YeldurPaviseV2

### DIFF
--- a/items/shields.xml
+++ b/items/shields.xml
@@ -1216,33 +1216,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_v1_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h0" name="{=}Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="3.481" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="25" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="320" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="35" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="200" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_v1_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h1" name="{=}Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="3.481" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="26" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="346" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="37" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="216" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_v1_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h2" name="{=}Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="3.481" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="27" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="372" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="38" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="232" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_pavise_v1_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="5.5696" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_pavise_v1_h3" name="{=}Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="pavise" using_tableau="true" weight="3.481" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="28" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="397" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="39" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="248" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -1440,33 +1440,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_v1_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h0" name="{=}Reinforced Pavise" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="5.2215" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="5" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="570" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="25" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="300" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_v1_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h1" name="{=}Reinforced Pavise +1" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="5.2215" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="616" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="26" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="324" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_v1_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h2" name="{=}Reinforced Pavise +2" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="5.2215" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="662" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="27" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="348" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_reinforcedpavise_v1_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="9.92085" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
+  <Item id="crpg_reinforcedpavise_v1_h3" name="{=}Reinforced Pavise +3" body_name="bo_cap_pavise_shield" shield_body_name="bo_pavise_shield" recalculate_body="false" mesh="reinforcedpavise" using_tableau="true" weight="5.2215" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,-0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="6" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="707" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="28" thrust_speed="80" thrust_damage_type="Blunt" speed_rating="80" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="118" center_of_mass="0.0,0.1,0.1" hit_points="372" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>


### PR DESCRIPTION
After watching and seeing for a bit, Pavise's seem under-utilised because of their weight, to that effect I've opted to make the following changes:

- Reduced the weight significantly for the Reinforced Pavise, maintaining its status as a "heavy-weight" shield but lessening the extent with the aim of increasing utilisation.
- Drastically decreased the weight of the Regular Pavise, positioning it as a 0 shield skill option for full body coverage, with a lower weight and cost.
- Increased body armor on the Regular Pavise, enhancing its use as effective back protection.