### PR TITLE
Yeldur Dagger Rework

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31591,7 +31591,7 @@
   <CraftingPiece id="crpg_tanto_blade_h0" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.75">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
       <Thrust damage_type="Pierce" damage_factor="3.1" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31600,10 +31600,22 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tanto_blade_h1" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.6">
+  <CraftingPiece id="crpg_tanto_blade_h1" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.55">
+    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
+      <Thrust damage_type="Pierce" damage_factor="3.1" />
+      <Swing damage_type="Cut" damage_factor="3.1" />
+    </BladeData>
+    <Flags>
+      <Flag name="Civilian" type="ItemFlags" />
+    </Flags>
+    <Materials>
+      <Material id="Iron3" count="1" />
+    </Materials>
+  </CraftingPiece>
+  <CraftingPiece id="crpg_tanto_blade_h2" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.55">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
       <Thrust damage_type="Pierce" damage_factor="3.2" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31612,22 +31624,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tanto_blade_h2" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.5">
+  <CraftingPiece id="crpg_tanto_blade_h3" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.55">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
       <Thrust damage_type="Pierce" damage_factor="3.3" />
-      <Swing damage_type="Cut" damage_factor="2.9" />
-    </BladeData>
-    <Flags>
-      <Flag name="Civilian" type="ItemFlags" />
-    </Flags>
-    <Materials>
-      <Material id="Iron3" count="1" />
-    </Materials>
-  </CraftingPiece>
-  <CraftingPiece id="crpg_tanto_blade_h3" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.5">
-    <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
-      <Thrust damage_type="Pierce" damage_factor="3.4" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31936,10 +31936,10 @@
   <CraftingPiece id="crpg_jian_handle_h3" name="{=}Jian Handle" tier="3" piece_type="Handle" mesh="jian_handle" culture="Culture.khuzait" length="27.3" weight="0.1">
     <BuildData piece_offset="1" previous_piece_offset="0.0" next_piece_offset="0" />
   </CraftingPiece>
-  <CraftingPiece id="crpg_longdagger_blade_h0" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.3">
+  <CraftingPiece id="crpg_longdagger_blade_h0" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.95">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="1.8" />
-      <Swing damage_type="Cut" damage_factor="1.7" />
+      <Thrust damage_type="Pierce" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="2.4" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31948,10 +31948,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_longdagger_blade_h1" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.3">
+  <CraftingPiece id="crpg_longdagger_blade_h1" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.95">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="1.8" />
+      <Thrust damage_type="Pierce" damage_factor="3.4" />
+      <Swing damage_type="Cut" damage_factor="2.5" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31960,10 +31960,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_longdagger_blade_h2" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.3">
+  <CraftingPiece id="crpg_longdagger_blade_h2" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.95">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="1.9" />
+      <Thrust damage_type="Pierce" damage_factor="3.5" />
+      <Swing damage_type="Cut" damage_factor="2.6" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
@@ -31972,10 +31972,10 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_longdagger_blade_h3" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.3">
+  <CraftingPiece id="crpg_longdagger_blade_h3" name="{=}Long Dagger Blade" tier="2" piece_type="Blade" mesh="longdagger_blade" full_scale="false" length="40.4" weight="0.95">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="2.1" />
-      <Swing damage_type="Cut" damage_factor="2.0" />
+      <Thrust damage_type="Pierce" damage_factor="3.7" />
+      <Swing damage_type="Cut" damage_factor="2.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -31588,7 +31588,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_tanto_blade_h0" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.75">
+  <CraftingPiece id="crpg_tanto_blade_h0" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.65">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
       <Thrust damage_type="Pierce" damage_factor="3.1" />
       <Swing damage_type="Cut" damage_factor="3.1" />
@@ -31626,7 +31626,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_tanto_blade_h3" name="{=}Tanto Blade" tier="2" piece_type="Blade" mesh="tanto_blade" full_scale="true" length="40.4" weight="1.55">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="tanto_scabbard" holster_mesh_length="42">
-      <Thrust damage_type="Pierce" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="3.4" />
       <Swing damage_type="Cut" damage_factor="3.4" />
     </BladeData>
     <Flags>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -33022,7 +33022,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_black_longdagger_blade_h1" name="{=Yeldur}Long Dagger Blade" tier="2" piece_type="Blade" mesh="black_longdagger_blade" full_scale="false" length="40.4" weight="0.01">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="black_longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="3.4" />
+      <Thrust damage_type="Pierce" damage_factor="2.6" />
       <Swing damage_type="Cut" damage_factor="0.5" />
     </BladeData>
     <Flags>
@@ -33034,7 +33034,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_black_longdagger_blade_h2" name="{=Yeldur}Long Dagger Blade" tier="2" piece_type="Blade" mesh="black_longdagger_blade" full_scale="false" length="40.4" weight="0.01">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="black_longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="3.5" />
+      <Thrust damage_type="Pierce" damage_factor="2.7" />
       <Swing damage_type="Cut" damage_factor="0.5" />
     </BladeData>
     <Flags>
@@ -33046,7 +33046,7 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_black_longdagger_blade_h3" name="{=Yeldur}Long Dagger Blade" tier="2" piece_type="Blade" mesh="black_longdagger_blade" full_scale="false" length="40.4" weight="0.01">
     <BladeData stack_amount="9" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="black_longdagger_scabbard" holster_mesh_length="43.3">
-      <Thrust damage_type="Pierce" damage_factor="3.6" />
+      <Thrust damage_type="Pierce" damage_factor="2.8" />
       <Swing damage_type="Cut" damage_factor="0.5" />
     </BladeData>
     <Flags>

--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -11962,8 +11962,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_seax_blade_h0" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.75">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="1.7" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11975,8 +11975,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_seax_blade_h1" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.60">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="1.9" />
-      <Swing damage_type="Cut" damage_factor="3.0" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.2" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -11988,8 +11988,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_seax_blade_h2" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.1" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.3" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />
@@ -12001,8 +12001,8 @@
   </CraftingPiece>
   <CraftingPiece id="crpg_seax_blade_h3" name="{=aBnaaaHv}Long Seax Blade" tier="3" piece_type="Blade" mesh="dagger_blade_3" length="47" weight="1.56">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_knife_a" holster_mesh="">
-      <Thrust damage_type="Pierce" damage_factor="2.0" />
-      <Swing damage_type="Cut" damage_factor="3.3" />
+      <Thrust damage_type="Pierce" damage_factor="2.1" />
+      <Swing damage_type="Cut" damage_factor="3.5" />
     </BladeData>
     <Flags>
       <Flag name="CanBePickedUpFromCorpse" type="ItemFlags" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -12812,7 +12812,7 @@
       <Piece id="crpg_runic_axe_handle_h3" Type="Handle" scale_factor="121" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_longdagger_v1_h0" name="{=Yeldur}Ancient Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_longdagger_v2_h0" name="{=Yeldur}Ancient Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_longdagger_blade_h0" Type="Blade" scale_factor="96" />
       <Piece id="crpg_longdagger_guard_h0" Type="Guard" scale_factor="100" />
@@ -12820,7 +12820,7 @@
       <Piece id="crpg_longdagger_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_longdagger_v1_h1" name="{=Yeldur}Ancient Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_longdagger_v2_h1" name="{=Yeldur}Ancient Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_longdagger_blade_h1" Type="Blade" scale_factor="96" />
       <Piece id="crpg_longdagger_guard_h1" Type="Guard" scale_factor="100" />
@@ -12828,7 +12828,7 @@
       <Piece id="crpg_longdagger_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_longdagger_v1_h2" name="{=Yeldur}Ancient Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_longdagger_v2_h2" name="{=Yeldur}Ancient Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_longdagger_blade_h2" Type="Blade" scale_factor="96" />
       <Piece id="crpg_longdagger_guard_h2" Type="Guard" scale_factor="100" />
@@ -12836,7 +12836,7 @@
       <Piece id="crpg_longdagger_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_longdagger_v1_h3" name="{=Yeldur}Ancient Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_longdagger_v2_h3" name="{=Yeldur}Ancient Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_longdagger_blade_h3" Type="Blade" scale_factor="96" />
       <Piece id="crpg_longdagger_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -13204,7 +13204,7 @@
       <Piece id="crpg_longseax_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_h0" name="{=BalanceMe}Decorative Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h0" name="{=BalanceMe}Decorative Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h0" Type="Guard" scale_factor="100" />
@@ -13212,7 +13212,7 @@
       <Piece id="crpg_black_longdagger_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_h1" name="{=BalanceMe}Decorative Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h1" name="{=BalanceMe}Decorative Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h1" Type="Guard" scale_factor="100" />
@@ -13220,7 +13220,7 @@
       <Piece id="crpg_black_longdagger_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_h2" name="{=BalanceMe}Decorative Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h2" name="{=BalanceMe}Decorative Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h2" Type="Guard" scale_factor="100" />
@@ -13228,7 +13228,7 @@
       <Piece id="crpg_black_longdagger_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_h3" name="{=BalanceMe}Decorative Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h3" name="{=BalanceMe}Decorative Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h3" Type="Guard" scale_factor="100" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -4896,7 +4896,7 @@
       <Piece id="crpg_highland_dagger_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v2_h0" name="{=Yeldur}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v3_h0" name="{=Yeldur}Seax" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h0" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h0" Type="Guard" scale_factor="90" />
@@ -4904,7 +4904,7 @@
       <Piece id="crpg_seax_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v2_h1" name="{=Yeldur}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v3_h1" name="{=Yeldur}Seax +1" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h1" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h1" Type="Guard" scale_factor="90" />
@@ -4912,7 +4912,7 @@
       <Piece id="crpg_seax_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v2_h2" name="{=Yeldur}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v3_h2" name="{=Yeldur}Seax +2" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h2" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h2" Type="Guard" scale_factor="90" />
@@ -4920,7 +4920,7 @@
       <Piece id="crpg_seax_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_seax_v2_h3" name="{=Yeldur}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
+  <CraftedItem id="crpg_seax_v3_h3" name="{=Yeldur}Seax +3" crafting_template="crpg_Dagger" culture="Culture.sturgia" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_seax_blade_h3" Type="Blade" scale_factor="93" />
       <Piece id="crpg_seax_guard_h3" Type="Guard" scale_factor="90" />
@@ -12636,25 +12636,25 @@
       <Piece id="crpg_kopesh_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tanto_v1_h0" name="{=Yeldur}Tanto" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_tanto_v2_h0" name="{=Yeldur}Tanto" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_tanto_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tanto_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tanto_v1_h1" name="{=Yeldur}Tanto +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_tanto_v2_h1" name="{=Yeldur}Tanto +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_tanto_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tanto_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tanto_v1_h2" name="{=Yeldur}Tanto +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_tanto_v2_h2" name="{=Yeldur}Tanto +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_tanto_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tanto_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tanto_v1_h3" name="{=Yeldur}Tanto +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_tanto_v2_h3" name="{=Yeldur}Tanto +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_tanto_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tanto_handle_h3" Type="Handle" scale_factor="100" />
@@ -13204,7 +13204,7 @@
       <Piece id="crpg_longseax_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_v1_h0" name="{=BalanceMe}Decorative Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h0" name="{=Yeldur}Decorative Long Dagger" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h0" Type="Guard" scale_factor="100" />
@@ -13212,7 +13212,7 @@
       <Piece id="crpg_black_longdagger_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_v1_h1" name="{=BalanceMe}Decorative Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h1" name="{=Yeldur}Decorative Long Dagger +1" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h1" Type="Guard" scale_factor="100" />
@@ -13220,7 +13220,7 @@
       <Piece id="crpg_black_longdagger_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_v1_h2" name="{=BalanceMe}Decorative Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h2" name="{=Yeldur}Decorative Long Dagger +2" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h2" Type="Guard" scale_factor="100" />
@@ -13228,7 +13228,7 @@
       <Piece id="crpg_black_longdagger_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_black_longdagger_v1_h3" name="{=BalanceMe}Decorative Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
+  <CraftedItem id="crpg_black_longdagger_v1_h3" name="{=Yeldur}Decorative Long Dagger +3" crafting_template="crpg_Dagger_Scabbard" culture="Culture.empire" modifier_group="sword">
     <Pieces>
       <Piece id="crpg_black_longdagger_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_black_longdagger_guard_h3" Type="Guard" scale_factor="100" />


### PR DESCRIPTION
Rework daggers to increase high tier cut options

Reworks Tanto, Seax and Ancient Long Dagger to increase higher tier dagger options in the form of Cut as they were originally built to be weaker than Stab-Only as they were intended to be able to block. As they can no longer block, a rework to increase stats makes sense.

Lowers the tier of Decorative Dagger as the stats given to it as a bonus for looms were too high for what the weapon is intended to be.

Tanto, Seax, ALD and DD are refunded as part of this rework.