### PR TITLE
Rename + Rebalance Heaters

### DIFF
--- a/items/shields.xml
+++ b/items/shields.xml
@@ -384,33 +384,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_flat_heater_shield_v3_h0" name="{=ap2yulQ2}Flat Heater Shield" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.537483" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
+  <Item id="crpg_flat_heater_shield_v4_h0" name="{=ap2yulQ2}Flat Heater Shield" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.963938" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="1" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="274" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="10" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="350" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_flat_heater_shield_v3_h1" name="{=ap2yulQ2}Flat Heater Shield +1" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.537483" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
+  <Item id="crpg_flat_heater_shield_v4_h1" name="{=ap2yulQ2}Flat Heater Shield +1" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.963938" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="296" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="11" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="378" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_flat_heater_shield_v3_h2" name="{=ap2yulQ2}Flat Heater Shield +2" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.537483" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
+  <Item id="crpg_flat_heater_shield_v4_h2" name="{=ap2yulQ2}Flat Heater Shield +2" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.963938" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="318" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="11" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="406" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_flat_heater_shield_v3_h3" name="{=ap2yulQ2}Flat Heater Shield +3" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.537483" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
+  <Item id="crpg_flat_heater_shield_v4_h3" name="{=ap2yulQ2}Flat Heater Shield +3" body_name="bo_cap_heater_shield_f" shield_body_name="bo_heater_shield_f" recalculate_body="false" mesh="heater_shield_f" using_tableau="true" weight="1.963938" appearance="1" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.10,0.1,0.025" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="340" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="11" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="93" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="67" center_of_mass="0.0,0.1,0.05" hit_points="434" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
@@ -512,7 +512,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_heavy_heater_shield_v3_h0" name="{=rF7Xm7C0}Heavy Heater Shield" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
+  <Item id="crpg_heavy_heater_shield_v3_h0" name="{=rF7Xm7C0}Heavy Kite Shield" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="SmallShield" body_armor="4" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="87" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="71" center_of_mass="0.0,0.05,0.05" hit_points="530" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -520,7 +520,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_heavy_heater_shield_v3_h1" name="{=rF7Xm7C0}Heavy Heater Shield +1" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
+  <Item id="crpg_heavy_heater_shield_v3_h1" name="{=rF7Xm7C0}Heavy Kite Shield +1" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="SmallShield" body_armor="5" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="87" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="71" center_of_mass="0.0,0.05,0.05" hit_points="573" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -528,7 +528,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_heavy_heater_shield_v3_h2" name="{=rF7Xm7C0}Heavy Heater Shield +2" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
+  <Item id="crpg_heavy_heater_shield_v3_h2" name="{=rF7Xm7C0}Heavy Kite Shield +2" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="SmallShield" body_armor="5" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="87" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="71" center_of_mass="0.0,0.05,0.05" hit_points="615" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -536,7 +536,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_heavy_heater_shield_v3_h3" name="{=rF7Xm7C0}Heavy Heater Shield +3" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
+  <Item id="crpg_heavy_heater_shield_v3_h3" name="{=rF7Xm7C0}Heavy Kite Shield +3" body_name="bo_cap_heater_shield_g" shield_body_name="bo_heater_shield_g" recalculate_body="false" mesh="heater_shield_g" using_tableau="true" weight="3.339663" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,0,0.025" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="SmallShield" body_armor="5" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="87" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="71" center_of_mass="0.0,0.05,0.05" hit_points="658" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1920,7 +1920,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_tall_heater_shield_v3_h0" name="{=Lbm7asY3}Tall Heater Shield" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
+  <Item id="crpg_tall_heater_shield_v3_h0" name="{=Lbm7asY3}Tall Kite Shield" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="15" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="85" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.0,0.1,0.05" hit_points="410" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1928,7 +1928,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_tall_heater_shield_v3_h1" name="{=Lbm7asY3}Tall Heater Shield +1" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
+  <Item id="crpg_tall_heater_shield_v3_h1" name="{=Lbm7asY3}Tall Kite Shield +1" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="16" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="85" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.0,0.1,0.05" hit_points="443" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1936,7 +1936,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_tall_heater_shield_v3_h2" name="{=Lbm7asY3}Tall Heater Shield +2" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
+  <Item id="crpg_tall_heater_shield_v3_h2" name="{=Lbm7asY3}Tall Kite Shield +2" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="16" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="85" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.0,0.1,0.05" hit_points="476" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -1944,7 +1944,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_tall_heater_shield_v3_h3" name="{=Lbm7asY3}Tall Heater Shield +3" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
+  <Item id="crpg_tall_heater_shield_v3_h3" name="{=Lbm7asY3}Tall Kite Shield +3" body_name="bo_cap_heater_shield_k" shield_body_name="bo_heater_shield_k" recalculate_body="false" mesh="heater_shield_k" using_tableau="true" weight="3.038613" appearance="0.6" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.0,0" culture="Culture.vlandia">
     <ItemComponent>
       <Weapon weapon_class="LargeShield" body_armor="17" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="85" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="77" center_of_mass="-0.0,0.1,0.05" hit_points="509" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
@@ -2080,33 +2080,33 @@
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_wide_heater_shield_v3_h0" name="{=OhEQUMk0}Wide Heater Shield" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.67825" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
+  <Item id="crpg_wide_heater_shield_v4_h0" name="{=OhEQUMk0}Wide Heater Shield" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.990625" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="1" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="274" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="14" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="325" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_wide_heater_shield_v3_h1" name="{=OhEQUMk0}Wide Heater Shield +1" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.67825" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
+  <Item id="crpg_wide_heater_shield_v4_h1" name="{=OhEQUMk0}Wide Heater Shield +1" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.990625" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="296" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="15" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="351" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_wide_heater_shield_v3_h2" name="{=OhEQUMk0}Wide Heater Shield +2" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.67825" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
+  <Item id="crpg_wide_heater_shield_v4_h2" name="{=OhEQUMk0}Wide Heater Shield +2" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.990625" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="318" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="15" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="377" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>
     <Flags WoodenParry="true" HeldInOffHand="true" ForceAttachOffHandSecondaryItemBone="true" />
   </Item>
-  <Item id="crpg_wide_heater_shield_v3_h3" name="{=OhEQUMk0}Wide Heater Shield +3" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.67825" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
+  <Item id="crpg_wide_heater_shield_v4_h3" name="{=OhEQUMk0}Wide Heater Shield +3" body_name="bo_cap_heater_shield_i" shield_body_name="bo_heater_shield_i" recalculate_body="false" mesh="heater_shield_i" using_tableau="true" weight="1.990625" appearance="0.7" Type="Shield" item_holsters="shield:shield_2:shield_3:shield_4" has_lower_holster_priority="true" holster_position_shift="-0.1,-0.1,0" culture="Culture.vlandia">
     <ItemComponent>
-      <Weapon weapon_class="SmallShield" body_armor="2" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="340" modifier_group="shield">
+      <Weapon weapon_class="SmallShield" body_armor="16" thrust_speed="82" thrust_damage_type="Blunt" speed_rating="82" physics_material="wood_shield" item_usage="shield" position="0.0, 0.00, 0.00" rotation="0.0,10.0,40.00" weapon_length="70" center_of_mass="-0.0,0.2,0.05" hit_points="403" modifier_group="shield">
         <WeaponFlags CanBlockRanged="true" HasHitPoints="true" />
       </Weapon>
     </ItemComponent>


### PR DESCRIPTION
Rename 2 heater shields to more appropriate names, rebalance two separate heaters to have increased stats.

- Renamed the Heavy and Tall Heater shields to Kite Shields to better reflect the shield type.
- Rebalanced Flat and Wide Heater shields to boost their stats and increase the visibility of heaters as a shield type.
- Processed refunds due to stat changes.