### PR TITLE
Roman equip.update.nov2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -12412,22 +12412,22 @@
     </Materials>
     <BuildData next_piece_offset="-0.1" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h0" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.2" appearance="0.9">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h0" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.1" appearance="0.9">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h1" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.2" appearance="0.9">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h1" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.1" appearance="0.9">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h2" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.2" appearance="0.9">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h2" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.1" appearance="0.9">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h3" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.2" appearance="0.9">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_pommel_h3" name="{=PUAi75mb}Imperial Ring Pommel" tier="4" piece_type="Pommel" mesh="empire_noble_pommel_2" culture="Culture.empire" length="6.5" weight="0.1" appearance="0.9">
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
@@ -15052,25 +15052,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h0" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="1.33">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h0" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="0.20">
     <BuildData piece_offset="0" next_piece_offset="0" previous_piece_offset="0.5" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h1" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="1.33">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h1" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="0.20">
     <BuildData piece_offset="0" next_piece_offset="0" previous_piece_offset="0.5" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h2" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="1.33">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h2" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="0.20">
     <BuildData piece_offset="0" next_piece_offset="0" previous_piece_offset="0.5" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h3" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="1.33">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_handle_h3" name="{=bQkJSHCt}Bronze Two Handed Grip With Silver Spiral" tier="5" piece_type="Handle" mesh="empire_noble_grip_4" culture="Culture.sturgia" length="25" weight="0.20">
     <BuildData piece_offset="0" next_piece_offset="0" previous_piece_offset="0.5" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -17444,28 +17444,28 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h0" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.60">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h0" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.20">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h1" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.60">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h1" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.20">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h2" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.60">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h2" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.20">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h3" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.60">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_guard_h3" name="{=fd6Lnv1l}Golden Gladius Guard" tier="5" piece_type="Guard" mesh="empire_noble_guard_3" culture="Culture.empire" length="4.5" weight="0.20">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -20356,37 +20356,37 @@
       <Material id="Iron6" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h0" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.8">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h0" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h1" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.7">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h1" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h2" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.7">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h2" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.2" />
+      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="0.66">
+  <CraftingPiece id="crpg_spatha_blade_with_ring_pommel_blade_h3" name="{=HwCYBWq2}Sharp Tipped Spatha Blade" tier="4" piece_type="Blade" mesh="empire_noble_blade_4" culture="Culture.empire" length="95.8" weight="1.5">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_noble_blade_4_scabbard_4">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Materials>
       <Material id="Iron5" count="3" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -15000,25 +15000,25 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_handle_h0" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.60">
+  <CraftingPiece id="crpg_iron_spatha_handle_h0" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.50">
     <BuildData piece_offset="-0.07" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_handle_h1" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.60">
+  <CraftingPiece id="crpg_iron_spatha_handle_h1" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.50">
     <BuildData piece_offset="-0.07" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_handle_h2" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.60">
+  <CraftingPiece id="crpg_iron_spatha_handle_h2" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.50">
     <BuildData piece_offset="-0.07" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_handle_h3" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.60">
+  <CraftingPiece id="crpg_iron_spatha_handle_h3" name="{=6HybYLtu}Rough Leather Covered Northern One Handed Grip" tier="2" piece_type="Handle" mesh="sturgian_grip_5" culture="Culture.sturgia" length="15.15" weight="0.50">
     <BuildData piece_offset="-0.07" next_piece_offset="0.1" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron2" count="1" />
@@ -21764,10 +21764,36 @@
       <Material id="Iron3" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h0" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.10">
+  <CraftingPiece id="crpg_iron_spatha_blade_h0" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.275">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_iron_spatha_blade_h1" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.275">
+    <BuildData previous_piece_offset="-0.4" />
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="2.8" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_iron_spatha_blade_h2" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.275">
+    <BuildData previous_piece_offset="-0.4" />
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
       <Swing damage_type="Cut" damage_factor="2.9" />
     </BladeData>
     <Flags>
@@ -21777,36 +21803,10 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h1" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.01">
+  <CraftingPiece id="crpg_iron_spatha_blade_h3" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.275">
     <BuildData previous_piece_offset="-0.4" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h2" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="1.01">
-    <BuildData previous_piece_offset="-0.4" />
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_iron_spatha_blade_h3" name="{=c1YI2Nxt}Iron Spatha Blade" tier="2" piece_type="Blade" mesh="empire_blade_2" culture="Culture.empire" length="91.3" weight="0.97">
-    <BuildData previous_piece_offset="-0.4" />
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -14128,22 +14128,22 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h0" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h0" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.5">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h1" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h1" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.5">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h2" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h2" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.5">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h3" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_pommel_h3" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.5">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -17048,25 +17048,25 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h0" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.25">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h0" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.4">
     <BuildData piece_offset="-0.18" next_piece_offset="-0.15" previous_piece_offset="0.6" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h1" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.25">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h1" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.4">
     <BuildData piece_offset="-0.18" next_piece_offset="-0.15" previous_piece_offset="0.6" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h2" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.25">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h2" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.4">
     <BuildData piece_offset="-0.18" next_piece_offset="-0.15" previous_piece_offset="0.6" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h3" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.25">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_handle_h3" name="{=DID87A6l}Woven Leather Grip" tier="3" piece_type="Handle" mesh="empire_grip_1" culture="Culture.empire" length="15.4" weight="0.4">
     <BuildData piece_offset="-0.18" next_piece_offset="-0.15" previous_piece_offset="0.6" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -19544,28 +19544,28 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h0" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.16">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h0" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.25">
     <BuildData next_piece_offset="2.1" />
     <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h1" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.16">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h1" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.25">
     <BuildData next_piece_offset="2.1" />
     <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h2" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.16">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h2" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.25">
     <BuildData next_piece_offset="2.1" />
     <StatContributions armor_bonus="1" />
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h3" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.16">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_guard_h3" name="{=yilLfxCc}Lipped Guard" tier="2" piece_type="Guard" mesh="empire_guard_3" culture="Culture.empire" length="5.2" weight="0.25">
     <BuildData next_piece_offset="2.1" />
     <StatContributions armor_bonus="1" />
     <Materials>
@@ -23904,10 +23904,10 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.2">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23916,34 +23916,34 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.7" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.1">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="3.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_with_narrow_fuller_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.0">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -12600,22 +12600,22 @@
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h0" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.85">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h0" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.25">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h1" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.85">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h1" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.25">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h2" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.85">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h2" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.25">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h3" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.85">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_pommel_h3" name="{=HuYwPEmh}Ornamental Pommel" tier="5" piece_type="Pommel" mesh="sturgian_noble_pommel_3" culture="Culture.sturgia" length="3.9" weight="0.25">
     <Materials>
       <Material id="Iron5" count="1" />
     </Materials>
@@ -15364,25 +15364,25 @@
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h0" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.15">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h0" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.10">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h1" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.15">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h1" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.10">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h2" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.15">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h2" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.10">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h3" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.15">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_handle_h3" name="{=HF2WJagx}Decorated Leather Wrapped Warsword Grip" tier="5" piece_type="Handle" mesh="sturgian_noble_grip_1" culture="Culture.sturgia" length="17.8" weight="0.10">
     <BuildData piece_offset="0" previous_piece_offset="0.2" next_piece_offset="0.3" />
     <Materials>
       <Material id="Iron5" count="2" />
@@ -20884,46 +20884,46 @@
       <Material id="Iron6" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h0" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.93">
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h0" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.35">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron6" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h1" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.35">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron6" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h2" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.35">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
+      <Thrust damage_type="Pierce" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron6" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h3" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="1.35">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron6" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h1" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.8">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.5" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron6" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h2" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.76">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.6" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron6" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_thamaskene_short_warsword_blade_h3" name="{=mSNaSLiC}Thamaskene Steel Warsword Blade" tier="5" piece_type="Blade" mesh="sturgian_noble_blade_2" culture="Culture.sturgia" length="61.4" weight="0.69">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="sturgian_noble_blade_2_scabbard_2">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -14108,22 +14108,22 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_pommel_h0" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_pommel_h0" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.625">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_pommel_h1" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_pommel_h1" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.625">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_pommel_h2" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_pommel_h2" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.625">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_pommel_h3" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.170">
+  <CraftingPiece id="crpg_spatha_pommel_h3" name="{=d4aLa7tz}Top Pommel" tier="3" piece_type="Pommel" mesh="empire_pommel_4" culture="Culture.empire" length="6.795" weight="0.625">
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
@@ -17024,25 +17024,25 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_handle_h0" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.1">
+  <CraftingPiece id="crpg_spatha_handle_h0" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.525">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_handle_h1" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.1">
+  <CraftingPiece id="crpg_spatha_handle_h1" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.525">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_handle_h2" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.1">
+  <CraftingPiece id="crpg_spatha_handle_h2" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.525">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_handle_h3" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.1">
+  <CraftingPiece id="crpg_spatha_handle_h3" name="{=Knv8oS4x}Leather Wrapped Thick One Handed Grip" tier="3" piece_type="Handle" mesh="empire_grip_4" culture="Culture.empire" length="15.3" weight="0.525">
     <BuildData piece_offset="-0.14" previous_piece_offset="0.3" />
     <Materials>
       <Material id="Iron3" count="1" />
@@ -19516,28 +19516,28 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_guard_h0" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.20">
+  <CraftingPiece id="crpg_spatha_guard_h0" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.25">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_guard_h1" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.20">
+  <CraftingPiece id="crpg_spatha_guard_h1" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.25">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_guard_h2" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.20">
+  <CraftingPiece id="crpg_spatha_guard_h2" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.25">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_guard_h3" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.20">
+  <CraftingPiece id="crpg_spatha_guard_h3" name="{=4XytssVk}Half Moon Guard" tier="2" piece_type="Guard" mesh="empire_guard_6" culture="Culture.empire" length="4.362" weight="0.25">
     <BuildData next_piece_offset="1" />
     <StatContributions armor_bonus="5" />
     <Materials>
@@ -23856,34 +23856,10 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.18">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.09">
-    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="2.7" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron4" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.09">
+  <CraftingPiece id="crpg_spatha_blade_h0" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="2.8" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -23892,10 +23868,34 @@
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="1.04">
+  <CraftingPiece id="crpg_spatha_blade_h1" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.0" />
+      <Swing damage_type="Cut" damage_factor="3.6" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_blade_h2" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
       <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.7" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron4" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_spatha_blade_h3" name="{=iuQE1xwL}Narrow Fullered Spatha Blade" tier="3" piece_type="Blade" mesh="empire_blade_1" culture="Culture.empire" length="92.4" weight="0.65">
+    <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed" holster_mesh="empire_blade_1_scabbard_1">
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Swing damage_type="Cut" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/items/shields.xml
+++ b/items/shields.xml
@@ -224,33 +224,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_emirs_oval_shield_v2_h0" name="{=G7AEWZ6c}Decorated Oval Shield" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="2.201141" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_emirs_oval_shield_v3_h0" name="{=Diggles}Decorated Oval Shield" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="3.705625" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="297" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="8" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="500" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_emirs_oval_shield_v2_h1" name="{=G7AEWZ6c}Decorated Oval Shield +1" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="2.201141" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_emirs_oval_shield_v3_h1" name="{=Diggles}Decorated Oval Shield +1" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="3.705625" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="3" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="321" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="9" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="540" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_emirs_oval_shield_v2_h2" name="{=G7AEWZ6c}Decorated Oval Shield +2" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="2.201141" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_emirs_oval_shield_v3_h2" name="{=Diggles}Decorated Oval Shield +2" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="3.705625" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="3" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="345" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="9" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="580" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_emirs_oval_shield_v2_h3" name="{=G7AEWZ6c}Decorated Oval Shield +3" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="2.201141" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_emirs_oval_shield_v3_h3" name="{=Diggles}Decorated Oval Shield +3" body_name="bo_cap_shield_aserai_infantary_c" shield_body_name="bo_shield_aserai_infantary_c" recalculate_body="false" mesh="shield_aserai_infantary_c" using_tableau="true" weight="3.705625" appearance="0.7" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="3" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="369" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="9" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="620" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -1408,33 +1408,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_southern_oval_shield_v2_h0" name="{=8nNLS96w}Reinforced Oval Shield" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.030683" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_southern_oval_shield_v3_h0" name="{=Diggles}Reinforced Oval Shield" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.534647" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="1" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="274" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="3" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="342" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_southern_oval_shield_v2_h1" name="{=8nNLS96w}Reinforced Oval Shield +1" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.030683" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_southern_oval_shield_v3_h1" name="{=Diggles}Reinforced Oval Shield +1" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.534647" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="296" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="4" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="370" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_southern_oval_shield_v2_h2" name="{=8nNLS96w}Reinforced Oval Shield +2" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.030683" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_southern_oval_shield_v3_h2" name="{=Diggles}Reinforced Oval Shield +2" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.534647" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="318" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="4" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="397" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_southern_oval_shield_v2_h3" name="{=8nNLS96w}Reinforced Oval Shield +3" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.030683" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
+  <Item id="crpg_southern_oval_shield_v3_h3" name="{=Diggles}Reinforced Oval Shield +3" body_name="bo_cap_shield_aserai_infantary_b" shield_body_name="bo_shield_aserai_infantary_b" recalculate_body="false" mesh="shield_aserai_infantary_b" using_tableau="true" weight="2.534647" appearance="0.8" Type="Shield" item_holsters="shield_oval:shield_4:shield_3:shield_2" has_lower_holster_priority="true" holster_position_shift="-0.04,-0.0,0" culture="Culture.aserai">
     <ItemComponent>
-      <Weapon weapon_class="LargeShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="340" modifier_group="shield">
+      <Weapon weapon_class="LargeShield" body_armor="4" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.035, 0.1, 0.1" hit_points="425" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -7328,33 +7328,33 @@
       <Piece id="crpg_slightly_ridged_flyssa_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_h0" name="{=M2wvaObX}Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v2_h0" name="{=Diggles}Cavalry Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_h1" name="{=M2wvaObX}Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v2_h1" name="{=Diggles}Cavalry Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_h2" name="{=M2wvaObX}Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v2_h2" name="{=Diggles}Cavalry Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_h3" name="{=M2wvaObX}Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_v2_h3" name="{=Diggles}Cavalry Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_spatha_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_pommel_h3" Type="Pommel" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -7360,33 +7360,33 @@
       <Piece id="crpg_spatha_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_h0" name="{=4OaVIYuD}Spatha With Narrow Fuller" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v2_h0" name="{=Diggles}Imperial Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_with_narrow_fuller_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_with_narrow_fuller_blade_h0" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_h1" name="{=4OaVIYuD}Spatha With Narrow Fuller +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v2_h1" name="{=Diggles}Imperial Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_with_narrow_fuller_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_with_narrow_fuller_blade_h1" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_h2" name="{=4OaVIYuD}Spatha With Narrow Fuller +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v2_h2" name="{=Diggles}Imperial Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_with_narrow_fuller_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_with_narrow_fuller_blade_h2" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_with_narrow_fuller_h3" name="{=4OaVIYuD}Spatha With Narrow Fuller +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_with_narrow_fuller_v2_h3" name="{=Diggles}Imperial Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_with_narrow_fuller_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_spatha_with_narrow_fuller_blade_h3" Type="Blade" scale_factor="87" />
       <Piece id="crpg_spatha_with_narrow_fuller_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_spatha_with_narrow_fuller_pommel_h3" Type="Pommel" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -7424,33 +7424,33 @@
       <Piece id="crpg_iron_cavalry_sword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_spatha_h0" name="{=1CamO1P3}Iron Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_iron_spatha_v2_h0" name="{=Diggles}Republican Spatha" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_iron_spatha_blade_h0" Type="Blade" scale_factor="90" />
+      <Piece id="crpg_iron_spatha_blade_h0" Type="Blade" scale_factor="82" />
       <Piece id="crpg_iron_spatha_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_iron_spatha_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_iron_spatha_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_spatha_h1" name="{=1CamO1P3}Iron Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_iron_spatha_v2_h1" name="{=Diggles}Republican Spatha +1" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_iron_spatha_blade_h1" Type="Blade" scale_factor="90" />
+      <Piece id="crpg_iron_spatha_blade_h1" Type="Blade" scale_factor="82" />
       <Piece id="crpg_iron_spatha_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_iron_spatha_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_iron_spatha_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_spatha_h2" name="{=1CamO1P3}Iron Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_iron_spatha_v2_h2" name="{=Diggles}Republican Spatha +2" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_iron_spatha_blade_h2" Type="Blade" scale_factor="90" />
+      <Piece id="crpg_iron_spatha_blade_h2" Type="Blade" scale_factor="82" />
       <Piece id="crpg_iron_spatha_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_iron_spatha_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_iron_spatha_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_iron_spatha_h3" name="{=1CamO1P3}Iron Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_iron_spatha_v2_h3" name="{=Diggles}Republican Spatha +3" crafting_template="crpg_OneHandedSword" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_iron_spatha_blade_h3" Type="Blade" scale_factor="90" />
+      <Piece id="crpg_iron_spatha_blade_h3" Type="Blade" scale_factor="82" />
       <Piece id="crpg_iron_spatha_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_iron_spatha_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_iron_spatha_pommel_h3" Type="Pommel" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -5696,7 +5696,7 @@
       <Piece id="crpg_decorated_long_warsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_thamaskene_short_warsword_h0" name="{=lXwaLAYP}Thamaskene Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_thamaskene_short_warsword_v2_h0" name="{=Diggles}Norse Short Warsword" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_thamaskene_short_warsword_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_thamaskene_short_warsword_guard_h0" Type="Guard" scale_factor="100" />
@@ -5704,7 +5704,7 @@
       <Piece id="crpg_thamaskene_short_warsword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_thamaskene_short_warsword_h1" name="{=lXwaLAYP}Thamaskene Short Warsword +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_thamaskene_short_warsword_v2_h1" name="{=Diggles}Norse Short Warsword +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_thamaskene_short_warsword_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_thamaskene_short_warsword_guard_h1" Type="Guard" scale_factor="100" />
@@ -5712,7 +5712,7 @@
       <Piece id="crpg_thamaskene_short_warsword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_thamaskene_short_warsword_h2" name="{=lXwaLAYP}Thamaskene Short Warsword +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_thamaskene_short_warsword_v2_h2" name="{=Diggles}Norse Short Warsword +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_thamaskene_short_warsword_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_thamaskene_short_warsword_guard_h2" Type="Guard" scale_factor="100" />
@@ -5720,7 +5720,7 @@
       <Piece id="crpg_thamaskene_short_warsword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_thamaskene_short_warsword_h3" name="{=lXwaLAYP}Thamaskene Short Warsword +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_thamaskene_short_warsword_v2_h3" name="{=Diggles}Norse Short Warsword +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_thamaskene_short_warsword_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_thamaskene_short_warsword_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -5984,33 +5984,33 @@
       <Piece id="crpg_decorated_kaskara_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_h0" name="{=HpdJJO9g}Spatha Blade with Ring Pommel" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v2_h0" name="{=Diggles}Prefect's Spatha" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h0" Type="Blade" scale_factor="91" />
+      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h0" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h0" Type="Guard" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_handle_h0" Type="Handle" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_h1" name="{=HpdJJO9g}Spatha Blade with Ring Pommel +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v2_h1" name="{=Diggles}Prefect's Spatha +1" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h1" Type="Blade" scale_factor="91" />
+      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h1" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h1" Type="Guard" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_handle_h1" Type="Handle" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_h2" name="{=HpdJJO9g}Spatha Blade with Ring Pommel +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v2_h2" name="{=Diggles}Prefect's Spatha +2" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h2" Type="Blade" scale_factor="91" />
+      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h2" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h2" Type="Guard" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_handle_h2" Type="Handle" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_h3" name="{=HpdJJO9g}Spatha Blade with Ring Pommel +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_spatha_blade_with_ring_pommel_v2_h3" name="{=Diggles}Prefect's Spatha +3" crafting_template="crpg_OneHandedSword" is_merchandise="false" culture="Culture.empire" modifier_group="sword">
     <Pieces>
-      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h3" Type="Blade" scale_factor="91" />
+      <Piece id="crpg_spatha_blade_with_ring_pommel_blade_h3" Type="Blade" scale_factor="84" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_guard_h3" Type="Guard" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_handle_h3" Type="Handle" scale_factor="90" />
       <Piece id="crpg_spatha_blade_with_ring_pommel_pommel_h3" Type="Pommel" scale_factor="90" />


### PR DESCRIPTION
RomanEquip.Update.NOV2023 (if accepted)
-Strengthened 2 Oval shields to give Roman's better selection
-Renamed and updated 4 Spatha's with better thrusting specs
-Spatha to Cavalry Spatha, reach + high cut, slow
-Spatha with Narrow Fuller to Imperial Spatha, slightly more cut than thrust
-Iron Spatha to Republican Spatha, equal cut and thrust
-Spatha Blade with Ring Pommel to Prefect's Spatha, thrust specialty
-Updated 1 Sturgian shortsword to be thrust speciality (Gauls!)