### PR TITLE
Increase Polehammer to T9.8

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -26724,9 +26724,9 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.61">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h0" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.58">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
       <Swing damage_type="Blunt" damage_factor="3.4" />
     </BladeData>
     <Flags>
@@ -26736,9 +26736,9 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.61">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h1" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.575">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.2" />
       <Swing damage_type="Blunt" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -26748,9 +26748,9 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.56">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h2" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.55">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Blunt" damage_factor="3.5" />
     </BladeData>
     <Flags>
@@ -26760,9 +26760,9 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.555">
+  <CraftingPiece id="crpg_spiked_polehammer_blade_h3" name="{=kaikaikai}Spiked Polehammer Blade" tier="3" piece_type="Blade" mesh="spiked_polehammer_head" culture="Culture.vlandia" length="98.3" weight="0.525">
     <BladeData stack_amount="1" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.3" />
       <Swing damage_type="Blunt" damage_factor="3.6" />
     </BladeData>
     <Flags>
@@ -26772,25 +26772,25 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_handle_h0" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.5" CraftingCost="120">
+  <CraftingPiece id="crpg_spiked_polehammer_handle_h0" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.3" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_handle_h1" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.5" CraftingCost="120">
+  <CraftingPiece id="crpg_spiked_polehammer_handle_h1" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.3" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_handle_h2" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.5" CraftingCost="120">
+  <CraftingPiece id="crpg_spiked_polehammer_handle_h2" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.3" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_spiked_polehammer_handle_h3" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.5" CraftingCost="120">
+  <CraftingPiece id="crpg_spiked_polehammer_handle_h3" name="Spiked Polehammer Shaft" tier="2" piece_type="Handle" mesh="spiked_polehammer_shaft" length="156" weight="1.3" CraftingCost="120">
     <BuildData previous_piece_offset="0" next_piece_offset="72" piece_offset="44" />
     <Materials>
       <Material id="Wood" count="1" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -120,25 +120,25 @@
       <Piece id="crpg_bec_de_corbin_handle_h3" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v3_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v4_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v3_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v4_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v3_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v4_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v3_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v4_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h3" Type="Handle" scale_factor="100" />


### PR DESCRIPTION
Increase of Polehammer to T9.8 to give a better spread of blunt/pierce polearms. New spread:

T2 - Bo Staff
T5 - Bludgeon Staff
T7.5 - Iron Rod (pending Yeldur change, from T5)
T8.5 - Bec de Corbin
T10 - Polehammer (pending this change, from T7.5)