### PR TITLE
Hoplite.update.DEC2023

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -3782,7 +3782,7 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_leaf_spear_handle_h3" name="{=yD9v5GS0}Decorated Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_16" length="180" weight="1.40">
+  <CraftingPiece id="crpg_fine_steel_leaf_spear_handle_h3" name="{=yD9v5GS0}Decorated Pine Shaft" tier="4" piece_type="Handle" mesh="spear_handle_16" length="180" weight="1.55">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -7174,35 +7174,35 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h0" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Thrust damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="2.3" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h1" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
+  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h1" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.125">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="2.0" />
+      <Thrust damage_type="Cut" damage_factor="3.2" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h2" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
+  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h2" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.125">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Thrust damage_type="Cut" damage_factor="3.3" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h3" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.1456">
+  <CraftingPiece id="crpg_fine_steel_leaf_spear_blade_h3" name="{=9aYBy1RN}Fine Steel Leaf Spear Head" tier="4" piece_type="Blade" mesh="spear_blade_42" length="42" weight="0.125">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4_1" holster_body_name="bo_throwing_spear_quiver_4_1" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="2.1" />
+      <Thrust damage_type="Cut" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron4" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -4004,25 +4004,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h0" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.6">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h0" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h1" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.5">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h1" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h2" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.5">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h2" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h3" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.25">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_handle_h3" name="{=ow1aK4DJ}Wrapped Oaken Long Shaft" tier="3" piece_type="Handle" mesh="spear_handle_18" excluded_item_usage_features="long" length="200" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="4" />
@@ -7060,37 +7060,33 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h0" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="TwoHandedPolearm_Bracing">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h0" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.35" excluded_item_usage_features="TwoHandedPolearm_Bracing">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h1" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.25" excluded_item_usage_features="TwoHandedPolearm_Bracing">
+    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h2" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.35" excluded_item_usage_features="TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="1.5" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h1" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="TwoHandedPolearm_Bracing">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.7" />
-      <Swing damage_type="Blunt" damage_factor="1.5" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h2" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="TwoHandedPolearm_Bracing">
+  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h3" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.35" excluded_item_usage_features="TwoHandedPolearm_Bracing">
     <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
       <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="1.6" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_narrow_long_headed_spear_blade_h3" name="{=T1aiDuOp}Narrow Menavlon Head" tier="3" piece_type="Blade" mesh="spear_blade_14" length="46.28" weight="0.3768" excluded_item_usage_features="TwoHandedPolearm_Bracing">
-    <BladeData stack_amount="3" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_4" holster_body_name="bo_throwing_spear_quiver_4" holster_mesh_length="96.2">
-      <Thrust damage_type="Pierce" damage_factor="2.8" />
-      <Swing damage_type="Blunt" damage_factor="1.6" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="1" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -4312,25 +4312,25 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h0" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.6">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h0" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h1" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.5">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h1" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h2" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.5">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h2" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h3" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.2">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_handle_h3" name="{=nGP3FlHm}Long Mahogany Shaft" tier="3" piece_type="Handle" mesh="spear_handle_25" length="270" weight="1.0">
     <BuildData piece_offset="22.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -7480,37 +7480,33 @@
       <Flag name="CanDismount" />
     </Flags>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h0" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.7">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="1.2" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h1" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.7">
-    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
-      <Thrust damage_type="Pierce" damage_factor="2.5" />
-      <Swing damage_type="Blunt" damage_factor="1.2" />
-    </BladeData>
-    <Materials>
-      <Material id="Iron3" count="2" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h2" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.7">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h0" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.4">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="1.3" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h3" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.7">
+  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h1" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.35">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
       <Thrust damage_type="Pierce" damage_factor="2.6" />
-      <Swing damage_type="Blunt" damage_factor="1.3" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h2" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.35">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
+    </BladeData>
+    <Materials>
+      <Material id="Iron3" count="2" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tall_tipped_long_spear_blade_h3" name="{=CdBAvJdP}Kontos Head" tier="3" piece_type="Blade" mesh="spear_blade_8" length="60.153" weight="0.35">
+    <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b">
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
     </BladeData>
     <Materials>
       <Material id="Iron3" count="2" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -4438,19 +4438,19 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_handle_h1" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="0.9" CraftingCost="120">
+  <CraftingPiece id="crpg_simple_short_spear_handle_h1" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="1.0" CraftingCost="120">
     <BuildData piece_offset="24.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_handle_h2" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="0.9" CraftingCost="120">
+  <CraftingPiece id="crpg_simple_short_spear_handle_h2" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="1.0" CraftingCost="120">
     <BuildData piece_offset="24.9" />
     <Materials>
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_handle_h3" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="0.8" CraftingCost="120">
+  <CraftingPiece id="crpg_simple_short_spear_handle_h3" name="{=RXjhTS9s}Long Wrapped Oak Shaft" tier="2" piece_type="Handle" mesh="spear_handle_6" length="250" weight="1.0" CraftingCost="120">
     <BuildData piece_offset="24.9" />
     <Materials>
       <Material id="Wood" count="1" />
@@ -5460,37 +5460,33 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_blade_h0" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.204" is_default="true">
+  <CraftingPiece id="crpg_simple_short_spear_blade_h0" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.25" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Blunt" damage_factor="1.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.4" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_blade_h1" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.204" is_default="true">
+  <CraftingPiece id="crpg_simple_short_spear_blade_h1" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.25" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="2.2" />
-      <Swing damage_type="Blunt" damage_factor="1.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.5" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_blade_h2" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.204" is_default="true">
+  <CraftingPiece id="crpg_simple_short_spear_blade_h2" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.25" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_simple_short_spear_blade_h3" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.204" is_default="true">
+  <CraftingPiece id="crpg_simple_short_spear_blade_h3" name="{=r3R6RM9G}Short Simple Pike Head" tier="1" piece_type="Blade" mesh="spear_blade_9" length="23.328" weight="0.25" is_default="true">
     <BladeData stack_amount="2" physics_material="wood_weapon" body_name="bo_spear_b" holster_mesh="throwing_spear_quiver_3_1" holster_body_name="bo_throwing_spear_quiver_3_1" holster_mesh_length="96.8">
-      <Thrust damage_type="Pierce" damage_factor="2.3" />
-      <Swing damage_type="Blunt" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
     </BladeData>
     <Materials>
       <Material id="Iron2" count="1" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9284,25 +9284,25 @@
       <Piece id="crpg_highland_war_spear_handle_h3" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h0" name="{=Vyw5KNxR}Short Militia Spear" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v1_h0" name="{=Diggles}Hasta Spear" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h1" name="{=Vyw5KNxR}Short Militia Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v1_h1" name="{=Diggles}Hasta Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h2" name="{=Vyw5KNxR}Short Militia Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v1_h2" name="{=Diggles}Hasta Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h3" name="{=Vyw5KNxR}Short Militia Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v1_h3" name="{=Diggles}Hasta Militia Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h3" Type="Handle" scale_factor="90" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9156,28 +9156,28 @@
       <Piece id="crpg_reinforced_highland_spear_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h0" name="{=G7EbBKuA}Narrow Long Headed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h0" name="{=Diggles}Narrow Headed Long Spear" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h0" Type="Blade" scale_factor="110" />
-      <Piece id="crpg_narrow_long_headed_spear_handle_h0" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_narrow_long_headed_spear_handle_h0" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h1" name="{=G7EbBKuA}Narrow Long Headed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h1" name="{=Diggles}Narrow Headed Long Spear +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h1" Type="Blade" scale_factor="110" />
-      <Piece id="crpg_narrow_long_headed_spear_handle_h1" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_narrow_long_headed_spear_handle_h1" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h2" name="{=G7EbBKuA}Narrow Long Headed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h2" name="{=Diggles}Narrow Headed Long Spear +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h2" Type="Blade" scale_factor="110" />
-      <Piece id="crpg_narrow_long_headed_spear_handle_h2" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_narrow_long_headed_spear_handle_h2" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h3" name="{=G7EbBKuA}Narrow Long Headed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h3" name="{=Diggles}Narrow Headed Long Spear +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h3" Type="Blade" scale_factor="110" />
-      <Piece id="crpg_narrow_long_headed_spear_handle_h3" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_narrow_long_headed_spear_handle_h3" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_tall_tipped_long_spear_v1_h0" name="{=NFT4sLva}Tall Tipped Long Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9356,28 +9356,28 @@
       <Piece id="crpg_jagged_spear_handle_h3" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h0" name="{=bue69aD4}Simple Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h0" name="{=Diggles}Militia Short Spear" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_simple_short_spear_blade_h0" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_simple_short_spear_handle_h0" Type="Handle" scale_factor="90" />
+      <Piece id="crpg_simple_short_spear_blade_h0" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_simple_short_spear_handle_h0" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h1" name="{=bue69aD4}Simple Short Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h1" name="{=Diggles}Militia Short Spear +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_simple_short_spear_blade_h1" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_simple_short_spear_handle_h1" Type="Handle" scale_factor="90" />
+      <Piece id="crpg_simple_short_spear_blade_h1" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_simple_short_spear_handle_h1" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h2" name="{=bue69aD4}Simple Short Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h2" name="{=Diggles}Militia Short Spear +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_simple_short_spear_blade_h2" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_simple_short_spear_handle_h2" Type="Handle" scale_factor="90" />
+      <Piece id="crpg_simple_short_spear_blade_h2" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_simple_short_spear_handle_h2" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h3" name="{=bue69aD4}Simple Short Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h3" name="{=Diggles}Militia Short Spear +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
-      <Piece id="crpg_simple_short_spear_blade_h3" Type="Blade" scale_factor="90" />
-      <Piece id="crpg_simple_short_spear_handle_h3" Type="Handle" scale_factor="90" />
+      <Piece id="crpg_simple_short_spear_blade_h3" Type="Blade" scale_factor="100" />
+      <Piece id="crpg_simple_short_spear_handle_h3" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
   <CraftedItem id="crpg_simple_commoner_spear_v1_h0" name="{=hyq1zBg5}Noble Hunting Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -8904,35 +8904,35 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h0" name="{=bwXACVOb}Fine Steel Leaf Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h0" name="{=Diggles}Leaf Bladed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h0" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_fine_steel_leaf_spear_handle_h0" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_fine_steel_leaf_spear_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h1" name="{=bwXACVOb}Fine Steel Leaf Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h1" name="{=Diggles}Leaf Bladed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h1" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_fine_steel_leaf_spear_handle_h1" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_fine_steel_leaf_spear_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h2" name="{=bwXACVOb}Fine Steel Leaf Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h2" name="{=Diggles}Leaf Bladed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h2" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_fine_steel_leaf_spear_handle_h2" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_fine_steel_leaf_spear_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h3" name="{=bwXACVOb}Fine Steel Leaf Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h3" name="{=Diggles}Leaf Bladed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h3" Type="Guard" scale_factor="100" />
-      <Piece id="crpg_fine_steel_leaf_spear_handle_h3" Type="Handle" scale_factor="110" />
+      <Piece id="crpg_fine_steel_leaf_spear_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -9180,25 +9180,25 @@
       <Piece id="crpg_narrow_long_headed_spear_handle_h3" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h0" name="{=NFT4sLva}Tall Tipped Long Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h0" name="{=Diggles}Tall Tipped Long Spear" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h0" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h1" name="{=NFT4sLva}Tall Tipped Long Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h1" name="{=Diggles}Tall Tipped Long Spear +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h1" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h2" name="{=NFT4sLva}Tall Tipped Long Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h2" name="{=Diggles}Tall Tipped Long Spear +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h2" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h3" name="{=NFT4sLva}Tall Tipped Long Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h3" name="{=Diggles}Tall Tipped Long Spear +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h3" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h3" Type="Handle" scale_factor="90" />

--- a/weapon_descriptions.xml
+++ b/weapon_descriptions.xml
@@ -11339,10 +11339,6 @@
       <AvailablePiece id="crpg_triangular_headed_spear_handle_h1" />
       <AvailablePiece id="crpg_triangular_headed_spear_handle_h2" />
       <AvailablePiece id="crpg_triangular_headed_spear_handle_h3" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_handle_h0" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_handle_h1" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_handle_h2" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_handle_h3" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_handle_h0" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_handle_h1" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_handle_h2" />
@@ -11527,10 +11523,6 @@
       <AvailablePiece id="crpg_reinforced_highland_spear_blade_h1" />
       <AvailablePiece id="crpg_reinforced_highland_spear_blade_h2" />
       <AvailablePiece id="crpg_reinforced_highland_spear_blade_h3" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_blade_h0" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_blade_h1" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_blade_h2" />
-      <AvailablePiece id="crpg_tall_tipped_long_spear_blade_h3" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_blade_h0" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_blade_h1" />
       <AvailablePiece id="crpg_tall_tipped_war_spear_blade_h2" />


### PR DESCRIPTION
Hoplite.update.DEC2023
•	Renamed Short Milita Spear to Hasta Spear
•	Converted Fine Steel Leaf Spear to CUT damage only and renamed to Leaf Bladed Spear (community request)
  o	T8 – 2h mode: 167 L, 32c 86 spd swing, 23c 94 spd thrust
  o	T8 – 1h mode: 86 spd thrust
•	Converted 3x 4d spears back to 2d for more hoplite choices
  o	Narrow Long Headed renamed to Narrow Headed Long Spear
      	T6, 1H mode: 179 L, 89 spd, 26 pierce
  o	Simple Short Spear to Militia Short Spear
      	T2 – 1H mode: 146 L, 92 spd, 24 pierce
  o	Tall Tipped Long Spear
      	T7 – 1H mode: 199 L, 88 spd, 26 pierce
•	All altered items refunded except Short Militia Spear (rename only)
