### PR TITLE
Removed ability to thrust from Large Flachion (0p)

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -34448,7 +34448,7 @@
       <Material id="Iron4" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_large_falchion_blade_h0" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.2">
+  <CraftingPiece id="crpg_large_falchion_blade_h0" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.2" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="4.0" />
     </BladeData>
@@ -34456,7 +34456,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_large_falchion_blade_h1" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.17">
+  <CraftingPiece id="crpg_large_falchion_blade_h1" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.17" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="4.1" />
     </BladeData>
@@ -34464,7 +34464,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_large_falchion_blade_h2" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.17">
+  <CraftingPiece id="crpg_large_falchion_blade_h2" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.17" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>
@@ -34472,7 +34472,7 @@
       <Material id="Iron4" count="4" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_large_falchion_blade_h3" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.1">
+  <CraftingPiece id="crpg_large_falchion_blade_h3" name="{=Salt}Large Falchion Blade Head" tier="3" piece_type="Blade" mesh="cleaver_blade_2" culture="Culture.aserai" length="100.1" weight="1.1" excluded_item_usage_features="thrust">
     <BladeData stack_amount="2" physics_material="metal_weapon" body_name="bo_sword_one_handed">
       <Swing damage_type="Cut" damage_factor="4.3" />
     </BladeData>


### PR DESCRIPTION
Removed ability to thrust from Large Falchion

The Large Falchion has 0p thrust and was only intended to swing, but I forgot to add the excluded item usage set for thrust in my original PR, this corrects that. No refund as nothing about the weapon has changed.