### PR TITLE
1h mace.update.dec2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -536,25 +536,25 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_handle_h0" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="1.100" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_decorated_round_mace_handle_h0" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="17" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_handle_h1" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="1.100" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_decorated_round_mace_handle_h1" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="17" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_handle_h2" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="1.100" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_decorated_round_mace_handle_h2" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="17" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_handle_h3" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="1.100" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_decorated_round_mace_handle_h3" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="17" />
     <Materials>
       <Material id="Iron4" count="3" />
@@ -976,15 +976,7 @@
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_blade_h0" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.46" full_scale="true" excluded_item_usage_features="thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_blade_h1" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.46" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_round_mace_blade_h0" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="1.0" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
@@ -992,7 +984,7 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_blade_h2" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.46" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_round_mace_blade_h1" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="1.0" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
@@ -1000,9 +992,17 @@
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_decorated_round_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="0.44" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_decorated_round_mace_blade_h2" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="1.0" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
+      <Swing damage_type="Blunt" damage_factor="2.4" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_decorated_round_mace_blade_h3" name="{=ntIEIQ0N}Light Shishpar Head" tier="4" piece_type="Blade" mesh="mace_head_21" length="6.5" weight="1.0" full_scale="true" excluded_item_usage_features="thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -292,25 +292,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_handle_h0" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.4" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
+  <CraftingPiece id="crpg_blacksmith_hammer_handle_h0" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.1" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
     <BuildData piece_offset="10.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_handle_h1" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.4" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
+  <CraftingPiece id="crpg_blacksmith_hammer_handle_h1" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.1" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
     <BuildData piece_offset="10.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_handle_h2" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.4" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
+  <CraftingPiece id="crpg_blacksmith_hammer_handle_h2" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.1" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
     <BuildData piece_offset="10.0" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_handle_h3" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.4" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
+  <CraftingPiece id="crpg_blacksmith_hammer_handle_h3" name="{=reHxxC6K}Blacksmith Hammer Handle" tier="1" piece_type="Handle" mesh="blacksmith_hammer_handle" length="45" weight="0.1" item_holster_pos_shift="0,0,0.1" CraftingCost="75" is_default="true">
     <BuildData piece_offset="10.0" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -1340,19 +1340,7 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h0" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.48" full_scale="true" excluded_item_usage_features="thrust">
-    <BuildData piece_offset="-10" next_piece_offset="0" />
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron2" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.48" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h0" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.125" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.1" />
@@ -1364,7 +1352,7 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.44" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h1" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.125" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
@@ -1376,10 +1364,22 @@
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.37" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h2" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.125" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-10" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.3" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron2" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_blacksmith_hammer_blade_h3" name="{=X1FY4VYe}Smith Hammer Head" tier="1" piece_type="Blade" mesh="blacksmith_hammer_tip" length="7.4" weight="1.125" full_scale="true" excluded_item_usage_features="thrust">
+    <BuildData piece_offset="-10" next_piece_offset="0" />
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -29124,23 +29124,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_blade_h0" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.0" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_blade_h1" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_blade_h2" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_short_western_mace_blade_h0" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.2" />
     </BladeData>
@@ -29148,7 +29132,7 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.1" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_short_western_mace_blade_h1" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.5" full_scale="true" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.3" />
     </BladeData>
@@ -29156,25 +29140,41 @@
       <Material id="Iron3" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_handle_h0" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.50" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_short_western_mace_blade_h2" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.5" full_scale="true" excluded_item_usage_features="thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.4" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_short_western_mace_blade_h3" name="{=YFy0t1NY}Fullered Western Mace Head" tier="4" piece_type="Blade" mesh="mace_head_16" length="16.5" weight="1.5" full_scale="true" excluded_item_usage_features="thrust">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.5" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_short_western_mace_handle_h0" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="16.5" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_handle_h1" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.50" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_short_western_mace_handle_h1" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="16.5" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_handle_h2" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.50" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_short_western_mace_handle_h2" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="16.5" />
     <Materials>
       <Material id="Iron4" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_short_western_mace_handle_h3" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.50" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
+  <CraftingPiece id="crpg_short_western_mace_handle_h3" name="{=kjw9c4M2}Steel Angular Mace Handle" tier="4" piece_type="Handle" mesh="mace_handle_10" length="52" weight="0.1" item_holster_pos_shift="0,0,0.05" CraftingCost="80">
     <BuildData piece_offset="16.5" />
     <Materials>
       <Material id="Iron4" count="3" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -784,25 +784,25 @@
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_handle_h0" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.420" CraftingCost="75">
+  <CraftingPiece id="crpg_light_winged_mace_handle_h0" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.1" CraftingCost="75">
     <BuildData piece_offset="15" />
     <Materials>
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_handle_h1" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.420" CraftingCost="75">
+  <CraftingPiece id="crpg_light_winged_mace_handle_h1" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.1" CraftingCost="75">
     <BuildData piece_offset="15" />
     <Materials>
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_handle_h2" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.420" CraftingCost="75">
+  <CraftingPiece id="crpg_light_winged_mace_handle_h2" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.1" CraftingCost="75">
     <BuildData piece_offset="15" />
     <Materials>
       <Material id="Wood" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_handle_h3" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.420" CraftingCost="75">
+  <CraftingPiece id="crpg_light_winged_mace_handle_h3" name="{=87BmkiMO}Gnarled Mace Handle" tier="2" piece_type="Handle" mesh="mace_handle_6" length="56.2" weight="0.1" CraftingCost="75">
     <BuildData piece_offset="15" />
     <Materials>
       <Material id="Wood" count="2" />
@@ -1740,33 +1740,33 @@
       <Material id="Iron2" count="3" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_blade_h0" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.88" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.1" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron2" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_blade_h1" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.88" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.2" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron2" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_blade_h2" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.88" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.3" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron2" count="3" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_light_winged_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.88" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+  <CraftingPiece id="crpg_light_winged_mace_blade_h0" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
       <Swing damage_type="Blunt" damage_factor="2.4" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron2" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_light_winged_mace_blade_h1" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.5" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron2" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_light_winged_mace_blade_h2" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.6" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron2" count="3" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_light_winged_mace_blade_h3" name="{=sw5rAz73}Light Southern Mace Head" tier="2" piece_type="Blade" mesh="mace_head_1" length="11.5" weight="0.682" full_scale="true" excluded_item_usage_features="thrust" is_default="true">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_mace_a">
+      <Swing damage_type="Blunt" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="3" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -11824,25 +11824,25 @@
       <Piece id="crpg_knobbed_mace_handle_h3" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v1_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v2_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h0" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v1_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v2_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h1" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v1_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v2_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h2" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v1_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v2_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h3" Type="Handle" scale_factor="105" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -4248,28 +4248,28 @@
       <Piece id="crpg_bone_crusher_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h0" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h1" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h2" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h3" Type="Handle" scale_factor="120" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -4668,27 +4668,27 @@
       <Piece id="crpg_steppe_spiked_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v1_h0" name="{=6QI8X6CY}Light Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v2_h0" name="{=6QI8X6CY}Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
-      <Piece id="crpg_light_winged_mace_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_light_winged_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v1_h1" name="{=6QI8X6CY}Light Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v2_h1" name="{=6QI8X6CY}Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
-      <Piece id="crpg_light_winged_mace_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_light_winged_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v1_h2" name="{=6QI8X6CY}Light Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v2_h2" name="{=6QI8X6CY}Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
-      <Piece id="crpg_light_winged_mace_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_light_winged_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v1_h3" name="{=6QI8X6CY}Light Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v2_h3" name="{=6QI8X6CY}Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
-      <Piece id="crpg_light_winged_mace_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_light_winged_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -11072,28 +11072,28 @@
       <Piece id="crpg_blacksmith_warhammer_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v1_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v2_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v1_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v2_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v1_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v2_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v1_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v2_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
-      <Piece id="crpg_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="100" />
-      <Piece id="crpg_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="100" />
+      <Piece id="crpg_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="110" />
+      <Piece id="crpg_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_sickle_v1_h0" name="{=4wdgiTta}Sickle" crafting_template="crpg_OneHandedAxe" modifier_group="cheap_weapon">


### PR DESCRIPTION
Updated the 4x 1h Maces above 93 speed to slow them down and compensated by reducing weight, increasing damage and/or reach.
•	Blacksmith Hammer: -4 spd, +9 length, +1 dmg, -0.26 w, updated heirloom model for all +dmg
•	Decorated Round Mace: -2 spd, +2 dmg, -0.53 w, updated heirloom model for all +dmg
•	Short Western Mace: -4 spd, +2 dmg, -0.08 w
•	Light Winged Mace: renamed to ‘Winged Mace’, -8 spd, +0.46 w, +3 dmg (changed tiers as many similar of that length/speed/dmg)
•	All changed weapons refunded

