### PR TITLE
1h axe.heirloom update.nov2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11168,7 +11168,7 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tabar_axe_blade_h1" name="{=VfzFTGd8}Small Round Bit Head" tier="2" piece_type="Blade" mesh="axe_craft_35_head" distance_to_next_piece="5" distance_to_previous_piece="3.6" weight="0.64">
+  <CraftingPiece id="crpg_tabar_axe_blade_h1" name="{=VfzFTGd8}Small Round Bit Head" tier="2" piece_type="Blade" mesh="axe_craft_35_head" distance_to_next_piece="5" distance_to_previous_piece="3.6" weight="0.7">
     <BuildData piece_offset="-7.2" />
     <BladeData stack_amount="2" blade_length="10.364" blade_width="20.3" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.5" />
@@ -11183,7 +11183,7 @@
   <CraftingPiece id="crpg_tabar_axe_blade_h2" name="{=VfzFTGd8}Small Round Bit Head" tier="2" piece_type="Blade" mesh="axe_craft_35_head" distance_to_next_piece="5" distance_to_previous_piece="3.6" weight="0.62">
     <BuildData piece_offset="-7.2" />
     <BladeData stack_amount="2" blade_length="10.364" blade_width="20.3" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.6" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11192,10 +11192,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tabar_axe_blade_h3" name="{=VfzFTGd8}Small Round Bit Head" tier="2" piece_type="Blade" mesh="axe_craft_35_head" distance_to_next_piece="5" distance_to_previous_piece="3.6" weight="0.6">
+  <CraftingPiece id="crpg_tabar_axe_blade_h3" name="{=VfzFTGd8}Small Round Bit Head" tier="2" piece_type="Blade" mesh="axe_craft_35_head" distance_to_next_piece="5" distance_to_previous_piece="3.6" weight="0.62">
     <BuildData piece_offset="-7.2" />
     <BladeData stack_amount="2" blade_length="10.364" blade_width="20.3" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10713,7 +10713,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hatchet_blade_h1" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.61" is_default="true">
+  <CraftingPiece id="crpg_hatchet_blade_h1" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.632" is_default="true">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.664" blade_width="17.21" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.1" />
@@ -10726,10 +10726,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hatchet_blade_h2" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.58" is_default="true">
+  <CraftingPiece id="crpg_hatchet_blade_h2" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.632" is_default="true">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.664" blade_width="17.21" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="2.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10739,10 +10739,10 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_hatchet_blade_h3" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.55" is_default="true">
+  <CraftingPiece id="crpg_hatchet_blade_h3" name="{=KhHXgQJb}Common Wrought Iron Axe Head" tier="1" piece_type="Blade" mesh="axe_craft_32_head" distance_to_next_piece="4.3" distance_to_previous_piece="2.7" weight="0.632" is_default="true">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.664" blade_width="17.21" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.4" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10609,20 +10609,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shield_reaver_axe_blade_h1" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.72">
-    <BuildData piece_offset="-2.6" />
-    <BladeData stack_amount="2" blade_length="11.4" blade_width="17.4" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-      <Material id="Iron4" count="4" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_shield_reaver_axe_blade_h2" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.7">
+  <CraftingPiece id="crpg_shield_reaver_axe_blade_h1" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.77">
     <BuildData piece_offset="-2.6" />
     <BladeData stack_amount="2" blade_length="11.4" blade_width="17.4" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.8" />
@@ -10635,10 +10622,23 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_shield_reaver_axe_blade_h3" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.7">
+  <CraftingPiece id="crpg_shield_reaver_axe_blade_h2" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.77">
     <BuildData piece_offset="-2.6" />
     <BladeData stack_amount="2" blade_length="11.4" blade_width="17.4" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="4.0" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+      <Material id="Iron4" count="4" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_shield_reaver_axe_blade_h3" name="{=4Ilo91CO}Western Battle Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_18_head" distance_to_next_piece="3.4" distance_to_previous_piece="1.3" weight="0.77">
+    <BuildData piece_offset="-2.6" />
+    <BladeData stack_amount="2" blade_length="11.4" blade_width="17.4" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="4.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10969,7 +10969,7 @@
   <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h1" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -10980,11 +10980,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h2" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.30">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10994,11 +10994,11 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.35">
+  <CraftingPiece id="crpg_knightly_spiked_battle_axe_blade_h3" name="{=m6CVEgTU}Spiked Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_25_head" distance_to_next_piece="13.9" distance_to_previous_piece="4" weight="0.30">
     <BuildData piece_offset="-8" />
     <BladeData stack_amount="0" blade_length="25.328" blade_width="31.023" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11021,7 +11021,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_pillager_axe_blade_h1" name="{=1NSafswc}Gallogaich Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_11_head" distance_to_next_piece="2.124" distance_to_previous_piece="3.279" weight="0.69">
+  <CraftingPiece id="crpg_steel_pillager_axe_blade_h1" name="{=1NSafswc}Gallogaich Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_11_head" distance_to_next_piece="2.124" distance_to_previous_piece="3.279" weight="0.70">
     <BuildData piece_offset="-6.558" />
     <BladeData stack_amount="2" blade_length="9.79" blade_width="28.335" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -11037,7 +11037,7 @@
   <CraftingPiece id="crpg_steel_pillager_axe_blade_h2" name="{=1NSafswc}Gallogaich Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_11_head" distance_to_next_piece="2.124" distance_to_previous_piece="3.279" weight="0.66">
     <BuildData piece_offset="-6.558" />
     <BladeData stack_amount="2" blade_length="9.79" blade_width="28.335" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11050,7 +11050,7 @@
   <CraftingPiece id="crpg_steel_pillager_axe_blade_h3" name="{=1NSafswc}Gallogaich Axe Head" tier="4" piece_type="Blade" mesh="axe_craft_11_head" distance_to_next_piece="2.124" distance_to_previous_piece="3.279" weight="0.66">
     <BuildData piece_offset="-6.558" />
     <BladeData stack_amount="2" blade_length="9.79" blade_width="28.335" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11217,20 +11217,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_raider_battle_axe_blade_h1" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.5">
-    <BuildData piece_offset="-6.8" />
-    <BladeData stack_amount="2" blade_length="15.764" blade_width="16" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.4" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="3" />
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_raider_battle_axe_blade_h2" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.5">
+  <CraftingPiece id="crpg_raider_battle_axe_blade_h1" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.55">
     <BuildData piece_offset="-6.8" />
     <BladeData stack_amount="2" blade_length="15.764" blade_width="16" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -11243,10 +11230,23 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_raider_battle_axe_blade_h3" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.5">
+  <CraftingPiece id="crpg_raider_battle_axe_blade_h2" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.55">
     <BuildData piece_offset="-6.8" />
     <BladeData stack_amount="2" blade_length="15.764" blade_width="16" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="3" />
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_raider_battle_axe_blade_h3" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.55">
+    <BuildData piece_offset="-6.8" />
+    <BladeData stack_amount="2" blade_length="15.764" blade_width="16" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10812,7 +10812,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_forester_axe_blade_h1" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.78">
+  <CraftingPiece id="crpg_forester_axe_blade_h1" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.83">
     <BuildData piece_offset="-4" />
     <BladeData stack_amount="2" blade_length="9.382" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.7" />
@@ -10824,10 +10824,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_forester_axe_blade_h2" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.76">
+  <CraftingPiece id="crpg_forester_axe_blade_h2" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.83">
     <BuildData piece_offset="-4" />
     <BladeData stack_amount="2" blade_length="9.382" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10836,10 +10836,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_forester_axe_blade_h3" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.74">
+  <CraftingPiece id="crpg_forester_axe_blade_h3" name="{=NS83CCvb}Common Iron Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_21_head" distance_to_next_piece="2.6" distance_to_previous_piece="2" weight="0.83">
     <BuildData piece_offset="-4" />
     <BladeData stack_amount="2" blade_length="9.382" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10451,22 +10451,7 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_round_axe_blade_h1" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.57">
-    <BuildData piece_offset="-4.208" />
-    <BladeData stack_amount="2" blade_length="11.538" blade_width="26.876" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-      <Flag name="BonusAgainstShield" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-      <Material id="Iron5" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_steel_round_axe_blade_h2" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.55">
+  <CraftingPiece id="crpg_steel_round_axe_blade_h1" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.625">
     <BuildData piece_offset="-4.208" />
     <BladeData stack_amount="2" blade_length="11.538" blade_width="26.876" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Pierce" damage_factor="1.8" />
@@ -10481,11 +10466,26 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_round_axe_blade_h3" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.55">
+  <CraftingPiece id="crpg_steel_round_axe_blade_h2" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.625">
     <BuildData piece_offset="-4.208" />
     <BladeData stack_amount="2" blade_length="11.538" blade_width="26.876" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="1.9" />
       <Swing damage_type="Cut" damage_factor="3.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+      <Flag name="BonusAgainstShield" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+      <Material id="Iron5" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_steel_round_axe_blade_h3" name="{=8S6ZYPFD}Round Bitted Fine Steel Hatchet Head" tier="5" piece_type="Blade" mesh="axe_craft_9_head" distance_to_next_piece="4.642" distance_to_previous_piece="2.104" weight="0.625">
+    <BuildData piece_offset="-4.208" />
+    <BladeData stack_amount="2" blade_length="11.538" blade_width="26.876" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10560,10 +10560,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_norse_huscarl_axe_blade_h1" name="{=VccYBtB0}Northern Hatchet Head" tier="2" piece_type="Blade" mesh="axe_craft_2_head" distance_to_next_piece="3.986" distance_to_previous_piece="2.314" weight="0.5">
+  <CraftingPiece id="crpg_norse_huscarl_axe_blade_h1" name="{=VccYBtB0}Northern Hatchet Head" tier="2" piece_type="Blade" mesh="axe_craft_2_head" distance_to_next_piece="3.986" distance_to_previous_piece="2.314" weight="0.54">
     <BuildData piece_offset="-5.628" />
     <BladeData stack_amount="2" blade_length="12.2" blade_width="24.433" physics_material="metal_weapon" body_name="bo_axe_longer_a">
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10861,7 +10861,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_footman_axe_blade_h1" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.65">
+  <CraftingPiece id="crpg_steel_footman_axe_blade_h1" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.675">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.5" />
@@ -10874,10 +10874,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_footman_axe_blade_h2" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.63">
+  <CraftingPiece id="crpg_steel_footman_axe_blade_h2" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.675">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10887,10 +10887,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_steel_footman_axe_blade_h3" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.63">
+  <CraftingPiece id="crpg_steel_footman_axe_blade_h3" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.675">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11072,19 +11072,7 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h1" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.25">
-    <BuildData piece_offset="-7" />
-    <BladeData stack_amount="2" blade_length="17.6" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.8" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="4" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h2" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.25">
+  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h1" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.28">
     <BuildData piece_offset="-7" />
     <BladeData stack_amount="2" blade_length="17.6" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.9" />
@@ -11096,10 +11084,22 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h3" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.25">
+  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h2" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.28">
     <BuildData piece_offset="-7" />
     <BladeData stack_amount="2" blade_length="17.6" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="4" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_long_tzikourion_axe_blade_h3" name="{=Tui9qvOZ}Tzikurion Head" tier="3" piece_type="Blade" mesh="axe_craft_26_head" distance_to_next_piece="9" distance_to_previous_piece="3.5" weight="0.28">
+    <BuildData piece_offset="-7" />
+    <BladeData stack_amount="2" blade_length="17.6" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10913,20 +10913,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_hand_axe_blade_h1" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.62">
-    <BuildData piece_offset="-5.4" />
-    <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="4" />
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_iron_hand_axe_blade_h2" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.6">
+  <CraftingPiece id="crpg_iron_hand_axe_blade_h1" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.675">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.0" />
@@ -10939,7 +10926,20 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_hand_axe_blade_h3" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.6">
+  <CraftingPiece id="crpg_iron_hand_axe_blade_h2" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.625">
+    <BuildData piece_offset="-5.4" />
+    <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="3.0" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="4" />
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_iron_hand_axe_blade_h3" name="{=X7OrRebK}Narrow Sparth Blade" tier="2" piece_type="Blade" mesh="axe_craft_20_head" distance_to_next_piece="3.6" distance_to_previous_piece="2.7" weight="0.625">
     <BuildData piece_offset="-5.4" />
     <BladeData stack_amount="2" blade_length="9.683" blade_width="18.004" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11120,19 +11120,7 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_crescent_axe_blade_h1" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.52">
-    <BuildData piece_offset="-6.2" />
-    <BladeData stack_amount="2" blade_length="16.562" blade_width="13.626" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="4" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_desert_crescent_axe_blade_h2" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.5">
+  <CraftingPiece id="crpg_desert_crescent_axe_blade_h1" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.575">
     <BuildData piece_offset="-6.2" />
     <BladeData stack_amount="2" blade_length="16.562" blade_width="13.626" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.8" />
@@ -11144,10 +11132,22 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_crescent_axe_blade_h3" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.5">
+  <CraftingPiece id="crpg_desert_crescent_axe_blade_h2" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.575">
     <BuildData piece_offset="-6.2" />
     <BladeData stack_amount="2" blade_length="16.562" blade_width="13.626" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="4" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_desert_crescent_axe_blade_h3" name="{=g2r3QKOB}Southern Small Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_27_head" distance_to_next_piece="8.3" distance_to_previous_piece="3.1" weight="0.575">
+    <BuildData piece_offset="-6.2" />
+    <BladeData stack_amount="2" blade_length="16.562" blade_width="13.626" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10300,19 +10300,7 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tzikourion_axe_blade_h1" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.58">
-    <BuildData piece_offset="-9.6" />
-    <BladeData stack_amount="2" blade_length="9.105" blade_width="23.082" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="4" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tzikourion_axe_blade_h2" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.56">
+  <CraftingPiece id="crpg_tzikourion_axe_blade_h1" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.635">
     <BuildData piece_offset="-9.6" />
     <BladeData stack_amount="2" blade_length="9.105" blade_width="23.082" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.7" />
@@ -10324,7 +10312,19 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tzikourion_axe_blade_h3" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.56">
+  <CraftingPiece id="crpg_tzikourion_axe_blade_h2" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.58">
+    <BuildData piece_offset="-9.6" />
+    <BladeData stack_amount="2" blade_length="9.105" blade_width="23.082" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="2.7" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="4" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tzikourion_axe_blade_h3" name="{=iFhr5nGq}Imperial Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_29_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.58">
     <BuildData piece_offset="-9.6" />
     <BladeData stack_amount="2" blade_length="9.105" blade_width="23.082" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.9" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10397,7 +10397,7 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_chopper_axe_blade_h1" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.8">
+  <CraftingPiece id="crpg_wood_chopper_axe_blade_h1" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.85">
     <BuildData piece_offset="-3.92" />
     <BladeData stack_amount="2" blade_length="22.332" blade_width="23.205" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.3" />
@@ -10410,10 +10410,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_chopper_axe_blade_h2" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.78">
+  <CraftingPiece id="crpg_wood_chopper_axe_blade_h2" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.85">
     <BuildData piece_offset="-3.92" />
     <BladeData stack_amount="2" blade_length="22.332" blade_width="23.205" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10423,10 +10423,10 @@
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_chopper_axe_blade_h3" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.78">
+  <CraftingPiece id="crpg_wood_chopper_axe_blade_h3" name="{=WkTkxQfw}Rectangular Bit Blade" tier="5" piece_type="Blade" mesh="axe_craft_8_head" distance_to_next_piece="11.156" distance_to_previous_piece="1.96" weight="0.85">
     <BuildData piece_offset="-3.92" />
     <BladeData stack_amount="2" blade_length="22.332" blade_width="23.205" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10100,7 +10100,7 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_splitter_axe_blade_h1" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.62">
+  <CraftingPiece id="crpg_wood_splitter_axe_blade_h1" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.655">
     <BuildData piece_offset="-6" />
     <BladeData stack_amount="2" blade_length="12.564" blade_width="15.1" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -10112,10 +10112,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_splitter_axe_blade_h2" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.6">
+  <CraftingPiece id="crpg_wood_splitter_axe_blade_h2" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.655">
     <BuildData piece_offset="-6" />
     <BladeData stack_amount="2" blade_length="12.564" blade_width="15.1" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10124,10 +10124,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_wood_splitter_axe_blade_h3" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.6">
+  <CraftingPiece id="crpg_wood_splitter_axe_blade_h3" name="{=SR7a3qlO}Round Bit Battle Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_33_head" distance_to_next_piece="7.2" distance_to_previous_piece="3" weight="0.655">
     <BuildData piece_offset="-6" />
     <BladeData stack_amount="2" blade_length="12.564" blade_width="15.1" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="4.0" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10200,19 +10200,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_franziska_axe_blade_h1" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.44">
-    <BuildData piece_offset="-3" />
-    <BladeData stack_amount="2" blade_length="11.622" blade_width="23.945" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_long_franziska_axe_blade_h2" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.44">
+  <CraftingPiece id="crpg_long_franziska_axe_blade_h1" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.495">
     <BuildData piece_offset="-3" />
     <BladeData stack_amount="2" blade_length="11.622" blade_width="23.945" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.7" />
@@ -10224,10 +10212,22 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_franziska_axe_blade_h3" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.44">
+  <CraftingPiece id="crpg_long_franziska_axe_blade_h2" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.495">
     <BuildData piece_offset="-3" />
     <BladeData stack_amount="2" blade_length="11.622" blade_width="23.945" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.8" />
+    </BladeData>
+    <Flags>
+      <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_long_franziska_axe_blade_h3" name="{=cK6D7cyn}Large Franziska Head" tier="3" piece_type="Blade" mesh="axe_craft_12_head" distance_to_next_piece="5" distance_to_previous_piece="1.5" weight="0.495">
+    <BuildData piece_offset="-3" />
+    <BladeData stack_amount="2" blade_length="11.622" blade_width="23.945" physics_material="metal_weapon" body_name="bo_axe_longer_b">
+      <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10149,7 +10149,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_battle_axe_blade_h1" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.73">
+  <CraftingPiece id="crpg_desert_battle_axe_blade_h1" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.75">
     <BuildData piece_offset="-20.4" />
     <BladeData stack_amount="2" blade_length="22.539" blade_width="16.706" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.6" />
@@ -10162,10 +10162,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_battle_axe_blade_h2" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.7">
+  <CraftingPiece id="crpg_desert_battle_axe_blade_h2" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.75">
     <BuildData piece_offset="-20.4" />
     <BladeData stack_amount="2" blade_length="22.539" blade_width="16.706" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10175,10 +10175,10 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_battle_axe_blade_h3" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.69">
+  <CraftingPiece id="crpg_desert_battle_axe_blade_h3" name="{=ZxZ7AJ1r}Southern Battle Axe Blade" tier="4" piece_type="Blade" mesh="axe_craft_19_head" distance_to_next_piece="11.1" distance_to_previous_piece="10.2" weight="0.75">
     <BuildData piece_offset="-20.4" />
     <BladeData stack_amount="2" blade_length="22.539" blade_width="16.706" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10776,10 +10776,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_ascia_axe_blade_h2" name="{=IZw8FnwW}Large Ascia Head" tier="2" piece_type="Blade" mesh="axe_craft_30_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.5">
+  <CraftingPiece id="crpg_desert_ascia_axe_blade_h2" name="{=IZw8FnwW}Large Ascia Head" tier="2" piece_type="Blade" mesh="axe_craft_30_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.478">
     <BuildData piece_offset="-4.6" />
     <BladeData stack_amount="2" blade_length="8.442" blade_width="19.527" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.0" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10788,10 +10788,10 @@
       <Material id="Iron2" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_desert_ascia_axe_blade_h3" name="{=IZw8FnwW}Large Ascia Head" tier="2" piece_type="Blade" mesh="axe_craft_30_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.5">
+  <CraftingPiece id="crpg_desert_ascia_axe_blade_h3" name="{=IZw8FnwW}Large Ascia Head" tier="2" piece_type="Blade" mesh="axe_craft_30_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.3" weight="0.478">
     <BuildData piece_offset="-4.6" />
     <BladeData stack_amount="2" blade_length="8.442" blade_width="19.527" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10522,10 +10522,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_saxon_bearded_axe_blade_h2" name="{=kNhcSC6i}Northern Bearded Head" tier="4" piece_type="Blade" mesh="axe_craft_23_head" distance_to_next_piece="3" distance_to_previous_piece="5.3" weight="0.74">
+  <CraftingPiece id="crpg_saxon_bearded_axe_blade_h2" name="{=kNhcSC6i}Northern Bearded Head" tier="4" piece_type="Blade" mesh="axe_craft_23_head" distance_to_next_piece="3" distance_to_previous_piece="5.3" weight="0.765">
     <BuildData piece_offset="-10.6" />
     <BladeData stack_amount="2" blade_length="24.97" blade_width="20.661" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.8" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10535,10 +10535,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_saxon_bearded_axe_blade_h3" name="{=kNhcSC6i}Northern Bearded Head" tier="4" piece_type="Blade" mesh="axe_craft_23_head" distance_to_next_piece="3" distance_to_previous_piece="5.3" weight="0.72">
+  <CraftingPiece id="crpg_saxon_bearded_axe_blade_h3" name="{=kNhcSC6i}Northern Bearded Head" tier="4" piece_type="Blade" mesh="axe_craft_23_head" distance_to_next_piece="3" distance_to_previous_piece="5.3" weight="0.765">
     <BuildData piece_offset="-10.6" />
     <BladeData stack_amount="2" blade_length="24.97" blade_width="20.661" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.9" />
+      <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11233,7 +11233,7 @@
   <CraftingPiece id="crpg_raider_battle_axe_blade_h2" name="{=cEU66ABf}Northern Battle Axe Blade" tier="3" piece_type="Blade" mesh="axe_craft_36_head" distance_to_next_piece="10.4" distance_to_previous_piece="3.4" weight="0.55">
     <BuildData piece_offset="-6.8" />
     <BladeData stack_amount="2" blade_length="15.764" blade_width="16" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.6" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10348,7 +10348,7 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_boarding_axe_blade_h1" name="{=fOrRdtNK}Small Spurred Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_24_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.1" weight="0.75">
+  <CraftingPiece id="crpg_boarding_axe_blade_h1" name="{=fOrRdtNK}Small Spurred Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_24_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.1" weight="0.79">
     <BuildData piece_offset="-4.2" />
     <BladeData stack_amount="2" blade_length="9.46" blade_width="21.987" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -10363,7 +10363,7 @@
   <CraftingPiece id="crpg_boarding_axe_blade_h2" name="{=fOrRdtNK}Small Spurred Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_24_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.1" weight="0.72">
     <BuildData piece_offset="-4.2" />
     <BladeData stack_amount="2" blade_length="9.46" blade_width="21.987" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10375,7 +10375,7 @@
   <CraftingPiece id="crpg_boarding_axe_blade_h3" name="{=fOrRdtNK}Small Spurred Axe Head" tier="2" piece_type="Blade" mesh="axe_craft_24_head" distance_to_next_piece="2.6" distance_to_previous_piece="2.1" weight="0.72">
     <BuildData piece_offset="-4.2" />
     <BladeData stack_amount="2" blade_length="9.46" blade_width="21.987" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -10249,7 +10249,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_saxon_hooked_axe_blade_h1" name="{=ajVcY9v6}Small Hammer Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_28_head" distance_to_next_piece="2.8" distance_to_previous_piece="3.1" weight="0.8">
+  <CraftingPiece id="crpg_saxon_hooked_axe_blade_h1" name="{=ajVcY9v6}Small Hammer Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_28_head" distance_to_next_piece="2.8" distance_to_previous_piece="3.1" weight="0.855">
     <BuildData piece_offset="-6.2" />
     <BladeData stack_amount="2" blade_length="12.961" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Swing damage_type="Cut" damage_factor="2.7" />
@@ -10265,7 +10265,7 @@
   <CraftingPiece id="crpg_saxon_hooked_axe_blade_h2" name="{=ajVcY9v6}Small Hammer Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_28_head" distance_to_next_piece="2.8" distance_to_previous_piece="3.1" weight="0.78">
     <BuildData piece_offset="-6.2" />
     <BladeData stack_amount="2" blade_length="12.961" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -10275,10 +10275,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_saxon_hooked_axe_blade_h3" name="{=ajVcY9v6}Small Hammer Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_28_head" distance_to_next_piece="2.8" distance_to_previous_piece="3.1" weight="0.74">
+  <CraftingPiece id="crpg_saxon_hooked_axe_blade_h3" name="{=ajVcY9v6}Small Hammer Axe Head" tier="3" piece_type="Blade" mesh="axe_craft_28_head" distance_to_next_piece="2.8" distance_to_previous_piece="3.1" weight="0.78">
     <BuildData piece_offset="-6.2" />
     <BladeData stack_amount="2" blade_length="12.961" blade_width="19.393" physics_material="metal_weapon" body_name="bo_axe_longer_b">
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9716,25 +9716,25 @@
       <Piece id="crpg_steel_round_axe_handle_h3" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_chopper_axe_h0" name="{=uSBxV2Ob}Wood Chopper Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_wood_chopper_axe_v2_h0" name="{=Diggles}Wood Chopper Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_chopper_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_wood_chopper_axe_handle_h0" Type="Handle" scale_factor="94" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_chopper_axe_h1" name="{=uSBxV2Ob}Wood Chopper Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_wood_chopper_axe_v2_h1" name="{=Diggles}Wood Chopper Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_chopper_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_wood_chopper_axe_handle_h1" Type="Handle" scale_factor="94" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_chopper_axe_h2" name="{=uSBxV2Ob}Wood Chopper Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_wood_chopper_axe_v2_h2" name="{=Diggles}Wood Chopper Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_chopper_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_wood_chopper_axe_handle_h2" Type="Handle" scale_factor="94" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_chopper_axe_h3" name="{=uSBxV2Ob}Wood Chopper Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_wood_chopper_axe_v2_h3" name="{=Diggles}Wood Chopper Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_chopper_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_wood_chopper_axe_handle_h3" Type="Handle" scale_factor="94" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10004,25 +10004,25 @@
       <Piece id="crpg_steel_footman_axe_handle_h3" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_raider_battle_axe_h0" name="{=DFcMeRdB}Raider Battle Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_raider_battle_axe_v2_h0" name="{=Diggles}Raider Battle Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_raider_battle_axe_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_raider_battle_axe_handle_h0" Type="Handle" scale_factor="113" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_raider_battle_axe_h1" name="{=DFcMeRdB}Raider Battle Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_raider_battle_axe_v2_h1" name="{=Diggles}Raider Battle Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_raider_battle_axe_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_raider_battle_axe_handle_h1" Type="Handle" scale_factor="113" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_raider_battle_axe_h2" name="{=DFcMeRdB}Raider Battle Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_raider_battle_axe_v2_h2" name="{=Diggles}Raider Battle Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_raider_battle_axe_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_raider_battle_axe_handle_h2" Type="Handle" scale_factor="113" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_raider_battle_axe_h3" name="{=DFcMeRdB}Raider Battle Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_raider_battle_axe_v2_h3" name="{=Diggles}Raider Battle Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_raider_battle_axe_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_raider_battle_axe_handle_h3" Type="Handle" scale_factor="113" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10172,25 +10172,25 @@
       <Piece id="crpg_desert_ascia_axe_handle_h3" Type="Handle" scale_factor="134" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_splitter_axe_h0" name="{=bcjcw1o9}Wood Splitter Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_wood_splitter_axe_v2_h0" name="{=Diggles}Wood Splitter Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_splitter_axe_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_wood_splitter_axe_handle_h0" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_splitter_axe_h1" name="{=bcjcw1o9}Wood Splitter Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_wood_splitter_axe_v2_h1" name="{=Diggles}Wood Splitter Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_splitter_axe_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_wood_splitter_axe_handle_h1" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_splitter_axe_h2" name="{=bcjcw1o9}Wood Splitter Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_wood_splitter_axe_v2_h2" name="{=Diggles}Wood Splitter Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_splitter_axe_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_wood_splitter_axe_handle_h2" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wood_splitter_axe_h3" name="{=bcjcw1o9}Wood Splitter Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_wood_splitter_axe_v2_h3" name="{=Diggles}Wood Splitter Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_wood_splitter_axe_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_wood_splitter_axe_handle_h3" Type="Handle" scale_factor="123" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10100,25 +10100,25 @@
       <Piece id="crpg_boarding_axe_handle_h3" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_norse_huscarl_axe_h0" name="{=ljOwXClb}Norse Huscarl Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_norse_huscarl_axe_v2_h0" name="{=Diggles}Norse Huscarl Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_norse_huscarl_axe_blade_h0" Type="Blade" scale_factor="103" />
       <Piece id="crpg_norse_huscarl_axe_handle_h0" Type="Handle" scale_factor="126" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_norse_huscarl_axe_h1" name="{=ljOwXClb}Norse Huscarl Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_norse_huscarl_axe_v2_h1" name="{=Diggles}Norse Huscarl Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_norse_huscarl_axe_blade_h1" Type="Blade" scale_factor="103" />
       <Piece id="crpg_norse_huscarl_axe_handle_h1" Type="Handle" scale_factor="126" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_norse_huscarl_axe_h2" name="{=ljOwXClb}Norse Huscarl Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_norse_huscarl_axe_v2_h2" name="{=Diggles}Norse Huscarl Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_norse_huscarl_axe_blade_h2" Type="Blade" scale_factor="103" />
       <Piece id="crpg_norse_huscarl_axe_handle_h2" Type="Handle" scale_factor="126" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_norse_huscarl_axe_h3" name="{=ljOwXClb}Norse Huscarl Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_norse_huscarl_axe_v2_h3" name="{=Diggles}Norse Huscarl Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_norse_huscarl_axe_blade_h3" Type="Blade" scale_factor="103" />
       <Piece id="crpg_norse_huscarl_axe_handle_h3" Type="Handle" scale_factor="126" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9956,25 +9956,25 @@
       <Piece id="crpg_tzikourion_axe_handle_h3" Type="Handle" scale_factor="86" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_forester_axe_h0" name="{=xgOuAWEE}Forester Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_forester_axe_v2_h0" name="{=Diggles}Forester Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_forester_axe_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_forester_axe_handle_h0" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_forester_axe_h1" name="{=xgOuAWEE}Forester Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_forester_axe_v2_h1" name="{=Diggles}Forester Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_forester_axe_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_forester_axe_handle_h1" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_forester_axe_h2" name="{=xgOuAWEE}Forester Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_forester_axe_v2_h2" name="{=Diggles}Forester Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_forester_axe_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_forester_axe_handle_h2" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_forester_axe_h3" name="{=xgOuAWEE}Forester Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_forester_axe_v2_h3" name="{=Diggles}Forester Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_forester_axe_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_forester_axe_handle_h3" Type="Handle" scale_factor="111" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10148,25 +10148,25 @@
       <Piece id="crpg_iron_hand_axe_handle_h3" Type="Handle" scale_factor="106" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_ascia_axe_h0" name="{=89OWzLBb}Desert Ascia Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_ascia_axe_v2_h0" name="{=Diggles}Desert Ascia Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_ascia_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_desert_ascia_axe_handle_h0" Type="Handle" scale_factor="134" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_ascia_axe_h1" name="{=89OWzLBb}Desert Ascia Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_ascia_axe_v2_h1" name="{=Diggles}Desert Ascia Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_ascia_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_desert_ascia_axe_handle_h1" Type="Handle" scale_factor="134" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_ascia_axe_h2" name="{=89OWzLBb}Desert Ascia Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_ascia_axe_v2_h2" name="{=Diggles}Desert Ascia Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_ascia_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_desert_ascia_axe_handle_h2" Type="Handle" scale_factor="134" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_ascia_axe_h3" name="{=89OWzLBb}Desert Ascia Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_ascia_axe_v2_h3" name="{=Diggles}Desert Ascia Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_ascia_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_desert_ascia_axe_handle_h3" Type="Handle" scale_factor="134" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10124,25 +10124,25 @@
       <Piece id="crpg_norse_huscarl_axe_handle_h3" Type="Handle" scale_factor="126" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_hand_axe_h0" name="{=hQrLHkaU}Iron Hand Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_iron_hand_axe_v2_h0" name="{=Diggles}Iron Hand Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_iron_hand_axe_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_iron_hand_axe_handle_h0" Type="Handle" scale_factor="106" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_hand_axe_h1" name="{=hQrLHkaU}Iron Hand Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_iron_hand_axe_v2_h1" name="{=Diggles}Iron Hand Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_iron_hand_axe_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_iron_hand_axe_handle_h1" Type="Handle" scale_factor="106" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_hand_axe_h2" name="{=hQrLHkaU}Iron Hand Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_iron_hand_axe_v2_h2" name="{=Diggles}Iron Hand Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_iron_hand_axe_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_iron_hand_axe_handle_h2" Type="Handle" scale_factor="106" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_hand_axe_h3" name="{=hQrLHkaU}Iron Hand Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_iron_hand_axe_v2_h3" name="{=Diggles}Iron Hand Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_iron_hand_axe_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_iron_hand_axe_handle_h3" Type="Handle" scale_factor="106" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9908,25 +9908,25 @@
       <Piece id="crpg_long_tzikourion_axe_handle_h3" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_hooked_axe_h0" name="{=6q0nmVtg}Saxon Hooked Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_hooked_axe_v2_h0" name="{=Diggles}Saxon Hooked Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_hooked_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_hooked_axe_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_hooked_axe_h1" name="{=6q0nmVtg}Saxon Hooked Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_hooked_axe_v2_h1" name="{=Diggles}Saxon Hooked Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_hooked_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_hooked_axe_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_hooked_axe_h2" name="{=6q0nmVtg}Saxon Hooked Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_hooked_axe_v2_h2" name="{=Diggles}Saxon Hooked Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_hooked_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_hooked_axe_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_hooked_axe_h3" name="{=6q0nmVtg}Saxon Hooked Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_hooked_axe_v2_h3" name="{=Diggles}Saxon Hooked Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_hooked_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_hooked_axe_handle_h3" Type="Handle" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -11120,25 +11120,25 @@
       <Piece id="crpg_sickle_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hatchet_h0" name="{=GghHAbIT}Hatchet" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_hatchet_v2_h0" name="{=Diggles}Hatchet" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_hatchet_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_hatchet_handle_h0" Type="Handle" scale_factor="147" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hatchet_h1" name="{=GghHAbIT}Hatchet +1" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_hatchet_v2_h1" name="{=Diggles}Hatchet +1" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_hatchet_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_hatchet_handle_h1" Type="Handle" scale_factor="147" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hatchet_h2" name="{=GghHAbIT}Hatchet +2" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_hatchet_v2_h2" name="{=Diggles}Hatchet +2" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_hatchet_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_hatchet_handle_h2" Type="Handle" scale_factor="147" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_hatchet_h3" name="{=GghHAbIT}Hatchet +3" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_hatchet_v2_h3" name="{=Diggles}Hatchet +3" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_hatchet_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_hatchet_handle_h3" Type="Handle" scale_factor="147" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9740,25 +9740,25 @@
       <Piece id="crpg_wood_chopper_axe_handle_h3" Type="Handle" scale_factor="94" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shield_reaver_axe_h0" name="{=xWFW8jXw}Shield Reaver Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_shield_reaver_axe_v2_h0" name="{=Diggles}Shield Reaver Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shield_reaver_axe_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shield_reaver_axe_handle_h0" Type="Handle" scale_factor="117" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shield_reaver_axe_h1" name="{=xWFW8jXw}Shield Reaver Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_shield_reaver_axe_v2_h1" name="{=Diggles}Shield Reaver Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shield_reaver_axe_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shield_reaver_axe_handle_h1" Type="Handle" scale_factor="117" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shield_reaver_axe_h2" name="{=xWFW8jXw}Shield Reaver Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_shield_reaver_axe_v2_h2" name="{=Diggles}Shield Reaver Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shield_reaver_axe_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shield_reaver_axe_handle_h2" Type="Handle" scale_factor="117" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_shield_reaver_axe_h3" name="{=xWFW8jXw}Shield Reaver Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_shield_reaver_axe_v2_h3" name="{=Diggles}Shield Reaver Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_shield_reaver_axe_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_shield_reaver_axe_handle_h3" Type="Handle" scale_factor="117" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9692,25 +9692,25 @@
       <Piece id="crpg_woodsman_two_handed_axe_handle_h3" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h0" name="{=Diggles}Steel Round Axe" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v2_h0" name="{=Diggles}Steel Round Axe" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h0" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h1" name="{=Diggles}Steel Round Axe +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v2_h1" name="{=Diggles}Steel Round Axe +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h1" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h2" name="{=Diggles}Steel Round Axe +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v2_h2" name="{=Diggles}Steel Round Axe +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h2" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_h3" name="{=Diggles}Steel Round Axe +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v2_h3" name="{=Diggles}Steel Round Axe +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h3" Type="Handle" scale_factor="91" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9932,25 +9932,25 @@
       <Piece id="crpg_saxon_hooked_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tzikourion_axe_h0" name="{=tsaSBPKu}Tzikourion Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
+  <CraftedItem id="crpg_tzikourion_axe_v2_h0" name="{=Diggles}Tzikourion Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tzikourion_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tzikourion_axe_handle_h0" Type="Handle" scale_factor="86" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tzikourion_axe_h1" name="{=tsaSBPKu}Tzikourion Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
+  <CraftedItem id="crpg_tzikourion_axe_v2_h1" name="{=Diggles}Tzikourion Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tzikourion_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tzikourion_axe_handle_h1" Type="Handle" scale_factor="86" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tzikourion_axe_h2" name="{=tsaSBPKu}Tzikourion Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
+  <CraftedItem id="crpg_tzikourion_axe_v2_h2" name="{=Diggles}Tzikourion Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tzikourion_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tzikourion_axe_handle_h2" Type="Handle" scale_factor="86" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tzikourion_axe_h3" name="{=tsaSBPKu}Tzikourion Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
+  <CraftedItem id="crpg_tzikourion_axe_v2_h3" name="{=Diggles}Tzikourion Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.empire" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tzikourion_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tzikourion_axe_handle_h3" Type="Handle" scale_factor="86" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9812,25 +9812,25 @@
       <Piece id="crpg_saxon_bearded_axe_handle_h3" Type="Handle" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pillager_axe_h0" name="{=Qpl5aCb0}Steel Pillager Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_pillager_axe_v2_h0" name="{=Diggles}Steel Pillager Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_pillager_axe_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_steel_pillager_axe_handle_h0" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pillager_axe_h1" name="{=Qpl5aCb0}Steel Pillager Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_pillager_axe_v2_h1" name="{=Diggles}Steel Pillager Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_pillager_axe_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_steel_pillager_axe_handle_h1" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pillager_axe_h2" name="{=Qpl5aCb0}Steel Pillager Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_pillager_axe_v2_h2" name="{=Diggles}Steel Pillager Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_pillager_axe_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_steel_pillager_axe_handle_h2" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pillager_axe_h3" name="{=Qpl5aCb0}Steel Pillager Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_pillager_axe_v2_h3" name="{=Diggles}Steel Pillager Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_pillager_axe_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_steel_pillager_axe_handle_h3" Type="Handle" scale_factor="124" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9836,25 +9836,25 @@
       <Piece id="crpg_steel_pillager_axe_handle_h3" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h0" name="{=Diggles}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v2_h0" name="{=Diggles}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h1" name="{=Diggles}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v2_h1" name="{=Diggles}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h2" name="{=Diggles}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v2_h2" name="{=Diggles}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v1_h3" name="{=Diggles}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v2_h3" name="{=Diggles}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h3" Type="Handle" scale_factor="135" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10076,25 +10076,25 @@
       <Piece id="crpg_desert_crescent_axe_handle_h3" Type="Handle" scale_factor="139" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boarding_axe_h0" name="{=dRWKmbaa}Boarding Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_boarding_axe_v2_h0" name="{=Diggles}Boarding Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_boarding_axe_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_boarding_axe_handle_h0" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boarding_axe_h1" name="{=dRWKmbaa}Boarding Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_boarding_axe_v2_h1" name="{=Diggles}Boarding Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_boarding_axe_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_boarding_axe_handle_h1" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boarding_axe_h2" name="{=dRWKmbaa}Boarding Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_boarding_axe_v2_h2" name="{=Diggles}Boarding Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_boarding_axe_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_boarding_axe_handle_h2" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boarding_axe_h3" name="{=dRWKmbaa}Boarding Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_boarding_axe_v2_h3" name="{=Diggles}Boarding Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_boarding_axe_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_boarding_axe_handle_h3" Type="Handle" scale_factor="103" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9884,25 +9884,25 @@
       <Piece id="crpg_long_franziska_axe_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_tzikourion_axe_h0" name="{=POhLMyat}Long Tzikourion Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_tzikourion_axe_v2_h0" name="{=Diggles}Long Tzikourion Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_tzikourion_axe_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_long_tzikourion_axe_handle_h0" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_tzikourion_axe_h1" name="{=POhLMyat}Long Tzikourion Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_tzikourion_axe_v2_h1" name="{=Diggles}Long Tzikourion Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_tzikourion_axe_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_long_tzikourion_axe_handle_h1" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_tzikourion_axe_h2" name="{=POhLMyat}Long Tzikourion Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_tzikourion_axe_v2_h2" name="{=Diggles}Long Tzikourion Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_tzikourion_axe_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_long_tzikourion_axe_handle_h2" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_tzikourion_axe_h3" name="{=POhLMyat}Long Tzikourion Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_tzikourion_axe_v2_h3" name="{=Diggles}Long Tzikourion Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_tzikourion_axe_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_long_tzikourion_axe_handle_h3" Type="Handle" scale_factor="123" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9764,25 +9764,25 @@
       <Piece id="crpg_shield_reaver_axe_handle_h3" Type="Handle" scale_factor="117" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_battle_axe_h0" name="{=FAzGPJn6}Desert Battle Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_battle_axe_v2_h0" name="{=Diggles}Desert Battle Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_battle_axe_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_desert_battle_axe_handle_h0" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_battle_axe_h1" name="{=FAzGPJn6}Desert Battle Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_battle_axe_v2_h1" name="{=Diggles}Desert Battle Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_battle_axe_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_desert_battle_axe_handle_h1" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_battle_axe_h2" name="{=FAzGPJn6}Desert Battle Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_battle_axe_v2_h2" name="{=Diggles}Desert Battle Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_battle_axe_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_desert_battle_axe_handle_h2" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_battle_axe_h3" name="{=FAzGPJn6}Desert Battle Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_battle_axe_v2_h3" name="{=Diggles}Desert Battle Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_battle_axe_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_desert_battle_axe_handle_h3" Type="Handle" scale_factor="103" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9980,25 +9980,25 @@
       <Piece id="crpg_forester_axe_handle_h3" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_footman_axe_h0" name="{=KanKBHcS}Steel Footman Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_footman_axe_v2_h0" name="{=Diggles}Steel Footman Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_footman_axe_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_steel_footman_axe_handle_h0" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_footman_axe_h1" name="{=KanKBHcS}Steel Footman Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_footman_axe_v2_h1" name="{=Diggles}Steel Footman Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_footman_axe_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_steel_footman_axe_handle_h1" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_footman_axe_h2" name="{=KanKBHcS}Steel Footman Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_footman_axe_v2_h2" name="{=Diggles}Steel Footman Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_footman_axe_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_steel_footman_axe_handle_h2" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_footman_axe_h3" name="{=KanKBHcS}Steel Footman Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_steel_footman_axe_v2_h3" name="{=Diggles}Steel Footman Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_footman_axe_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_steel_footman_axe_handle_h3" Type="Handle" scale_factor="105" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10052,25 +10052,25 @@
       <Piece id="crpg_tabar_axe_handle_h3" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_crescent_axe_h0" name="{=bdTQG99v}Desert Crescent Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_crescent_axe_v2_h0" name="{=Diggles}Desert Crescent Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_crescent_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_desert_crescent_axe_handle_h0" Type="Handle" scale_factor="139" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_crescent_axe_h1" name="{=bdTQG99v}Desert Crescent Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_crescent_axe_v2_h1" name="{=Diggles}Desert Crescent Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_crescent_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_desert_crescent_axe_handle_h1" Type="Handle" scale_factor="139" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_crescent_axe_h2" name="{=bdTQG99v}Desert Crescent Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_crescent_axe_v2_h2" name="{=Diggles}Desert Crescent Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_crescent_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_desert_crescent_axe_handle_h2" Type="Handle" scale_factor="139" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_desert_crescent_axe_h3" name="{=bdTQG99v}Desert Crescent Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_desert_crescent_axe_v2_h3" name="{=Diggles}Desert Crescent Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_desert_crescent_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_desert_crescent_axe_handle_h3" Type="Handle" scale_factor="139" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -10028,25 +10028,25 @@
       <Piece id="crpg_raider_battle_axe_handle_h3" Type="Handle" scale_factor="113" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tabar_axe_h0" name="{=XRaPBg6d}Tabar Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_tabar_axe_v2_h0" name="{=Diggles}Tabar Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tabar_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tabar_axe_handle_h0" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tabar_axe_h1" name="{=XRaPBg6d}Tabar Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_tabar_axe_v2_h1" name="{=Diggles}Tabar Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tabar_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tabar_axe_handle_h1" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tabar_axe_h2" name="{=XRaPBg6d}Tabar Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_tabar_axe_v2_h2" name="{=Diggles}Tabar Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tabar_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tabar_axe_handle_h2" Type="Handle" scale_factor="114" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tabar_axe_h3" name="{=XRaPBg6d}Tabar Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
+  <CraftedItem id="crpg_tabar_axe_v2_h3" name="{=Diggles}Tabar Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.aserai" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_tabar_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_tabar_axe_handle_h3" Type="Handle" scale_factor="114" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9860,25 +9860,25 @@
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h3" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_franziska_axe_h0" name="{=KRhIG1cw}Long Franziska Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_franziska_axe_v2_h0" name="{=Diggles}Long Franziska Axe" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_franziska_axe_blade_h0" Type="Blade" scale_factor="130" />
       <Piece id="crpg_long_franziska_axe_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_franziska_axe_h1" name="{=KRhIG1cw}Long Franziska Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_franziska_axe_v2_h1" name="{=Diggles}Long Franziska Axe +1" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_franziska_axe_blade_h1" Type="Blade" scale_factor="130" />
       <Piece id="crpg_long_franziska_axe_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_franziska_axe_h2" name="{=KRhIG1cw}Long Franziska Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_franziska_axe_v2_h2" name="{=Diggles}Long Franziska Axe +2" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_franziska_axe_blade_h2" Type="Blade" scale_factor="130" />
       <Piece id="crpg_long_franziska_axe_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_franziska_axe_h3" name="{=KRhIG1cw}Long Franziska Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
+  <CraftedItem id="crpg_long_franziska_axe_v2_h3" name="{=Diggles}Long Franziska Axe +3" crafting_template="crpg_OneHandedAxe" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_long_franziska_axe_blade_h3" Type="Blade" scale_factor="130" />
       <Piece id="crpg_long_franziska_axe_handle_h3" Type="Handle" scale_factor="115" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9788,25 +9788,25 @@
       <Piece id="crpg_desert_battle_axe_handle_h3" Type="Handle" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_bearded_axe_h0" name="{=pjvwuVuc}Saxon Bearded Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_bearded_axe_v2_h0" name="{=Diggles}Saxon Bearded Axe" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_bearded_axe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_bearded_axe_handle_h0" Type="Handle" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_bearded_axe_h1" name="{=pjvwuVuc}Saxon Bearded Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_bearded_axe_v2_h1" name="{=Diggles}Saxon Bearded Axe +1" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_bearded_axe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_bearded_axe_handle_h1" Type="Handle" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_bearded_axe_h2" name="{=pjvwuVuc}Saxon Bearded Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_bearded_axe_v2_h2" name="{=Diggles}Saxon Bearded Axe +2" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_bearded_axe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_bearded_axe_handle_h2" Type="Handle" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_saxon_bearded_axe_h3" name="{=pjvwuVuc}Saxon Bearded Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_saxon_bearded_axe_v2_h3" name="{=Diggles}Saxon Bearded Axe +3" crafting_template="crpg_OneHandedAxe" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_saxon_bearded_axe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_saxon_bearded_axe_handle_h3" Type="Handle" scale_factor="108" />


### PR DESCRIPTION
Updated 1h Axe Heirlooms to be more damage and consistent based on Niche(did not change axes I did not design, e.g. Shepherd)
Damage & Economy: H1: +1dmg, H2: +2dmg, H3: +2dmg
Reach: H1: +1dmg, H2: +1dmg, H3: +2dmg
Speed: H1: +1dmg, H2: +2spd, H3: +2dmg