### PR TITLE
Thamaskene swing pole

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -3272,25 +3272,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h0" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="1.5">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h0" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.8">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h1" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="1.35">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h1" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.7">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h2" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="1.35">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h2" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.62">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h3" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="1.2">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h3" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.58">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -5572,37 +5572,37 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h0" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3496">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h0" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h1" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3496">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h1" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="1.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h2" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3496">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h2" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h3" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3496">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h3" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.9" />
-      <Swing damage_type="Blunt" damage_factor="1.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -3272,7 +3272,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h0" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.8">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h0" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.85">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -3284,13 +3284,13 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h2" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.62">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h2" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.7">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h3" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.58">
+  <CraftingPiece id="crpg_long_thamaskene_tipped_spear_handle_h3" name="{=tgJ3dSOx}Oaken Long Spear Staff" tier="4" piece_type="Handle" mesh="spear_handle_20" length="220" weight="0.65">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -5575,7 +5575,7 @@
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h0" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5584,7 +5584,7 @@
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h1" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="2.5" />
+      <Swing damage_type="Blunt" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5593,7 +5593,7 @@
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h2" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />
@@ -5602,7 +5602,7 @@
   <CraftingPiece id="crpg_long_thamaskene_tipped_spear_blade_h3" name="{=S9zZO7qJ}Fine Steel Pike Head" tier="4" piece_type="Blade" mesh="spear_blade_11" length="34.56" weight="0.3">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="2.6" />
+      <Swing damage_type="Blunt" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="1" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8840,7 +8840,7 @@
       <Piece id="crpg_triangular_throwing_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v1_h0" name="{=vXYlLH6L}Long Thamaskene Tipped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h0" name="{=vXYlLH6L}Long Thamaskene Tipped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h0" Type="Guard" scale_factor="100" />
@@ -8848,7 +8848,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v1_h1" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h1" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h1" Type="Guard" scale_factor="100" />
@@ -8856,7 +8856,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v1_h2" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h2" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h2" Type="Guard" scale_factor="100" />
@@ -8864,7 +8864,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v1_h3" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h3" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Long Thamaskene Tipped Spear adjusted to be a more swing-focused spear that encourages putting away shield to fight with to maximise the quite nice swing damage. Created following the General Longform on the Discord, providing a long and damaging polearm that should feel good to fight with.

Thamaskene chosen because the current swing values are largely a waste of budget and other 4D spears occupy the same "space".

New and improved by not going over T10!