### PR TITLE
Heavy Blacksmith Hammer rework

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -25380,57 +25380,49 @@
       <Material id="Wood" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h0" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.67" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h0" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.58" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-29.5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.7" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-      <Flag name="CanCrushThrough" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h1" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.63" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h1" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.57" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-29.5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="2.9" />
+      <Swing damage_type="Blunt" damage_factor="3.8" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-      <Flag name="CanCrushThrough" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h2" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.63" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h2" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.57" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-29.5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.0" />
+      <Swing damage_type="Blunt" damage_factor="3.9" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-      <Flag name="CanCrushThrough" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="2" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h3" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.63" full_scale="true" excluded_item_usage_features="thrust">
+  <CraftingPiece id="crpg_heavy_blacksmith_hammer_blade_h3" name="{=}Heavy Smith Hammer Head" tier="1" piece_type="Blade" mesh="heavy_blacksmith_hammer_head" length="12.2" weight="0.57" full_scale="true" excluded_item_usage_features="thrust">
     <BuildData piece_offset="-29.5" next_piece_offset="0" />
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_mace_a">
-      <Swing damage_type="Blunt" damage_factor="3.1" />
+      <Swing damage_type="Blunt" damage_factor="4.1" />
     </BladeData>
     <Flags>
       <Flag name="Civilian" type="ItemFlags" />
-      <Flag name="CanKnockDown" />
-      <Flag name="CanCrushThrough" />
     </Flags>
     <Materials>
       <Material id="Iron2" count="2" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -504,25 +504,25 @@
       <Piece id="crpg_mallet_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v1_h0" name="{=}Heavy Blacksmith Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h0" name="{=}Heavy Blacksmith Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v1_h1" name="{=}Heavy Blacksmith Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h1" name="{=}Heavy Blacksmith Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v1_h2" name="{=}Heavy Blacksmith Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h2" name="{=}Heavy Blacksmith Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v1_h3" name="{=}Heavy Blacksmith Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h3" name="{=}Heavy Blacksmith Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="132" />


### PR DESCRIPTION
Rework Heavy Blacksmith Hammer to increase variety

It was noted that a lot of maces in 2h form have less, or similar damage to that of 1h, the reasoning for this is because almost all 2h maces have a flag attached that reduces their budget. This change serves to resolve that issue by reworking an underwhelming 2h mace that is seldom used and giving it stats without flags. 