### PR TITLE
Adjust balance stats for Great Long Axe (GLA)

### DIFF
--- a/crafting_pieces.xml
+++ b/crafting_pieces.xml
@@ -34012,7 +34012,7 @@
       <Material id="Iron2" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_blade_h0" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.16">
+  <CraftingPiece id="crpg_greatlongaxe_blade_h0" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.01">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Blunt" damage_factor="2.0" />
@@ -34027,7 +34027,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_blade_h1" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.16">
+  <CraftingPiece id="crpg_greatlongaxe_blade_h1" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.01">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Blunt" damage_factor="2.0" />
@@ -34042,7 +34042,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_blade_h2" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.16">
+  <CraftingPiece id="crpg_greatlongaxe_blade_h2" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.01">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Blunt" damage_factor="2.2" />
@@ -34057,7 +34057,7 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_blade_h3" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.16">
+  <CraftingPiece id="crpg_greatlongaxe_blade_h3" name="{=Salt}Great Long Axe Head" tier="3" piece_type="Blade" mesh="greataxe_blade" length="25.5" distance_to_next_piece="14.96" distance_to_previous_piece="2.712" weight="0.01">
     <BuildData piece_offset="-14.0" />
     <BladeData stack_amount="0" blade_length="28.366" blade_width="28.192" physics_material="metal_weapon" body_name="bo_axe_longer_b">
       <Thrust damage_type="Blunt" damage_factor="2.2" />
@@ -34072,28 +34072,28 @@
       <Material id="Iron3" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_handle_h0" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="2.0" item_holster_pos_shift="0,0,-0.1">
+  <CraftingPiece id="crpg_greatlongaxe_handle_h0" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="2.7" item_holster_pos_shift="0,0,-0.1">
     <BuildData piece_offset="28" next_piece_offset="12.0" />
     <Materials>
       <Material id="Wood" count="1" />
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_handle_h1" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="1.9" item_holster_pos_shift="0,0,-0.1">
+  <CraftingPiece id="crpg_greatlongaxe_handle_h1" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="2.69" item_holster_pos_shift="0,0,-0.1">
     <BuildData piece_offset="28" next_piece_offset="12.0" />
     <Materials>
       <Material id="Wood" count="1" />
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_handle_h2" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="1.9" item_holster_pos_shift="0,0,-0.1">
+  <CraftingPiece id="crpg_greatlongaxe_handle_h2" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="2.69" item_holster_pos_shift="0,0,-0.1">
     <BuildData piece_offset="28" next_piece_offset="12.0" />
     <Materials>
       <Material id="Wood" count="1" />
       <Material id="Iron5" count="1" />
     </Materials>
   </CraftingPiece>
-  <CraftingPiece id="crpg_greatlongaxe_handle_h3" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="1.8" item_holster_pos_shift="0,0,-0.1">
+  <CraftingPiece id="crpg_greatlongaxe_handle_h3" name="{=Salt}Great Long Axe Handle" tier="5" piece_type="Handle" mesh="long_greataxe_handle" length="129" weight="2.56" item_holster_pos_shift="0,0,-0.1">
     <BuildData piece_offset="28" next_piece_offset="12.0" />
     <Materials>
       <Material id="Wood" count="1" />

--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -13460,25 +13460,25 @@
       <Piece id="crpg_karabela_pommel_h3" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v1_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h0" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v1_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h1" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v1_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h2" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v1_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h3" Type="Handle" scale_factor="165" />


### PR DESCRIPTION
Adjust the balance stat for the Great Long Axe (GLA) to correct its swing speed.

The Great Long Axe (GLA) is currently experiencing issues similar to previous weapons where its balance stat results in a much faster swing speed than intended. This change aims to correct the balance stat to ensure the weapon performs as expected.