### PR TITLE
Refund blunt from v114 changes

### DIFF
--- a/items/weapons.xml
+++ b/items/weapons.xml
@@ -120,145 +120,145 @@
       <Piece id="crpg_bec_de_corbin_handle_h3" Type="Handle" scale_factor="98" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v5_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v6_h0" name="{=kaikaikai}Spiked Polehammer" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v5_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v6_h1" name="{=kaikaikai}Spiked Polehammer +1" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v5_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v6_h2" name="{=kaikaikai}Spiked Polehammer +2" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_polehammer_v5_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
+  <CraftedItem id="crpg_spiked_polehammer_v6_h3" name="{=kaikaikai}Spiked Polehammer +3" crafting_template="crpg_TwoHandedPolearm">
     <Pieces>
       <Piece id="crpg_spiked_polehammer_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_spiked_polehammer_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v1_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v2_h0" name="{=}Warhammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v1_h1" name="{=}Warhammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v2_h1" name="{=}Warhammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v1_h2" name="{=}Warhammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v2_h2" name="{=}Warhammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_warhammer_v1_h3" name="{=}Warhammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_warhammer_v2_h3" name="{=}Warhammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_warhammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_warhammer_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v1_h0" name="{=}Military Hammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v2_h0" name="{=}Military Hammer" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v1_h1" name="{=}Military Hammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v2_h1" name="{=}Military Hammer +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v1_h2" name="{=}Military Hammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v2_h2" name="{=}Military Hammer +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_military_hammer_v1_h3" name="{=}Military Hammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_military_hammer_v2_h3" name="{=}Military Hammer +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_military_hammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_military_hammer_handle_h3" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_v2_h0" name="{=}Heavy Goedendag" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v3_h0" name="{=}Heavy Goedendag" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_v2_h1" name="{=}Heavy Goedendag +1" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v3_h1" name="{=}Heavy Goedendag +1" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_v2_h2" name="{=}Heavy Goedendag +2" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v3_h2" name="{=}Heavy Goedendag +2" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_goedendag_v2_h3" name="{=}Heavy Goedendag +3" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
+  <CraftedItem id="crpg_heavy_goedendag_v3_h3" name="{=}Heavy Goedendag +3" crafting_template="crpg_TwoHandedSword" culture="Culture.sturgia">
     <Pieces>
       <Piece id="crpg_heavy_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_goedendag_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v1_h0" name="{=}Medium Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v2_h0" name="{=}Medium Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v1_h1" name="{=}Medium Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v2_h1" name="{=}Medium Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v1_h2" name="{=}Medium Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v2_h2" name="{=}Medium Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_medium_goedendag_v1_h3" name="{=}Medium Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_medium_goedendag_v2_h3" name="{=}Medium Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_medium_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_medium_goedendag_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v1_h0" name="{=}Light Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v2_h0" name="{=}Light Goedendag" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v1_h1" name="{=}Light Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v2_h1" name="{=}Light Goedendag +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v1_h2" name="{=}Light Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v2_h2" name="{=}Light Goedendag +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_goedendag_v1_h3" name="{=}Light Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_light_goedendag_v2_h3" name="{=}Light Goedendag +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_goedendag_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_light_goedendag_handle_h3" Type="Handle" scale_factor="110" />
@@ -456,97 +456,97 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <CraftedItem id="crpg_bone_breaker_v1_h0" name="{=}Bone Breaker" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_bone_breaker_v2_h0" name="{=}Bone Breaker" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_bone_breaker_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bone_breaker_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_breaker_v1_h1" name="{=}Bone Breaker +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_bone_breaker_v2_h1" name="{=}Bone Breaker +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_bone_breaker_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bone_breaker_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_breaker_v1_h2" name="{=}Bone Breaker +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_bone_breaker_v2_h2" name="{=}Bone Breaker +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_bone_breaker_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bone_breaker_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_breaker_v1_h3" name="{=}Bone Breaker +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_bone_breaker_v2_h3" name="{=}Bone Breaker +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_bone_breaker_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_bone_breaker_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_mallet_v1_h0" name="{=}Mallet" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_mallet_v2_h0" name="{=}Mallet" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_mallet_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_mallet_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_mallet_v1_h1" name="{=}Mallet +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_mallet_v2_h1" name="{=}Mallet +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_mallet_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_mallet_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_mallet_v1_h2" name="{=}Mallet +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_mallet_v2_h2" name="{=}Mallet +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_mallet_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_mallet_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_mallet_v1_h3" name="{=}Mallet +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_mallet_v2_h3" name="{=}Mallet +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_mallet_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_mallet_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h0" name="{=}Heavy Blacksmith Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v3_h0" name="{=}Heavy Blacksmith Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h1" name="{=}Heavy Blacksmith Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v3_h1" name="{=}Heavy Blacksmith Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h2" name="{=}Heavy Blacksmith Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v3_h2" name="{=}Heavy Blacksmith Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_blacksmith_hammer_v2_h3" name="{=}Heavy Blacksmith Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_heavy_blacksmith_hammer_v3_h3" name="{=}Heavy Blacksmith Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_heavy_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="132" />
       <Piece id="crpg_heavy_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="132" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_maul_v1_h0" name="{=}Great Maul" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_maul_v2_h0" name="{=}Great Maul" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_maul_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_great_maul_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_maul_v1_h1" name="{=}Great Maul +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_maul_v2_h1" name="{=}Great Maul +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_maul_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_great_maul_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_maul_v1_h2" name="{=}Great Maul +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_maul_v2_h2" name="{=}Great Maul +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_maul_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_great_maul_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_great_maul_v1_h3" name="{=}Great Maul +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_great_maul_v2_h3" name="{=}Great Maul +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_great_maul_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_great_maul_handle_h3" Type="Handle" scale_factor="100" />
@@ -664,25 +664,25 @@
       <Piece id="crpg_claymore_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_maul_v1_h0" name="{=}Long Maul" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_long_maul_v2_h0" name="{=}Long Maul" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_long_maul_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_long_maul_handle_h0" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_maul_v1_h1" name="{=}Long Maul +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_long_maul_v2_h1" name="{=}Long Maul +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_long_maul_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_long_maul_handle_h1" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_maul_v1_h2" name="{=}Long Maul +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_long_maul_v2_h2" name="{=}Long Maul +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_long_maul_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_long_maul_handle_h2" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_maul_v1_h3" name="{=}Long Maul +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_long_maul_v2_h3" name="{=}Long Maul +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_long_maul_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_long_maul_handle_h3" Type="Handle" scale_factor="165" />
@@ -744,25 +744,25 @@
       <Piece id="crpg_hoplite_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_hafted_spiked_mace_v3_h0" name="{=kaikaikai}Long Hafted Spiked Mace" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_hafted_spiked_mace_v4_h0" name="{=kaikaikai}Long Hafted Spiked Mace" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_hafted_spiked_mace_blade_h0" Type="Blade" scale_factor="162" />
       <Piece id="crpg_long_hafted_spiked_mace_handle_h0" Type="Handle" scale_factor="290" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_hafted_spiked_mace_v3_h1" name="{=kaikaikai}Long Hafted Spiked Mace +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_hafted_spiked_mace_v4_h1" name="{=kaikaikai}Long Hafted Spiked Mace +1" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_hafted_spiked_mace_blade_h1" Type="Blade" scale_factor="162" />
       <Piece id="crpg_long_hafted_spiked_mace_handle_h1" Type="Handle" scale_factor="290" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_hafted_spiked_mace_v3_h2" name="{=kaikaikai}Long Hafted Spiked Mace +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_hafted_spiked_mace_v4_h2" name="{=kaikaikai}Long Hafted Spiked Mace +2" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_hafted_spiked_mace_blade_h2" Type="Blade" scale_factor="162" />
       <Piece id="crpg_long_hafted_spiked_mace_handle_h2" Type="Handle" scale_factor="290" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_hafted_spiked_mace_v3_h3" name="{=kaikaikai}Long Hafted Spiked Mace +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_long_hafted_spiked_mace_v4_h3" name="{=kaikaikai}Long Hafted Spiked Mace +3" crafting_template="crpg_TwoHandedPolearm" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_hafted_spiked_mace_blade_h3" Type="Blade" scale_factor="162" />
       <Piece id="crpg_long_hafted_spiked_mace_handle_h3" Type="Handle" scale_factor="290" />
@@ -816,73 +816,73 @@
       <Piece id="crpg_greataxe_handle_h3" Type="Handle" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gada_v1_h0" name="{=}Gada" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_gada_v2_h0" name="{=}Gada" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_gada_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gada_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gada_v1_h1" name="{=}Gada +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_gada_v2_h1" name="{=}Gada +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_gada_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gada_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gada_v1_h2" name="{=}Gada +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_gada_v2_h2" name="{=}Gada +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_gada_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gada_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_gada_v1_h3" name="{=}Gada +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_gada_v2_h3" name="{=}Gada +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_gada_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_gada_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_barmace_v1_h0" name="{=}Barmace" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_barmace_v2_h0" name="{=}Barmace" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_barmace_blade_h0" Type="Blade" scale_factor="160" />
       <Piece id="crpg_barmace_handle_h0" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_barmace_v1_h1" name="{=}Barmace +1" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_barmace_v2_h1" name="{=}Barmace +1" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_barmace_blade_h1" Type="Blade" scale_factor="160" />
       <Piece id="crpg_barmace_handle_h1" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_barmace_v1_h2" name="{=}Barmace +2" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_barmace_v2_h2" name="{=}Barmace +2" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_barmace_blade_h2" Type="Blade" scale_factor="160" />
       <Piece id="crpg_barmace_handle_h2" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_barmace_v1_h3" name="{=}Barmace +3" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
+  <CraftedItem id="crpg_barmace_v2_h3" name="{=}Barmace +3" crafting_template="crpg_TwoHandedSword" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_barmace_blade_h3" Type="Blade" scale_factor="160" />
       <Piece id="crpg_barmace_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v3_h0" name="{=}Awlpike" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v4_h0" name="{=}Awlpike" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v3_h1" name="{=}Awlpike +1" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v4_h1" name="{=}Awlpike +1" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v3_h2" name="{=}Awlpike +2" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v4_h2" name="{=}Awlpike +2" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_awlpike_v3_h3" name="{=}Awlpike +3" crafting_template="crpg_Polearm_2dswing">
+  <CraftedItem id="crpg_awlpike_v4_h3" name="{=}Awlpike +3" crafting_template="crpg_Polearm_2dswing">
     <Pieces>
       <Piece id="crpg_awlpike_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_awlpike_handle_h3" Type="Handle" scale_factor="100" />
@@ -976,25 +976,25 @@
       <Piece id="crpg_war_scythe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boulder_on_a_stick_v1_h0" name="{=}Boulder on a Stick" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_boulder_on_a_stick_v2_h0" name="{=}Boulder on a Stick" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_boulder_on_a_stick_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_boulder_on_a_stick_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boulder_on_a_stick_v1_h1" name="{=}Boulder on a Stick +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_boulder_on_a_stick_v2_h1" name="{=}Boulder on a Stick +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_boulder_on_a_stick_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_boulder_on_a_stick_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boulder_on_a_stick_v1_h2" name="{=}Boulder on a Stick +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_boulder_on_a_stick_v2_h2" name="{=}Boulder on a Stick +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_boulder_on_a_stick_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_boulder_on_a_stick_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_boulder_on_a_stick_v1_h3" name="{=}Boulder on a Stick +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_boulder_on_a_stick_v2_h3" name="{=}Boulder on a Stick +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_boulder_on_a_stick_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_boulder_on_a_stick_handle_h3" Type="Handle" scale_factor="100" />
@@ -4116,685 +4116,685 @@
     </ItemComponent>
     <Flags ForceAttachOffHandPrimaryItemBone="true" />
   </Item>
-  <CraftedItem id="crpg_steel_flanged_mace_v1_h0" name="{=fz23ajFz}Steel Flanged Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v2_h0" name="{=fz23ajFz}Steel Flanged Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h0" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v1_h1" name="{=fz23ajFz}Steel Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v2_h1" name="{=fz23ajFz}Steel Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h1" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v1_h2" name="{=fz23ajFz}Steel Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v2_h2" name="{=fz23ajFz}Steel Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h2" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_flanged_mace_v1_h3" name="{=fz23ajFz}Steel Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steel_flanged_mace_v2_h3" name="{=fz23ajFz}Steel Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_flanged_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_steel_flanged_mace_handle_h3" Type="Handle" scale_factor="88" />
       <Piece id="crpg_steel_flanged_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v1_h0" name="{=Kv4zAMIh}Cataphract Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v2_h0" name="{=Kv4zAMIh}Cataphract Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h0" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v1_h1" name="{=Kv4zAMIh}Cataphract Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v2_h1" name="{=Kv4zAMIh}Cataphract Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h1" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v1_h2" name="{=Kv4zAMIh}Cataphract Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v2_h2" name="{=Kv4zAMIh}Cataphract Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h2" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_cataphract_mace_v1_h3" name="{=Kv4zAMIh}Cataphract Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_cataphract_mace_v2_h3" name="{=Kv4zAMIh}Cataphract Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_cataphract_mace_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_cataphract_mace_handle_h3" Type="Handle" scale_factor="130" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v1_h0" name="{=UMX05EQF}Light Royal Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v2_h0" name="{=UMX05EQF}Light Royal Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h0" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h0" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h0" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v1_h1" name="{=UMX05EQF}Light Royal Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v2_h1" name="{=UMX05EQF}Light Royal Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h1" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h1" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h1" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v1_h2" name="{=UMX05EQF}Light Royal Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v2_h2" name="{=UMX05EQF}Light Royal Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h2" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h2" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h2" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_royal_mace_v1_h3" name="{=UMX05EQF}Light Royal Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_light_royal_mace_v2_h3" name="{=UMX05EQF}Light Royal Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_royal_mace_blade_h3" Type="Blade" scale_factor="105" />
       <Piece id="crpg_light_royal_mace_handle_h3" Type="Handle" scale_factor="115" />
       <Piece id="crpg_light_royal_mace_pommel_h3" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v1_h0" name="{=rnzpyc0N}Steel Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v2_h0" name="{=rnzpyc0N}Steel Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h0" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h0" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h0" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v1_h1" name="{=rnzpyc0N}Steel Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v2_h1" name="{=rnzpyc0N}Steel Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h1" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h1" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h1" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v1_h2" name="{=rnzpyc0N}Steel Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v2_h2" name="{=rnzpyc0N}Steel Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h2" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h2" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h2" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_pernach_v1_h3" name="{=rnzpyc0N}Steel Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_steel_pernach_v2_h3" name="{=rnzpyc0N}Steel Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_pernach_blade_h3" Type="Blade" scale_factor="150" />
       <Piece id="crpg_steel_pernach_handle_h3" Type="Handle" scale_factor="117" />
       <Piece id="crpg_steel_pernach_pommel_h3" Type="Pommel" scale_factor="108" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_steel_mace_v1_h0" name="Long Steel Mace" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_steel_mace_v2_h0" name="Long Steel Mace" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_steel_mace_blade_h0" Type="Blade" scale_factor="150" />
       <Piece id="crpg_long_steel_mace_handle_h0" Type="Handle" scale_factor="175" />
       <Piece id="crpg_long_steel_mace_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_steel_mace_v1_h1" name="Long Steel Mace +1" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_steel_mace_v2_h1" name="Long Steel Mace +1" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_steel_mace_blade_h1" Type="Blade" scale_factor="150" />
       <Piece id="crpg_long_steel_mace_handle_h1" Type="Handle" scale_factor="175" />
       <Piece id="crpg_long_steel_mace_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_steel_mace_v1_h2" name="Long Steel Mace +2" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_steel_mace_v2_h2" name="Long Steel Mace +2" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_steel_mace_blade_h2" Type="Blade" scale_factor="150" />
       <Piece id="crpg_long_steel_mace_handle_h2" Type="Handle" scale_factor="175" />
       <Piece id="crpg_long_steel_mace_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_steel_mace_v1_h3" name="Long Steel Mace +3" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_steel_mace_v2_h3" name="Long Steel Mace +3" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_steel_mace_blade_h3" Type="Blade" scale_factor="150" />
       <Piece id="crpg_long_steel_mace_handle_h3" Type="Handle" scale_factor="175" />
       <Piece id="crpg_long_steel_mace_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v1_h0" name="{=xYk4953c}Bone Crusher" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v2_h0" name="{=xYk4953c}Bone Crusher" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h0" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v1_h1" name="{=xYk4953c}Bone Crusher +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v2_h1" name="{=xYk4953c}Bone Crusher +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h1" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v1_h2" name="{=xYk4953c}Bone Crusher +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v2_h2" name="{=xYk4953c}Bone Crusher +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h2" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bone_crusher_v1_h3" name="{=xYk4953c}Bone Crusher +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_bone_crusher_v2_h3" name="{=xYk4953c}Bone Crusher +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_bone_crusher_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_bone_crusher_handle_h3" Type="Handle" scale_factor="118" />
       <Piece id="crpg_bone_crusher_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h0" name="{=9EWN9SiT}Decorated Round Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h0" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h0" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h1" name="{=9EWN9SiT}Decorated Round Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h1" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h1" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h2" name="{=9EWN9SiT}Decorated Round Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h2" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h2" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_decorated_round_mace_v1_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_decorated_round_mace_v2_h3" name="{=9EWN9SiT}Decorated Round Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_decorated_round_mace_blade_h3" Type="Blade" scale_factor="107" />
       <Piece id="crpg_decorated_round_mace_handle_h3" Type="Handle" scale_factor="120" />
       <Piece id="crpg_decorated_round_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v1_h0" name="{=b88lWWOo}Fine Steel Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v2_h0" name="{=b88lWWOo}Fine Steel Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h0" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v1_h1" name="{=b88lWWOo}Fine Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v2_h1" name="{=b88lWWOo}Fine Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h1" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v1_h2" name="{=b88lWWOo}Fine Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v2_h2" name="{=b88lWWOo}Fine Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h2" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_mace_v1_h3" name="{=b88lWWOo}Fine Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_fine_steel_mace_v2_h3" name="{=b88lWWOo}Fine Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fine_steel_mace_blade_h3" Type="Blade" scale_factor="170" />
       <Piece id="crpg_fine_steel_mace_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v1_h0" name="{=fcgDtZy7}Eastern Heavy Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v2_h0" name="{=fcgDtZy7}Eastern Heavy Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h0" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v1_h1" name="{=fcgDtZy7}Eastern Heavy Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v2_h1" name="{=fcgDtZy7}Eastern Heavy Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h1" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v1_h2" name="{=fcgDtZy7}Eastern Heavy Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v2_h2" name="{=fcgDtZy7}Eastern Heavy Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h2" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_eastern_heavy_mace_v1_h3" name="{=fcgDtZy7}Eastern Heavy Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_eastern_heavy_mace_v2_h3" name="{=fcgDtZy7}Eastern Heavy Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_eastern_heavy_mace_blade_h3" Type="Blade" scale_factor="160" />
       <Piece id="crpg_eastern_heavy_mace_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v1_h0" name="{=JM8Mjfa0}Spiralled Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v2_h0" name="{=JM8Mjfa0}Spiralled Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h0" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v1_h1" name="{=JM8Mjfa0}Spiralled Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v2_h1" name="{=JM8Mjfa0}Spiralled Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h1" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v1_h2" name="{=JM8Mjfa0}Spiralled Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v2_h2" name="{=JM8Mjfa0}Spiralled Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h2" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiralled_mace_v1_h3" name="{=JM8Mjfa0}Spiralled Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_spiralled_mace_v2_h3" name="{=JM8Mjfa0}Spiralled Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiralled_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_spiralled_mace_handle_h3" Type="Handle" scale_factor="130" />
       <Piece id="crpg_spiralled_mace_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v1_h0" name="{=YLplNGxb}Calradic Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v2_h0" name="{=YLplNGxb}Calradic Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h0" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h0" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h0" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v1_h1" name="{=YLplNGxb}Calradic Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v2_h1" name="{=YLplNGxb}Calradic Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h1" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h1" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h1" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v1_h2" name="{=YLplNGxb}Calradic Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v2_h2" name="{=YLplNGxb}Calradic Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h2" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h2" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h2" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_calradic_mace_v1_h3" name="{=YLplNGxb}Calradic Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_calradic_mace_v2_h3" name="{=YLplNGxb}Calradic Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_calradic_mace_blade_h3" Type="Blade" scale_factor="130" />
       <Piece id="crpg_calradic_mace_handle_h3" Type="Handle" scale_factor="150" />
       <Piece id="crpg_calradic_mace_pommel_h3" Type="Pommel" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v1_h0" name="{=4cMV1pY3}Light Shishpar Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v2_h0" name="{=4cMV1pY3}Light Shishpar Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v1_h1" name="{=4cMV1pY3}Light Shishpar Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v2_h1" name="{=4cMV1pY3}Light Shishpar Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v1_h2" name="{=4cMV1pY3}Light Shishpar Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v2_h2" name="{=4cMV1pY3}Light Shishpar Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shishpar_mace_v1_h3" name="{=4cMV1pY3}Light Shishpar Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_shishpar_mace_v2_h3" name="{=4cMV1pY3}Light Shishpar Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shishpar_mace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_light_shishpar_mace_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v1_h0" name="{=dSTxsYsh}Fullered Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v2_h0" name="{=dSTxsYsh}Fullered Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h0" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v1_h1" name="{=dSTxsYsh}Fullered Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v2_h1" name="{=dSTxsYsh}Fullered Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h1" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v1_h2" name="{=dSTxsYsh}Fullered Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v2_h2" name="{=dSTxsYsh}Fullered Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h2" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fullered_western_mace_v1_h3" name="{=dSTxsYsh}Fullered Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_fullered_western_mace_v2_h3" name="{=dSTxsYsh}Fullered Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_fullered_western_mace_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_fullered_western_mace_handle_h3" Type="Handle" scale_factor="158" />
       <Piece id="crpg_fullered_western_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_morningstar_v2_h0" name="{=Meow}Heavy Morningstar" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_morningstar_v3_h0" name="{=Meow}Heavy Morningstar" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_morningstar_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_handle_h0" Type="Handle" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_pommel_h0" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_morningstar_v2_h1" name="{=Meow}Heavy Morningstar +1" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_morningstar_v3_h1" name="{=Meow}Heavy Morningstar +1" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_morningstar_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_handle_h1" Type="Handle" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_pommel_h1" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_morningstar_v2_h2" name="{=Meow}Heavy Morningstar +2" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_morningstar_v3_h2" name="{=Meow}Heavy Morningstar +2" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_morningstar_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_handle_h2" Type="Handle" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_pommel_h2" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_morningstar_v2_h3" name="{=Meow}Heavy Morningstar +3" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_morningstar_v3_h3" name="{=Meow}Heavy Morningstar +3" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_morningstar_blade_h3" Type="Blade" scale_factor="113" />
       <Piece id="crpg_heavy_morningstar_handle_h3" Type="Handle" scale_factor="110" />
       <Piece id="crpg_heavy_morningstar_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v1_h0" name="{=6EWm09LY}Morningstar" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v2_h0" name="{=6EWm09LY}Morningstar" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h0" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h0" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v1_h1" name="{=6EWm09LY}Morningstar +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v2_h1" name="{=6EWm09LY}Morningstar +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h1" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h1" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v1_h2" name="{=6EWm09LY}Morningstar +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v2_h2" name="{=6EWm09LY}Morningstar +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h2" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h2" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_morningstar_v1_h3" name="{=6EWm09LY}Morningstar +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_morningstar_v2_h3" name="{=6EWm09LY}Morningstar +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_morningstar_blade_h3" Type="Blade" scale_factor="135" />
       <Piece id="crpg_morningstar_handle_h3" Type="Handle" scale_factor="115" />
       <Piece id="crpg_morningstar_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v1_h0" name="{=8pnCvnFR}Steel Winged Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h0" name="{=8pnCvnFR}Steel Winged Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h0" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h0" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v1_h1" name="{=8pnCvnFR}Steel Winged Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h1" name="{=8pnCvnFR}Steel Winged Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h1" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h1" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v1_h2" name="{=8pnCvnFR}Steel Winged Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h2" name="{=8pnCvnFR}Steel Winged Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h2" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h2" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_winged_shestopyor_v1_h3" name="{=8pnCvnFR}Steel Winged Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_steel_winged_shestopyor_v2_h3" name="{=8pnCvnFR}Steel Winged Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steel_winged_shestopyor_blade_h3" Type="Blade" scale_factor="145" />
       <Piece id="crpg_steel_winged_shestopyor_handle_h3" Type="Handle" scale_factor="115" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v1_h0" name="{=PBLsXDgP}Star Pointed Mace" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v2_h0" name="{=PBLsXDgP}Star Pointed Mace" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h0" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v1_h1" name="{=PBLsXDgP}Star Pointed Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v2_h1" name="{=PBLsXDgP}Star Pointed Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h1" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v1_h2" name="{=PBLsXDgP}Star Pointed Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v2_h2" name="{=PBLsXDgP}Star Pointed Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h2" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_star_pointed_mace_v1_h3" name="{=PBLsXDgP}Star Pointed Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_star_pointed_mace_v2_h3" name="{=PBLsXDgP}Star Pointed Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_star_pointed_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_star_pointed_mace_handle_h3" Type="Handle" scale_factor="89" />
       <Piece id="crpg_star_pointed_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v1_h0" name="{=9pD32UdV}Light Morningstar" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v2_h0" name="{=9pD32UdV}Light Morningstar" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h0" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h0" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v1_h1" name="{=9pD32UdV}Light Morningstar +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v2_h1" name="{=9pD32UdV}Light Morningstar +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h1" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h1" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v1_h2" name="{=9pD32UdV}Light Morningstar +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v2_h2" name="{=9pD32UdV}Light Morningstar +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h2" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h2" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_morningstar_v1_h3" name="{=9pD32UdV}Light Morningstar +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_light_morningstar_v2_h3" name="{=9pD32UdV}Light Morningstar +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_morningstar_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_light_morningstar_handle_h3" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_morningstar_pommel_h3" Type="Pommel" scale_factor="103" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v1_h0" name="{=FJDCc3Y2}Heavy Horsemans Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h0" name="{=FJDCc3Y2}Heavy Horsemans Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h0" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v1_h1" name="{=FJDCc3Y2}Heavy Horsemans Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h1" name="{=FJDCc3Y2}Heavy Horsemans Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h1" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v1_h2" name="{=FJDCc3Y2}Heavy Horsemans Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h2" name="{=FJDCc3Y2}Heavy Horsemans Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h2" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_horsemans_mace_v1_h3" name="{=FJDCc3Y2}Heavy Horsemans Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_heavy_horsemans_mace_v2_h3" name="{=FJDCc3Y2}Heavy Horsemans Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_heavy_horsemans_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_heavy_horsemans_mace_handle_h3" Type="Handle" scale_factor="170" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_spiked_club_v1_h0" name="{=0SpLcthg}Highland Spiked Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_highland_spiked_club_v2_h0" name="{=0SpLcthg}Highland Spiked Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_highland_spiked_club_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_highland_spiked_club_handle_h0" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_spiked_club_v1_h1" name="{=0SpLcthg}Highland Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_highland_spiked_club_v2_h1" name="{=0SpLcthg}Highland Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_highland_spiked_club_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_highland_spiked_club_handle_h1" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_spiked_club_v1_h2" name="{=0SpLcthg}Highland Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_highland_spiked_club_v2_h2" name="{=0SpLcthg}Highland Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_highland_spiked_club_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_highland_spiked_club_handle_h2" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_spiked_club_v1_h3" name="{=0SpLcthg}Highland Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_highland_spiked_club_v2_h3" name="{=0SpLcthg}Highland Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_highland_spiked_club_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_highland_spiked_club_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v2_h0" name="{=knobbedclubweapon}Knobbed Ball Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v3_h0" name="{=knobbedclubweapon}Knobbed Ball Club" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h0" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h0" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v2_h1" name="{=knobbedclubweapon}Knobbed Ball Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v3_h1" name="{=knobbedclubweapon}Knobbed Ball Club +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h1" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h1" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v2_h2" name="{=knobbedclubweapon}Knobbed Ball Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v3_h2" name="{=knobbedclubweapon}Knobbed Ball Club +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h2" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h2" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_ball_club_v2_h3" name="{=knobbedclubweapon}Knobbed Ball Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_ball_club_v3_h3" name="{=knobbedclubweapon}Knobbed Ball Club +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_ball_club_blade_h3" Type="Blade" scale_factor="102" />
       <Piece id="crpg_knobbed_ball_club_handle_h3" Type="Handle" scale_factor="104" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v1_h0" name="{=N8VJWdVY}Steppe Spiked Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v2_h0" name="{=N8VJWdVY}Steppe Spiked Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h0" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h0" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v1_h1" name="{=N8VJWdVY}Steppe Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v2_h1" name="{=N8VJWdVY}Steppe Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h1" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h1" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v1_h2" name="{=N8VJWdVY}Steppe Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v2_h2" name="{=N8VJWdVY}Steppe Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h2" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h2" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steppe_spiked_mace_v1_h3" name="{=N8VJWdVY}Steppe Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_steppe_spiked_mace_v2_h3" name="{=N8VJWdVY}Steppe Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_steppe_spiked_mace_blade_h3" Type="Blade" />
       <Piece id="crpg_steppe_spiked_mace_handle_h3" Type="Handle" scale_factor="108" />
       <Piece id="crpg_steppe_spiked_mace_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v2_h0" name="{=6QI8X6CY}Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v3_h0" name="{=6QI8X6CY}Winged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v2_h1" name="{=6QI8X6CY}Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v3_h1" name="{=6QI8X6CY}Winged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v2_h2" name="{=6QI8X6CY}Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v3_h2" name="{=6QI8X6CY}Winged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_winged_mace_v2_h3" name="{=6QI8X6CY}Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_light_winged_mace_v3_h3" name="{=6QI8X6CY}Winged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_winged_mace_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_light_winged_mace_handle_h3" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v1_h0" name="{=wxL5TdDv}Rus Mace" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v2_h0" name="{=wxL5TdDv}Rus Mace" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h0" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v1_h1" name="{=wxL5TdDv}Rus Mace +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v2_h1" name="{=wxL5TdDv}Rus Mace +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h1" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v1_h2" name="{=wxL5TdDv}Rus Mace +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v2_h2" name="{=wxL5TdDv}Rus Mace +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h2" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_rus_mace_v1_h3" name="{=wxL5TdDv}Rus Mace +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
+  <CraftedItem id="crpg_rus_mace_v2_h3" name="{=wxL5TdDv}Rus Mace +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_rus_mace_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_rus_mace_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_rus_mace_pommel_h3" Type="Pommel" scale_factor="92" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v1_h0" name="{=HaK3y9yi}Spiked Club" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v2_h0" name="{=HaK3y9yi}Spiked Club" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v1_h1" name="{=HaK3y9yi}Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v2_h1" name="{=HaK3y9yi}Spiked Club +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v1_h2" name="{=HaK3y9yi}Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v2_h2" name="{=HaK3y9yi}Spiked Club +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_club_v1_h3" name="{=HaK3y9yi}Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_club_v2_h3" name="{=HaK3y9yi}Spiked Club +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_club_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_spiked_club_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_mace_v1_h0" name="{=7jH0kuof}Spiked Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_mace_v2_h0" name="{=7jH0kuof}Spiked Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_mace_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_spiked_mace_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_mace_v1_h1" name="{=7jH0kuof}Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_mace_v2_h1" name="{=7jH0kuof}Spiked Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_mace_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_spiked_mace_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_mace_v1_h2" name="{=7jH0kuof}Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_mace_v2_h2" name="{=7jH0kuof}Spiked Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_mace_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_spiked_mace_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_spiked_mace_v1_h3" name="{=7jH0kuof}Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_spiked_mace_v2_h3" name="{=7jH0kuof}Spiked Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_spiked_mace_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_spiked_mace_handle_h3" Type="Handle" scale_factor="125" />
@@ -8872,7 +8872,7 @@
       <Piece id="crpg_triangular_throwing_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h0" name="{=vXYlLH6L}Long Thamaskene Tipped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v3_h0" name="{=vXYlLH6L}Long Thamaskene Tipped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h0" Type="Guard" scale_factor="100" />
@@ -8880,7 +8880,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h1" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v3_h1" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h1" Type="Guard" scale_factor="100" />
@@ -8888,7 +8888,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h2" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v3_h2" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h2" Type="Guard" scale_factor="100" />
@@ -8896,7 +8896,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v2_h3" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_long_thamaskene_tipped_spear_v3_h3" name="{=vXYlLH6L}Long Thamaskene Tipped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_long_thamaskene_tipped_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_long_thamaskene_tipped_spear_guard_h3" Type="Guard" scale_factor="100" />
@@ -8904,7 +8904,7 @@
       <Piece id="crpg_long_thamaskene_tipped_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_tipped_hooked_spear_v1_h0" name="{=duIWCjdD}Steel Tipped Hooked Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_steel_tipped_hooked_spear_v2_h0" name="{=duIWCjdD}Steel Tipped Hooked Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_steel_tipped_hooked_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_tipped_hooked_spear_guard_h0" Type="Guard" scale_factor="100" />
@@ -8912,7 +8912,7 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_tipped_hooked_spear_v1_h1" name="{=duIWCjdD}Steel Tipped Hooked Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_steel_tipped_hooked_spear_v2_h1" name="{=duIWCjdD}Steel Tipped Hooked Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_steel_tipped_hooked_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_tipped_hooked_spear_guard_h1" Type="Guard" scale_factor="100" />
@@ -8920,7 +8920,7 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_tipped_hooked_spear_v1_h2" name="{=duIWCjdD}Steel Tipped Hooked Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_steel_tipped_hooked_spear_v2_h2" name="{=duIWCjdD}Steel Tipped Hooked Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_steel_tipped_hooked_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_tipped_hooked_spear_guard_h2" Type="Guard" scale_factor="100" />
@@ -8928,7 +8928,7 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_tipped_hooked_spear_v1_h3" name="{=duIWCjdD}Steel Tipped Hooked Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_steel_tipped_hooked_spear_v2_h3" name="{=duIWCjdD}Steel Tipped Hooked Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_steel_tipped_hooked_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_steel_tipped_hooked_spear_guard_h3" Type="Guard" scale_factor="100" />
@@ -8936,7 +8936,7 @@
       <Piece id="crpg_steel_tipped_hooked_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h0" name="{=bwXACVOb}Fine Steel Leaf Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h0" name="{=bwXACVOb}Fine Steel Leaf Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h0" Type="Guard" scale_factor="100" />
@@ -8944,7 +8944,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h1" name="{=bwXACVOb}Fine Steel Leaf Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h1" name="{=bwXACVOb}Fine Steel Leaf Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h1" Type="Guard" scale_factor="100" />
@@ -8952,7 +8952,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h2" name="{=bwXACVOb}Fine Steel Leaf Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h2" name="{=bwXACVOb}Fine Steel Leaf Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h2" Type="Guard" scale_factor="100" />
@@ -8960,7 +8960,7 @@
       <Piece id="crpg_fine_steel_leaf_spear_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_fine_steel_leaf_spear_v1_h3" name="{=bwXACVOb}Fine Steel Leaf Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_fine_steel_leaf_spear_v2_h3" name="{=bwXACVOb}Fine Steel Leaf Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_fine_steel_leaf_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_fine_steel_leaf_spear_guard_h3" Type="Guard" scale_factor="100" />
@@ -9032,25 +9032,25 @@
       <Piece id="crpg_long_fine_steel_spear_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_triangular_headed_spear_v1_h0" name="{=Jkd2gmyj}Triangular Headed Spear" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
+  <CraftedItem id="crpg_triangular_headed_spear_v2_h0" name="{=Jkd2gmyj}Triangular Headed Spear" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_triangular_headed_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_triangular_headed_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_triangular_headed_spear_v1_h1" name="{=Jkd2gmyj}Triangular Headed Spear +1" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
+  <CraftedItem id="crpg_triangular_headed_spear_v2_h1" name="{=Jkd2gmyj}Triangular Headed Spear +1" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_triangular_headed_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_triangular_headed_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_triangular_headed_spear_v1_h2" name="{=Jkd2gmyj}Triangular Headed Spear +2" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
+  <CraftedItem id="crpg_triangular_headed_spear_v2_h2" name="{=Jkd2gmyj}Triangular Headed Spear +2" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_triangular_headed_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_triangular_headed_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_triangular_headed_spear_v1_h3" name="{=Jkd2gmyj}Triangular Headed Spear +3" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
+  <CraftedItem id="crpg_triangular_headed_spear_v2_h3" name="{=Jkd2gmyj}Triangular Headed Spear +3" crafting_template="crpg_Spear4DMode" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_triangular_headed_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_triangular_headed_spear_handle_h3" Type="Handle" scale_factor="90" />
@@ -9084,80 +9084,80 @@
       <Piece id="crpg_jagged_throwing_spear_handle_h3" Type="Handle" scale_factor="150" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_leaf_shaped_spear_v2_h0" name="{=xTyib5ms}Short Leaf Shaped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_short_leaf_shaped_spear_v3_h0" name="{=xTyib5ms}Short Leaf Shaped Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_leaf_shaped_spear_blade_h0" Type="Blade" scale_factor="99" />
       <Piece id="crpg_short_leaf_shaped_spear_handle_h0" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_leaf_shaped_spear_v2_h1" name="{=xTyib5ms}Short Leaf Shaped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_short_leaf_shaped_spear_v3_h1" name="{=xTyib5ms}Short Leaf Shaped Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_leaf_shaped_spear_blade_h1" Type="Blade" scale_factor="99" />
       <Piece id="crpg_short_leaf_shaped_spear_handle_h1" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_leaf_shaped_spear_v2_h2" name="{=xTyib5ms}Short Leaf Shaped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_short_leaf_shaped_spear_v3_h2" name="{=xTyib5ms}Short Leaf Shaped Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_leaf_shaped_spear_blade_h2" Type="Blade" scale_factor="99" />
       <Piece id="crpg_short_leaf_shaped_spear_handle_h2" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_leaf_shaped_spear_v2_h3" name="{=xTyib5ms}Short Leaf Shaped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_short_leaf_shaped_spear_v3_h3" name="{=xTyib5ms}Short Leaf Shaped Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_leaf_shaped_spear_blade_h3" Type="Blade" scale_factor="99" />
       <Piece id="crpg_short_leaf_shaped_spear_handle_h3" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_v1_h0" name="{=IDfl59yt}Knob Headed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_v2_h0" name="{=IDfl59yt}Knob Headed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_guard_h0" Type="Guard" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_v1_h1" name="{=IDfl59yt}Knob Headed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_v2_h1" name="{=IDfl59yt}Knob Headed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_guard_h1" Type="Guard" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_v1_h2" name="{=IDfl59yt}Knob Headed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_v2_h2" name="{=IDfl59yt}Knob Headed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_guard_h2" Type="Guard" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_v1_h3" name="{=IDfl59yt}Knob Headed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_v2_h3" name="{=IDfl59yt}Knob Headed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_guard_h3" Type="Guard" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_with_frills_v1_h0" name="{=zH0QF7mE}Knob Headed Spear with Frills" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_with_frills_v2_h0" name="{=zH0QF7mE}Knob Headed Spear with Frills" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_with_frills_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_with_frills_guard_h0" Type="Guard" scale_factor="90" />
       <Piece id="crpg_knob_headed_spear_with_frills_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_with_frills_v1_h1" name="{=zH0QF7mE}Knob Headed Spear with Frills +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_with_frills_v2_h1" name="{=zH0QF7mE}Knob Headed Spear with Frills +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_with_frills_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_with_frills_guard_h1" Type="Guard" scale_factor="90" />
       <Piece id="crpg_knob_headed_spear_with_frills_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_with_frills_v1_h2" name="{=zH0QF7mE}Knob Headed Spear with Frills +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_with_frills_v2_h2" name="{=zH0QF7mE}Knob Headed Spear with Frills +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_with_frills_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_with_frills_guard_h2" Type="Guard" scale_factor="90" />
       <Piece id="crpg_knob_headed_spear_with_frills_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knob_headed_spear_with_frills_v1_h3" name="{=zH0QF7mE}Knob Headed Spear with Frills +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_knob_headed_spear_with_frills_v2_h3" name="{=zH0QF7mE}Knob Headed Spear with Frills +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_knob_headed_spear_with_frills_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knob_headed_spear_with_frills_guard_h3" Type="Guard" scale_factor="90" />
@@ -9188,76 +9188,76 @@
       <Piece id="crpg_reinforced_highland_spear_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h0" name="{=G7EbBKuA}Narrow Long Headed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h0" name="{=G7EbBKuA}Narrow Long Headed Spear" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_narrow_long_headed_spear_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h1" name="{=G7EbBKuA}Narrow Long Headed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h1" name="{=G7EbBKuA}Narrow Long Headed Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_narrow_long_headed_spear_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h2" name="{=G7EbBKuA}Narrow Long Headed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h2" name="{=G7EbBKuA}Narrow Long Headed Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_narrow_long_headed_spear_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_narrow_long_headed_spear_v1_h3" name="{=G7EbBKuA}Narrow Long Headed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
+  <CraftedItem id="crpg_narrow_long_headed_spear_v2_h3" name="{=G7EbBKuA}Narrow Long Headed Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.khuzait" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_narrow_long_headed_spear_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_narrow_long_headed_spear_handle_h3" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h0" name="{=NFT4sLva}Tall Tipped Long Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h0" name="{=NFT4sLva}Tall Tipped Long Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h0" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h1" name="{=NFT4sLva}Tall Tipped Long Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h1" name="{=NFT4sLva}Tall Tipped Long Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h1" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h2" name="{=NFT4sLva}Tall Tipped Long Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h2" name="{=NFT4sLva}Tall Tipped Long Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h2" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_long_spear_v1_h3" name="{=NFT4sLva}Tall Tipped Long Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_long_spear_v2_h3" name="{=NFT4sLva}Tall Tipped Long Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_long_spear_blade_h3" Type="Blade" scale_factor="94" />
       <Piece id="crpg_tall_tipped_long_spear_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_war_spear_v2_h0" name="{=WQksMqMR}Tall Tipped War Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_war_spear_v3_h0" name="{=WQksMqMR}Tall Tipped War Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_war_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_guard_h0" Type="Guard" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_handle_h0" Type="Handle" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_war_spear_v2_h1" name="{=WQksMqMR}Tall Tipped War Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_war_spear_v3_h1" name="{=WQksMqMR}Tall Tipped War Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_war_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_guard_h1" Type="Guard" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_handle_h1" Type="Handle" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_war_spear_v2_h2" name="{=WQksMqMR}Tall Tipped War Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_war_spear_v3_h2" name="{=WQksMqMR}Tall Tipped War Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_war_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_guard_h2" Type="Guard" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_handle_h2" Type="Handle" scale_factor="75" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tall_tipped_war_spear_v2_h3" name="{=WQksMqMR}Tall Tipped War Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_tall_tipped_war_spear_v3_h3" name="{=WQksMqMR}Tall Tipped War Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_tall_tipped_war_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_tall_tipped_war_spear_guard_h3" Type="Guard" scale_factor="90" />
@@ -9288,149 +9288,149 @@
       <Piece id="crpg_military_fork_handle_h3" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_war_spear_v1_h0" name="{=rhWOdhjr}Highland Marshal's Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_highland_war_spear_v2_h0" name="{=rhWOdhjr}Highland Marshal's Spear" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_highland_war_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_guard_h0" Type="Guard" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_handle_h0" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_war_spear_v1_h1" name="{=rhWOdhjr}Highland Marshal's Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_highland_war_spear_v2_h1" name="{=rhWOdhjr}Highland Marshal's Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_highland_war_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_guard_h1" Type="Guard" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_handle_h1" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_war_spear_v1_h2" name="{=rhWOdhjr}Highland Marshal's Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_highland_war_spear_v2_h2" name="{=rhWOdhjr}Highland Marshal's Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_highland_war_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_guard_h2" Type="Guard" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_handle_h2" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_highland_war_spear_v1_h3" name="{=rhWOdhjr}Highland Marshal's Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
+  <CraftedItem id="crpg_highland_war_spear_v2_h3" name="{=rhWOdhjr}Highland Marshal's Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.battania" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_highland_war_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_guard_h3" Type="Guard" scale_factor="90" />
       <Piece id="crpg_highland_war_spear_handle_h3" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h0" name="{=Vyw5KNxR}Short Militia Spear" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v2_h0" name="{=Vyw5KNxR}Short Militia Spear" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h1" name="{=Vyw5KNxR}Short Militia Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v2_h1" name="{=Vyw5KNxR}Short Militia Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h2" name="{=Vyw5KNxR}Short Militia Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v2_h2" name="{=Vyw5KNxR}Short Militia Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_militia_spear_v1_h3" name="{=Vyw5KNxR}Short Militia Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
+  <CraftedItem id="crpg_short_militia_spear_v2_h3" name="{=Vyw5KNxR}Short Militia Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.empire" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_militia_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_short_militia_spear_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_raider_spear_v2_h0" name="{=RzLZHrYT}Vanguard's Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_short_raider_spear_v3_h0" name="{=RzLZHrYT}Vanguard's Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_raider_spear_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_short_raider_spear_handle_h0" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_raider_spear_v2_h1" name="{=RzLZHrYT}Vanguard's Short Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_short_raider_spear_v3_h1" name="{=RzLZHrYT}Vanguard's Short Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_raider_spear_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_short_raider_spear_handle_h1" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_raider_spear_v2_h2" name="{=RzLZHrYT}Vanguard's Short Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_short_raider_spear_v3_h2" name="{=RzLZHrYT}Vanguard's Short Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_raider_spear_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_short_raider_spear_handle_h2" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_raider_spear_v2_h3" name="{=RzLZHrYT}Vanguard's Short Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
+  <CraftedItem id="crpg_short_raider_spear_v3_h3" name="{=RzLZHrYT}Vanguard's Short Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.sturgia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_short_raider_spear_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_short_raider_spear_handle_h3" Type="Handle" scale_factor="80" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_spear_v1_h0" name="{=yCvBx27Z}Jagged Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_spear_v2_h0" name="{=yCvBx27Z}Jagged Spear" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_jagged_spear_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_jagged_spear_handle_h0" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_spear_v1_h1" name="{=yCvBx27Z}Jagged Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_spear_v2_h1" name="{=yCvBx27Z}Jagged Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_jagged_spear_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_jagged_spear_handle_h1" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_spear_v1_h2" name="{=yCvBx27Z}Jagged Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_spear_v2_h2" name="{=yCvBx27Z}Jagged Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_jagged_spear_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_jagged_spear_handle_h2" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_jagged_spear_v1_h3" name="{=yCvBx27Z}Jagged Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
+  <CraftedItem id="crpg_jagged_spear_v2_h3" name="{=yCvBx27Z}Jagged Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.aserai" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_jagged_spear_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_jagged_spear_handle_h3" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h0" name="{=bue69aD4}Simple Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h0" name="{=bue69aD4}Simple Short Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_short_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_short_spear_handle_h0" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h1" name="{=bue69aD4}Simple Short Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h1" name="{=bue69aD4}Simple Short Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_short_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_short_spear_handle_h1" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h2" name="{=bue69aD4}Simple Short Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h2" name="{=bue69aD4}Simple Short Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_short_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_short_spear_handle_h2" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_short_spear_v1_h3" name="{=bue69aD4}Simple Short Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_short_spear_v2_h3" name="{=bue69aD4}Simple Short Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_short_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_short_spear_handle_h3" Type="Handle" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_commoner_spear_v1_h0" name="{=hyq1zBg5}Noble Hunting Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_commoner_spear_v2_h0" name="{=hyq1zBg5}Noble Hunting Spear" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_commoner_spear_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_commoner_spear_handle_h0" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_commoner_spear_v1_h1" name="{=hyq1zBg5}Noble Hunting Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_commoner_spear_v2_h1" name="{=hyq1zBg5}Noble Hunting Spear +1" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_commoner_spear_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_commoner_spear_handle_h1" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_commoner_spear_v1_h2" name="{=hyq1zBg5}Noble Hunting Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_commoner_spear_v2_h2" name="{=hyq1zBg5}Noble Hunting Spear +2" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_commoner_spear_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_commoner_spear_handle_h2" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_simple_commoner_spear_v1_h3" name="{=hyq1zBg5}Noble Hunting Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
+  <CraftedItem id="crpg_simple_commoner_spear_v2_h3" name="{=hyq1zBg5}Noble Hunting Spear +3" crafting_template="crpg_Spear4DMode" culture="Culture.vlandia" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_simple_commoner_spear_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_simple_commoner_spear_handle_h3" Type="Handle" scale_factor="85" />
@@ -9748,25 +9748,25 @@
       <Piece id="crpg_woodsman_two_handed_axe_handle_h3" Type="Handle" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_v2_h0" name="{=Diggles}Steel Round Axe" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v3_h0" name="{=Diggles}Steel Round Axe" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h0" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_v2_h1" name="{=Diggles}Steel Round Axe +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v3_h1" name="{=Diggles}Steel Round Axe +1" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h1" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_v2_h2" name="{=Diggles}Steel Round Axe +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v3_h2" name="{=Diggles}Steel Round Axe +2" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h2" Type="Handle" scale_factor="91" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_steel_round_axe_v2_h3" name="{=Diggles}Steel Round Axe +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
+  <CraftedItem id="crpg_steel_round_axe_v3_h3" name="{=Diggles}Steel Round Axe +3" crafting_template="crpg_Mace" culture="Culture.battania" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_steel_round_axe_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_steel_round_axe_handle_h3" Type="Handle" scale_factor="91" />
@@ -9892,25 +9892,25 @@
       <Piece id="crpg_steel_pillager_axe_handle_h3" Type="Handle" scale_factor="124" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v3_h0" name="{=Diggles}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v4_h0" name="{=Diggles}Knightly Spiked Battle Axe" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h0" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v3_h1" name="{=Diggles}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v4_h1" name="{=Diggles}Knightly Spiked Battle Axe +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h1" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v3_h2" name="{=Diggles}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v4_h2" name="{=Diggles}Knightly Spiked Battle Axe +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h2" Type="Handle" scale_factor="135" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knightly_spiked_battle_axe_v3_h3" name="{=Diggles}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
+  <CraftedItem id="crpg_knightly_spiked_battle_axe_v4_h3" name="{=Diggles}Knightly Spiked Battle Axe +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_knightly_spiked_battle_axe_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_knightly_spiked_battle_axe_handle_h3" Type="Handle" scale_factor="135" />
@@ -10396,105 +10396,105 @@
       <Piece id="crpg_black_heart_axe_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v1_h0" name="{=KRuZuMFI}Judgement" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v2_h0" name="{=KRuZuMFI}Judgement" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h0" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h0" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v1_h1" name="{=KRuZuMFI}Judgement +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v2_h1" name="{=KRuZuMFI}Judgement +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h1" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h1" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v1_h2" name="{=KRuZuMFI}Judgement +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v2_h2" name="{=KRuZuMFI}Judgement +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h2" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h2" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_judgement_v1_h3" name="{=KRuZuMFI}Judgement +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_judgement_v2_h3" name="{=KRuZuMFI}Judgement +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_judgement_blade_h3" Type="Blade" scale_factor="155" />
       <Piece id="crpg_judgement_handle_h3" Type="Handle" scale_factor="123" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v1_h0" name="{=BYPhysbH}Knight's Fall" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v2_h0" name="{=BYPhysbH}Knight's Fall" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h0" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h0" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v1_h1" name="{=BYPhysbH}Knight's Fall +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v2_h1" name="{=BYPhysbH}Knight's Fall +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h1" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h1" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v1_h2" name="{=BYPhysbH}Knight's Fall +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v2_h2" name="{=BYPhysbH}Knight's Fall +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h2" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h2" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knights_fall_v1_h3" name="{=BYPhysbH}Knight's Fall +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_knights_fall_v2_h3" name="{=BYPhysbH}Knight's Fall +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_knights_fall_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_knights_fall_handle_h3" Type="Handle" scale_factor="163" />
       <Piece id="crpg_knights_fall_pommel_h3" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v1_h0" name="{=WASZXuec}Militia Pernach" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v2_h0" name="{=WASZXuec}Militia Pernach" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h0" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h0" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v1_h1" name="{=WASZXuec}Militia Pernach +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v2_h1" name="{=WASZXuec}Militia Pernach +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h1" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h1" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v1_h2" name="{=WASZXuec}Militia Pernach +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v2_h2" name="{=WASZXuec}Militia Pernach +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h2" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h2" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_militia_pernach_v1_h3" name="{=WASZXuec}Militia Pernach +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_militia_pernach_v2_h3" name="{=WASZXuec}Militia Pernach +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_militia_pernach_blade_h3" Type="Blade" scale_factor="137" />
       <Piece id="crpg_militia_pernach_handle_h3" Type="Handle" scale_factor="142" />
       <Piece id="crpg_militia_pernach_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v1_h0" name="{=mzvtFPPi}Heavy Flanged Mace" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v2_h0" name="{=mzvtFPPi}Heavy Flanged Mace" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h0" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v1_h1" name="{=mzvtFPPi}Heavy Flanged Mace +1" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v2_h1" name="{=mzvtFPPi}Heavy Flanged Mace +1" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h1" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v1_h2" name="{=mzvtFPPi}Heavy Flanged Mace +2" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v2_h2" name="{=mzvtFPPi}Heavy Flanged Mace +2" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h2" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_heavy_flanged_mace_v1_h3" name="{=mzvtFPPi}Heavy Flanged Mace +3" crafting_template="crpg_Mace" is_merchandise="false">
+  <CraftedItem id="crpg_heavy_flanged_mace_v2_h3" name="{=mzvtFPPi}Heavy Flanged Mace +3" crafting_template="crpg_Mace" is_merchandise="false">
     <Pieces>
       <Piece id="crpg_heavy_flanged_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_heavy_flanged_mace_handle_h3" Type="Handle" scale_factor="95" />
@@ -10692,7 +10692,7 @@
       <Piece id="crpg_winds_fury_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <Item multiplayer_item="false" id="crpg_push_fork_v1_h0" name="{=l69aXkKH}Push Fork" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
+  <Item multiplayer_item="false" id="crpg_push_fork_v2_h0" name="{=l69aXkKH}Push Fork" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
     <ItemComponent>
       <Weapon weapon_class="TwoHandedPolearm" weapon_balance="100" thrust_speed="56" speed_rating="70" physics_material="wood_weapon" weapon_length="200" swing_damage="1" thrust_damage="15" swing_damage_type="Blunt" thrust_damage_type="Blunt" item_usage="polearm_block_thrust">
         <WeaponFlags MeleeWeapon="true" PenaltyWithShield="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" WideGrip="true" />
@@ -10700,7 +10700,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" DropOnWeaponChange="true" DoNotScaleBodyAccordingToWeaponLength="true" QuickFadeOut="true" />
   </Item>
-  <Item multiplayer_item="false" id="crpg_push_fork_v1_h1" name="{=l69aXkKH}Push Fork +1" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
+  <Item multiplayer_item="false" id="crpg_push_fork_v2_h1" name="{=l69aXkKH}Push Fork +1" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
     <ItemComponent>
       <Weapon weapon_class="TwoHandedPolearm" weapon_balance="100" thrust_speed="56" speed_rating="70" physics_material="wood_weapon" weapon_length="200" swing_damage="1" thrust_damage="15" swing_damage_type="Blunt" thrust_damage_type="Blunt" item_usage="polearm_block_thrust">
         <WeaponFlags MeleeWeapon="true" PenaltyWithShield="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" WideGrip="true" />
@@ -10708,7 +10708,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" DropOnWeaponChange="true" DoNotScaleBodyAccordingToWeaponLength="true" QuickFadeOut="true" />
   </Item>
-  <Item multiplayer_item="false" id="crpg_push_fork_v1_h2" name="{=l69aXkKH}Push Fork +2" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
+  <Item multiplayer_item="false" id="crpg_push_fork_v2_h2" name="{=l69aXkKH}Push Fork +2" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
     <ItemComponent>
       <Weapon weapon_class="TwoHandedPolearm" weapon_balance="100" thrust_speed="56" speed_rating="70" physics_material="wood_weapon" weapon_length="200" swing_damage="1" thrust_damage="15" swing_damage_type="Blunt" thrust_damage_type="Blunt" item_usage="polearm_block_thrust">
         <WeaponFlags MeleeWeapon="true" PenaltyWithShield="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" WideGrip="true" />
@@ -10716,7 +10716,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" DropOnWeaponChange="true" DoNotScaleBodyAccordingToWeaponLength="true" QuickFadeOut="true" />
   </Item>
-  <Item multiplayer_item="false" id="crpg_push_fork_v1_h3" name="{=l69aXkKH}Push Fork +3" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
+  <Item multiplayer_item="false" id="crpg_push_fork_v2_h3" name="{=l69aXkKH}Push Fork +3" is_merchandise="false" body_name="bo_push_fork" recalculate_body="true" mesh="push_fork" subtype="two_handed_wpn" weight="2" difficulty="0" appearance="0.1" Type="Polearm" item_holsters="polearm_back:polearm_back_2">
     <ItemComponent>
       <Weapon weapon_class="TwoHandedPolearm" weapon_balance="100" thrust_speed="56" speed_rating="70" physics_material="wood_weapon" weapon_length="200" swing_damage="1" thrust_damage="15" swing_damage_type="Blunt" thrust_damage_type="Blunt" item_usage="polearm_block_thrust">
         <WeaponFlags MeleeWeapon="true" PenaltyWithShield="true" NotUsableWithOneHand="true" TwoHandIdleOnMount="true" WideGrip="true" />
@@ -10724,7 +10724,7 @@
     </ItemComponent>
     <Flags WoodenParry="true" DropOnWeaponChange="true" DoNotScaleBodyAccordingToWeaponLength="true" QuickFadeOut="true" />
   </Item>
-  <CraftedItem id="crpg_bo_staff_v2_h0" name="{=kaikaikai}Bo Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bo_staff_v3_h0" name="{=kaikaikai}Bo Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bo_staff_blade_h0" Type="Blade" scale_factor="1" />
       <Piece id="crpg_bo_staff_guard_h0" Type="Guard" />
@@ -10732,7 +10732,7 @@
       <Piece id="crpg_bo_staff_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bo_staff_v2_h1" name="{=kaikaikai}Bo Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bo_staff_v3_h1" name="{=kaikaikai}Bo Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bo_staff_blade_h1" Type="Blade" scale_factor="1" />
       <Piece id="crpg_bo_staff_guard_h1" Type="Guard" />
@@ -10740,7 +10740,7 @@
       <Piece id="crpg_bo_staff_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bo_staff_v2_h2" name="{=kaikaikai}Bo Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bo_staff_v3_h2" name="{=kaikaikai}Bo Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bo_staff_blade_h2" Type="Blade" scale_factor="1" />
       <Piece id="crpg_bo_staff_guard_h2" Type="Guard" />
@@ -10748,7 +10748,7 @@
       <Piece id="crpg_bo_staff_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bo_staff_v2_h3" name="{=kaikaikai}Bo Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bo_staff_v3_h3" name="{=kaikaikai}Bo Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bo_staff_blade_h3" Type="Blade" scale_factor="1" />
       <Piece id="crpg_bo_staff_guard_h3" Type="Guard" />
@@ -10756,7 +10756,7 @@
       <Piece id="crpg_bo_staff_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v2_h0" name="{=kaikaikai}Bludgeon Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v3_h0" name="{=kaikaikai}Bludgeon Staff" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h0" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h0" Type="Guard" />
@@ -10764,7 +10764,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v2_h1" name="{=kaikaikai}Bludgeon Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v3_h1" name="{=kaikaikai}Bludgeon Staff +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h1" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h1" Type="Guard" />
@@ -10772,7 +10772,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v2_h2" name="{=kaikaikai}Bludgeon Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v3_h2" name="{=kaikaikai}Bludgeon Staff +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h2" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h2" Type="Guard" />
@@ -10780,7 +10780,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_bludgeon_staff_v2_h3" name="{=kaikaikai}Bludgeon Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_bludgeon_staff_v3_h3" name="{=kaikaikai}Bludgeon Staff +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_bludgeon_staff_blade_h3" Type="Blade" />
       <Piece id="crpg_bludgeon_staff_guard_h3" Type="Guard" />
@@ -10788,7 +10788,7 @@
       <Piece id="crpg_bludgeon_staff_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_twohander_v2_h0" name="{=bt0uFefo}Wooden Twohander" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_twohander_v3_h0" name="{=bt0uFefo}Wooden Twohander" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_twohander_blade_h0" Type="Blade" scale_factor="128" />
       <Piece id="crpg_wooden_twohander_guard_h0" Type="Guard" />
@@ -10796,7 +10796,7 @@
       <Piece id="crpg_wooden_twohander_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_twohander_v2_h1" name="{=bt0uFefo}Wooden Twohander +1" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_twohander_v3_h1" name="{=bt0uFefo}Wooden Twohander +1" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_twohander_blade_h1" Type="Blade" scale_factor="128" />
       <Piece id="crpg_wooden_twohander_guard_h1" Type="Guard" />
@@ -10804,7 +10804,7 @@
       <Piece id="crpg_wooden_twohander_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_twohander_v2_h2" name="{=bt0uFefo}Wooden Twohander +2" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_twohander_v3_h2" name="{=bt0uFefo}Wooden Twohander +2" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_twohander_blade_h2" Type="Blade" scale_factor="128" />
       <Piece id="crpg_wooden_twohander_guard_h2" Type="Guard" />
@@ -10812,7 +10812,7 @@
       <Piece id="crpg_wooden_twohander_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_twohander_v2_h3" name="{=bt0uFefo}Wooden Twohander +3" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_twohander_v3_h3" name="{=bt0uFefo}Wooden Twohander +3" is_merchandise="false" crafting_template="crpg_TwoHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_twohander_blade_h3" Type="Blade" scale_factor="128" />
       <Piece id="crpg_wooden_twohander_guard_h3" Type="Guard" />
@@ -10820,7 +10820,7 @@
       <Piece id="crpg_wooden_twohander_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_sword_v2_h0" name="{=1HWRwbwT}Wooden Sword" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_sword_v3_h0" name="{=1HWRwbwT}Wooden Sword" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_sword_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_wooden_sword_guard_h0" Type="Guard" scale_factor="100" />
@@ -10828,7 +10828,7 @@
       <Piece id="crpg_wooden_sword_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_sword_v2_h1" name="{=1HWRwbwT}Wooden Sword +1" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_sword_v3_h1" name="{=1HWRwbwT}Wooden Sword +1" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_sword_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_wooden_sword_guard_h1" Type="Guard" scale_factor="100" />
@@ -10836,7 +10836,7 @@
       <Piece id="crpg_wooden_sword_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_sword_v2_h2" name="{=1HWRwbwT}Wooden Sword +2" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_sword_v3_h2" name="{=1HWRwbwT}Wooden Sword +2" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_sword_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_wooden_sword_guard_h2" Type="Guard" scale_factor="100" />
@@ -10844,7 +10844,7 @@
       <Piece id="crpg_wooden_sword_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_sword_v2_h3" name="{=1HWRwbwT}Wooden Sword +3" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
+  <CraftedItem id="crpg_wooden_sword_v3_h3" name="{=1HWRwbwT}Wooden Sword +3" is_merchandise="false" crafting_template="crpg_OneHandedSword" has_modifier="false">
     <Pieces>
       <Piece id="crpg_wooden_sword_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_wooden_sword_guard_h3" Type="Guard" scale_factor="100" />
@@ -11076,77 +11076,77 @@
       <Piece id="crpg_hoe_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_hammer_v1_h0" name="{=beVFwINO}Wooden Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_wooden_hammer_v2_h0" name="{=beVFwINO}Wooden Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_wooden_hammer_blade_h0" Type="Blade" />
       <Piece id="crpg_wooden_hammer_handle_h0" Type="Handle" />
       <Piece id="crpg_wooden_hammer_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_hammer_v1_h1" name="{=beVFwINO}Wooden Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_wooden_hammer_v2_h1" name="{=beVFwINO}Wooden Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_wooden_hammer_blade_h1" Type="Blade" />
       <Piece id="crpg_wooden_hammer_handle_h1" Type="Handle" />
       <Piece id="crpg_wooden_hammer_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_hammer_v1_h2" name="{=beVFwINO}Wooden Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_wooden_hammer_v2_h2" name="{=beVFwINO}Wooden Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_wooden_hammer_blade_h2" Type="Blade" />
       <Piece id="crpg_wooden_hammer_handle_h2" Type="Handle" />
       <Piece id="crpg_wooden_hammer_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_wooden_hammer_v1_h3" name="{=beVFwINO}Wooden Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_wooden_hammer_v2_h3" name="{=beVFwINO}Wooden Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_wooden_hammer_blade_h3" Type="Blade" />
       <Piece id="crpg_wooden_hammer_handle_h3" Type="Handle" />
       <Piece id="crpg_wooden_hammer_pommel_h3" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v1_h0" name="{=6WcZ5Tr0}Blacksmith Warhammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v2_h0" name="{=6WcZ5Tr0}Blacksmith Warhammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h0" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v1_h1" name="{=6WcZ5Tr0}Blacksmith Warhammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v2_h1" name="{=6WcZ5Tr0}Blacksmith Warhammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h1" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v1_h2" name="{=6WcZ5Tr0}Blacksmith Warhammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v2_h2" name="{=6WcZ5Tr0}Blacksmith Warhammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h2" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_warhammer_v1_h3" name="{=6WcZ5Tr0}Blacksmith Warhammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_warhammer_v2_h3" name="{=6WcZ5Tr0}Blacksmith Warhammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_warhammer_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_blacksmith_warhammer_handle_h3" Type="Handle" scale_factor="145" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v2_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v3_h0" name="{=6WcZ5Tr0}Blacksmith Hammer" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h0" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h0" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v2_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v3_h1" name="{=6WcZ5Tr0}Blacksmith Hammer +1" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h1" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h1" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v2_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v3_h2" name="{=6WcZ5Tr0}Blacksmith Hammer +2" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h2" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h2" Type="Handle" scale_factor="125" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_blacksmith_hammer_v2_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_blacksmith_hammer_v3_h3" name="{=6WcZ5Tr0}Blacksmith Hammer +3" crafting_template="crpg_Mace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_blacksmith_hammer_blade_h3" Type="Blade" scale_factor="110" />
       <Piece id="crpg_blacksmith_hammer_handle_h3" Type="Handle" scale_factor="125" />
@@ -11224,49 +11224,49 @@
       <Piece id="crpg_pickaxe_handle_h3" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sledgehammer_v1_h0" name="{=gYpNILVC}Sledgehammer" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_sledgehammer_v2_h0" name="{=gYpNILVC}Sledgehammer" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_sledgehammer_blade_h0" Type="Blade" scale_factor="102" />
       <Piece id="crpg_sledgehammer_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sledgehammer_v1_h1" name="{=gYpNILVC}Sledgehammer +1" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_sledgehammer_v2_h1" name="{=gYpNILVC}Sledgehammer +1" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_sledgehammer_blade_h1" Type="Blade" scale_factor="102" />
       <Piece id="crpg_sledgehammer_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sledgehammer_v1_h2" name="{=gYpNILVC}Sledgehammer +2" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_sledgehammer_v2_h2" name="{=gYpNILVC}Sledgehammer +2" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_sledgehammer_blade_h2" Type="Blade" scale_factor="102" />
       <Piece id="crpg_sledgehammer_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_sledgehammer_v1_h3" name="{=gYpNILVC}Sledgehammer +3" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_sledgehammer_v2_h3" name="{=gYpNILVC}Sledgehammer +3" crafting_template="crpg_TwoHandedMace" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_sledgehammer_blade_h3" Type="Blade" scale_factor="102" />
       <Piece id="crpg_sledgehammer_handle_h3" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_makeshift_sledgehammer_v1_h0" name="{=nTc20R1R}Makeshift Sledgehammer" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_makeshift_sledgehammer_v2_h0" name="{=nTc20R1R}Makeshift Sledgehammer" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_makeshift_sledgehammer_blade_h0" Type="Blade" scale_factor="90" />
       <Piece id="crpg_makeshift_sledgehammer_handle_h0" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_makeshift_sledgehammer_v1_h1" name="{=nTc20R1R}Makeshift Sledgehammer +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_makeshift_sledgehammer_v2_h1" name="{=nTc20R1R}Makeshift Sledgehammer +1" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_makeshift_sledgehammer_blade_h1" Type="Blade" scale_factor="90" />
       <Piece id="crpg_makeshift_sledgehammer_handle_h1" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_makeshift_sledgehammer_v1_h2" name="{=nTc20R1R}Makeshift Sledgehammer +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_makeshift_sledgehammer_v2_h2" name="{=nTc20R1R}Makeshift Sledgehammer +2" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_makeshift_sledgehammer_blade_h2" Type="Blade" scale_factor="90" />
       <Piece id="crpg_makeshift_sledgehammer_handle_h2" Type="Handle" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_makeshift_sledgehammer_v1_h3" name="{=nTc20R1R}Makeshift Sledgehammer +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_makeshift_sledgehammer_v2_h3" name="{=nTc20R1R}Makeshift Sledgehammer +3" crafting_template="crpg_TwoHandedMace" is_merchandise="false" culture="Culture.battania" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_makeshift_sledgehammer_blade_h3" Type="Blade" scale_factor="90" />
       <Piece id="crpg_makeshift_sledgehammer_handle_h3" Type="Handle" scale_factor="110" />
@@ -11592,25 +11592,25 @@
       <Piece id="crpg_ancientlongsword_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_le_bonke_v1_h0" name="{=Diggles}Norse Battle Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_le_bonke_v2_h0" name="{=Diggles}Norse Battle Hammer" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_meowhammer_head_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_meowhammer_handle_h0" Type="Handle" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_le_bonke_v1_h1" name="{=Diggles}Norse Battle Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_le_bonke_v2_h1" name="{=Diggles}Norse Battle Hammer +1" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_meowhammer_head_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_meowhammer_handle_h1" Type="Handle" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_le_bonke_v1_h2" name="{=Diggles}Norse Battle Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_le_bonke_v2_h2" name="{=Diggles}Norse Battle Hammer +2" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_meowhammer_head_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_meowhammer_handle_h2" Type="Handle" scale_factor="109" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_le_bonke_v1_h3" name="{=Diggles}Norse Battle Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_le_bonke_v2_h3" name="{=Diggles}Norse Battle Hammer +3" crafting_template="crpg_TwoHandedMace" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_meowhammer_head_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_meowhammer_handle_h3" Type="Handle" scale_factor="109" />
@@ -11680,257 +11680,257 @@
       <Piece id="crpg_rondel_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v1_h0" name="{=Telford}Long Cavalry Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v2_h0" name="{=Telford}Long Cavalry Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h0" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h0" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v1_h1" name="{=Telford}Long Cavalry Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v2_h1" name="{=Telford}Long Cavalry Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h1" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h1" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v1_h2" name="{=Telford}Long Cavalry Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v2_h2" name="{=Telford}Long Cavalry Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h2" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h2" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_cavalry_mace_v1_h3" name="{=Telford}Long Cavalry Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_long_cavalry_mace_v2_h3" name="{=Telford}Long Cavalry Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_cavalry_mace_blade_h3" Type="Blade" scale_factor="120" />
       <Piece id="crpg_long_cavalry_mace_handle_h3" Type="Handle" scale_factor="152" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v1_h0" name="{=Telford}Long Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v2_h0" name="{=Telford}Long Pernach" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h0" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v1_h1" name="{=Telford}Long Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v2_h1" name="{=Telford}Long Pernach +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h1" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v1_h2" name="{=Telford}Long Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v2_h2" name="{=Telford}Long Pernach +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h2" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_long_pernach_v1_h3" name="{=Telford}Long Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_long_pernach_v2_h3" name="{=Telford}Long Pernach +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_long_pernach_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_long_pernach_handle_h3" Type="Handle" scale_factor="119" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v1_h0" name="{=Telford}Persian Steel Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v2_h0" name="{=Telford}Persian Steel Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h0" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h0" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h0" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v1_h1" name="{=Telford}Persian Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v2_h1" name="{=Telford}Persian Steel Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h1" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h1" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h1" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v1_h2" name="{=Telford}Persian Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v2_h2" name="{=Telford}Persian Steel Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h2" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h2" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h2" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_persian_steel_mace_v1_h3" name="{=Telford}Persian Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_persian_steel_mace_v2_h3" name="{=Telford}Persian Steel Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_persian_steel_mace_blade_h3" Type="Blade" scale_factor="78" />
       <Piece id="crpg_persian_steel_mace_handle_h3" Type="Handle" scale_factor="116" />
       <Piece id="crpg_persian_steel_mace_pommel_h3" Type="Pommel" scale_factor="59" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v1_h0" name="{=JM8Mjfa0}Flanged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v2_h0" name="{=JM8Mjfa0}Flanged Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h0" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h0" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h0" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v1_h1" name="{=JM8Mjfa0}Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v2_h1" name="{=JM8Mjfa0}Flanged Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h1" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h1" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h1" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v1_h2" name="{=JM8Mjfa0}Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v2_h2" name="{=JM8Mjfa0}Flanged Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h2" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h2" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h2" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_mace_v1_h3" name="{=JM8Mjfa0}Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_mace_v2_h3" name="{=JM8Mjfa0}Flanged Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_mace_blade_h3" Type="Blade" scale_factor="75" />
       <Piece id="crpg_flanged_mace_handle_h3" Type="Handle" scale_factor="110" />
       <Piece id="crpg_flanged_mace_pommel_h3" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v1_h0" name="{=fz23ajFz}Arabian Mace" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v2_h0" name="{=fz23ajFz}Arabian Mace" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h0" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h0" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v1_h1" name="{=fz23ajFz}Arabian Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v2_h1" name="{=fz23ajFz}Arabian Mace +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h1" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h1" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v1_h2" name="{=fz23ajFz}Arabian Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v2_h2" name="{=fz23ajFz}Arabian Mace +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h2" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h2" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_arabian_mace_v1_h3" name="{=fz23ajFz}Arabian Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_arabian_mace_v2_h3" name="{=fz23ajFz}Arabian Mace +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_arabian_mace_blade_h3" Type="Blade" scale_factor="130" />
       <Piece id="crpg_arabian_mace_handle_h3" Type="Handle" scale_factor="111" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v1_h0" name="{=JM8Mjfa0}Flanged Ball Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v2_h0" name="{=JM8Mjfa0}Flanged Ball Mace" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h0" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h0" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v1_h1" name="{=JM8Mjfa0}Flanged Ball Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v2_h1" name="{=JM8Mjfa0}Flanged Ball Mace +1" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h1" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h1" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v1_h2" name="{=JM8Mjfa0}Flanged Ball Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v2_h2" name="{=JM8Mjfa0}Flanged Ball Mace +2" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h2" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h2" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_flanged_ball_mace_v1_h3" name="{=JM8Mjfa0}Flanged Ball Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
+  <CraftedItem id="crpg_flanged_ball_mace_v2_h3" name="{=JM8Mjfa0}Flanged Ball Mace +3" crafting_template="crpg_Mace" culture="Culture.aserai" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_flanged_ball_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_flanged_ball_mace_handle_h3" Type="Handle" scale_factor="109" />
       <Piece id="crpg_flanged_ball_mace_pommel_h3" Type="Pommel" scale_factor="90" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v1_h0" name="{=Telford}Byzantine Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v2_h0" name="{=Telford}Byzantine Mace" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v1_h1" name="{=Telford}Byzantine Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v2_h1" name="{=Telford}Byzantine Mace +1" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v1_h2" name="{=Telford}Byzantine Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v2_h2" name="{=Telford}Byzantine Mace +2" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_byzantine_mace_v1_h3" name="{=Telford}Byzantine Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
+  <CraftedItem id="crpg_byzantine_mace_v2_h3" name="{=Telford}Byzantine Mace +3" crafting_template="crpg_Mace" culture="Culture.empire" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_byzantine_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_byzantine_mace_handle_h3" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v2_h0" name="{=8pnCvnFR}Light Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v3_h0" name="{=8pnCvnFR}Light Shestopyor" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h0" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h0" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h0" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v2_h1" name="{=8pnCvnFR}Light Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v3_h1" name="{=8pnCvnFR}Light Shestopyor +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h1" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h1" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h1" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v2_h2" name="{=8pnCvnFR}Light Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v3_h2" name="{=8pnCvnFR}Light Shestopyor +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h2" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h2" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h2" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_light_shestopyor_v2_h3" name="{=8pnCvnFR}Light Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_light_shestopyor_v3_h3" name="{=8pnCvnFR}Light Shestopyor +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_light_shestopyor_blade_h3" Type="Blade" scale_factor="115" />
       <Piece id="crpg_light_shestopyor_handle_h3" Type="Handle" scale_factor="107" />
       <Piece id="crpg_light_shestopyor_pommel_h3" Type="Pommel" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v1_h0" name="{=Telford}Knobbed Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v2_h0" name="{=Telford}Knobbed Mace" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h0" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v1_h1" name="{=Telford}Knobbed Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v2_h1" name="{=Telford}Knobbed Mace +1" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h1" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v1_h2" name="{=Telford}Knobbed Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v2_h2" name="{=Telford}Knobbed Mace +2" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h2" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_knobbed_mace_v1_h3" name="{=Telford}Knobbed Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
+  <CraftedItem id="crpg_knobbed_mace_v2_h3" name="{=Telford}Knobbed Mace +3" crafting_template="crpg_Mace" culture="Culture.khuzait" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_knobbed_mace_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_knobbed_mace_handle_h3" Type="Handle" scale_factor="82" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v2_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v3_h0" name="{=dSTxsYsh}Short Western Mace" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h0" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v2_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v3_h1" name="{=dSTxsYsh}Short Western Mace +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h1" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v2_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v3_h2" name="{=dSTxsYsh}Short Western Mace +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h2" Type="Handle" scale_factor="105" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_short_western_mace_v2_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_short_western_mace_v3_h3" name="{=dSTxsYsh}Short Western Mace +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_short_western_mace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_short_western_mace_handle_h3" Type="Handle" scale_factor="105" />
@@ -12032,25 +12032,25 @@
       <Piece id="crpg_gladius_republican_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tetsubo_v1_h0" name="{=Diggles}Tetsubo" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_tetsubo_v2_h0" name="{=Diggles}Tetsubo" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_tetsubo_head_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tetsubo_handle_h0" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tetsubo_v1_h1" name="{=Diggles}Tetsubo +1" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_tetsubo_v2_h1" name="{=Diggles}Tetsubo +1" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_tetsubo_head_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tetsubo_handle_h1" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tetsubo_v1_h2" name="{=Diggles}Tetsubo +2" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_tetsubo_v2_h2" name="{=Diggles}Tetsubo +2" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_tetsubo_head_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tetsubo_handle_h2" Type="Handle" scale_factor="120" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_tetsubo_v1_h3" name="{=Diggles}Tetsubo +3" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
+  <CraftedItem id="crpg_tetsubo_v2_h3" name="{=Diggles}Tetsubo +3" crafting_template="crpg_TwoHandedMace" culture="Culture.khuzait" modifier_group="cheap_weapon">
     <Pieces>
       <Piece id="crpg_tetsubo_head_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_tetsubo_handle_h3" Type="Handle" scale_factor="120" />
@@ -12440,25 +12440,25 @@
       <Piece id="crpg_rondel_reverse_pommel_h3" Type="Pommel" scale_factor="110" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v1_h0" name="{=}Horseman's Pick" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v2_h0" name="{=}Horseman's Pick" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemanspick_handle_h0" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v1_h1" name="{=}Horseman's Pick +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v2_h1" name="{=}Horseman's Pick +1" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemanspick_handle_h1" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v1_h2" name="{=}Horseman's Pick +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v2_h2" name="{=}Horseman's Pick +2" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemanspick_handle_h2" Type="Handle" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemanspick_v1_h3" name="{=}Horseman's Pick +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_horsemanspick_v2_h3" name="{=}Horseman's Pick +3" crafting_template="crpg_Mace" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_horsemanspick_head_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemanspick_handle_h3" Type="Handle" scale_factor="100" />
@@ -12612,49 +12612,49 @@
       <Piece id="crpg_zweihander_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v1_h0" name="{=}Steel Ball Mace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v2_h0" name="{=}Steel Ball Mace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h0" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h0" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v1_h1" name="{=}Steel Ball Mace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v2_h1" name="{=}Steel Ball Mace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h1" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h1" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v1_h2" name="{=}Steel Ball Mace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v2_h2" name="{=}Steel Ball Mace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h2" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h2" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_gada_v1_h3" name="{=}Steel Ball Mace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_gada_v2_h3" name="{=}Steel Ball Mace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_gada_blade_h3" Type="Blade" scale_factor="60" />
       <Piece id="crpg_onehanded_gada_handle_h3" Type="Handle" scale_factor="60" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v1_h0" name="{=}One-Handed Barmace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v2_h0" name="{=}One-Handed Barmace" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h0" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h0" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v1_h1" name="{=}One-Handed Barmace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v2_h1" name="{=}One-Handed Barmace +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h1" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h1" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v1_h2" name="{=}One-Handed Barmace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v2_h2" name="{=}One-Handed Barmace +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h2" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h2" Type="Handle" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_onehanded_barmace_v1_h3" name="{=}One-Handed Barmace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
+  <CraftedItem id="crpg_onehanded_barmace_v2_h3" name="{=}One-Handed Barmace +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.vlandia" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_onehanded_barmace_blade_h3" Type="Blade" scale_factor="95" />
       <Piece id="crpg_onehanded_barmace_handle_h3" Type="Handle" scale_factor="95" />
@@ -12844,7 +12844,7 @@
       <Piece id="crpg_jian_pommel_h3" Type="Pommel" scale_factor="85" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v3_h0" name="{=Yeldur}Iron Rod" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v4_h0" name="{=Yeldur}Iron Rod" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h0" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h0" Type="Guard" />
@@ -12852,7 +12852,7 @@
       <Piece id="crpg_ironrod_pommel_h0" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v3_h1" name="{=Yeldur}Iron Rod +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v4_h1" name="{=Yeldur}Iron Rod +1" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h1" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h1" Type="Guard" />
@@ -12860,7 +12860,7 @@
       <Piece id="crpg_ironrod_pommel_h1" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v3_h2" name="{=Yeldur}Iron Rod +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v4_h2" name="{=Yeldur}Iron Rod +2" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h2" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h2" Type="Guard" />
@@ -12868,7 +12868,7 @@
       <Piece id="crpg_ironrod_pommel_h2" Type="Pommel" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_ironrod_v3_h3" name="{=Yeldur}Iron Rod +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
+  <CraftedItem id="crpg_ironrod_v4_h3" name="{=Yeldur}Iron Rod +3" is_merchandise="false" crafting_template="crpg_TwoHandedPolearm" has_modifier="false">
     <Pieces>
       <Piece id="crpg_ironrod_blade_h3" Type="Blade" scale_factor="1" />
       <Piece id="crpg_ironrod_guard_h3" Type="Guard" />
@@ -13092,7 +13092,7 @@
       <Piece id="crpg_candycane_pole_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_2h_h0" name="{=BalanceMe}Candycane Twohanded Mace" crafting_template="crpg_TwoHandedMace">
+  <CraftedItem id="crpg_disabled_candycane_2h_v1_h0" name="{=BalanceMe}Candycane Twohanded Mace" crafting_template="crpg_TwoHandedMace">
     <Pieces>
       <Piece id="crpg_candycane_2h_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_2h_handle_h0" Type="Handle" scale_factor="100" />
@@ -13100,7 +13100,7 @@
       <Piece id="crpg_candycane_2h_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_2h_h1" name="{=BalanceMe}Candycane Twohanded Mace +1" crafting_template="crpg_TwoHandedMace">
+  <CraftedItem id="crpg_disabled_candycane_2h_v1_h1" name="{=BalanceMe}Candycane Twohanded Mace +1" crafting_template="crpg_TwoHandedMace">
     <Pieces>
       <Piece id="crpg_candycane_2h_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_2h_handle_h1" Type="Handle" scale_factor="100" />
@@ -13108,7 +13108,7 @@
       <Piece id="crpg_candycane_2h_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_2h_h2" name="{=BalanceMe}Candycane Twohanded Mace +2" crafting_template="crpg_TwoHandedMace">
+  <CraftedItem id="crpg_disabled_candycane_2h_v1_h2" name="{=BalanceMe}Candycane Twohanded Mace +2" crafting_template="crpg_TwoHandedMace">
     <Pieces>
       <Piece id="crpg_candycane_2h_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_2h_handle_h2" Type="Handle" scale_factor="100" />
@@ -13116,7 +13116,7 @@
       <Piece id="crpg_candycane_2h_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_2h_h3" name="{=BalanceMe}Candycane Twohanded Mace +3" crafting_template="crpg_TwoHandedMace">
+  <CraftedItem id="crpg_disabled_candycane_2h_v1_h3" name="{=BalanceMe}Candycane Twohanded Mace +3" crafting_template="crpg_TwoHandedMace">
     <Pieces>
       <Piece id="crpg_candycane_2h_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_2h_handle_h3" Type="Handle" scale_factor="100" />
@@ -13124,7 +13124,7 @@
       <Piece id="crpg_candycane_2h_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_1h_h0" name="{=BalanceMe}Candycane Onehanded Mace" crafting_template="crpg_Mace">
+  <CraftedItem id="crpg_disabled_candycane_1h_v1_h0" name="{=BalanceMe}Candycane Onehanded Mace" crafting_template="crpg_Mace">
     <Pieces>
       <Piece id="crpg_candycane_1h_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_1h_handle_h0" Type="Handle" scale_factor="100" />
@@ -13132,7 +13132,7 @@
       <Piece id="crpg_candycane_1h_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_1h_h1" name="{=BalanceMe}Candycane Onehanded Mace +1" crafting_template="crpg_Mace">
+  <CraftedItem id="crpg_disabled_candycane_1h_v1_h1" name="{=BalanceMe}Candycane Onehanded Mace +1" crafting_template="crpg_Mace">
     <Pieces>
       <Piece id="crpg_candycane_1h_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_1h_handle_h1" Type="Handle" scale_factor="100" />
@@ -13140,7 +13140,7 @@
       <Piece id="crpg_candycane_1h_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_1h_h2" name="{=BalanceMe}Candycane Onehanded Mace +2" crafting_template="crpg_Mace">
+  <CraftedItem id="crpg_disabled_candycane_1h_v1_h2" name="{=BalanceMe}Candycane Onehanded Mace +2" crafting_template="crpg_Mace">
     <Pieces>
       <Piece id="crpg_candycane_1h_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_1h_handle_h2" Type="Handle" scale_factor="100" />
@@ -13148,7 +13148,7 @@
       <Piece id="crpg_candycane_1h_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_candycane_1h_h3" name="{=BalanceMe}Candycane Onehanded Mace +3" crafting_template="crpg_Mace">
+  <CraftedItem id="crpg_disabled_candycane_1h_v1_h3" name="{=BalanceMe}Candycane Onehanded Mace +3" crafting_template="crpg_Mace">
     <Pieces>
       <Piece id="crpg_candycane_1h_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_candycane_1h_handle_h3" Type="Handle" scale_factor="100" />
@@ -13580,25 +13580,25 @@
       <Piece id="crpg_karabela_pommel_h3" Type="Pommel" scale_factor="95" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v1_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v2_h0" name="{=Salt}Great Long Axe" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h0" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h0" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v1_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v2_h1" name="{=Salt}Great Long Axe +1" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h1" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h1" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v1_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v2_h2" name="{=Salt}Great Long Axe +2" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h2" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h2" Type="Handle" scale_factor="165" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_greatlongaxe_v1_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
+  <CraftedItem id="crpg_greatlongaxe_v2_h3" name="{=Salt}Great Long Axe +3" crafting_template="crpg_TwoHandedPolearm" modifier_group="polearm">
     <Pieces>
       <Piece id="crpg_greatlongaxe_blade_h3" Type="Blade" scale_factor="125" />
       <Piece id="crpg_greatlongaxe_handle_h3" Type="Handle" scale_factor="165" />
@@ -13908,80 +13908,80 @@
       <Piece id="crpg_fabulousvoulge_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_h0" name="{=}Elder's Hammer" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v1_h0" name="{=}Elder's Hammer" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h0" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h0" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_h1" name="{=}Elder's Hammer +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v1_h1" name="{=}Elder's Hammer +1" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h1" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h1" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_h2" name="{=}Elder's Hammer +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v1_h2" name="{=}Elder's Hammer +2" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h2" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h2" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_smallhammer_h3" name="{=}Elder's Hammer +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
+  <CraftedItem id="crpg_smallhammer_v1_h3" name="{=}Elder's Hammer +3" crafting_template="crpg_Mace" is_merchandise="false" culture="Culture.battania">
     <Pieces>
       <Piece id="crpg_smallhammer_blade_h3" Type="Blade" scale_factor="140" />
       <Piece id="crpg_smallhammer_handle_h3" Type="Handle" scale_factor="140" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe_h0" name="{=BalanceMe}Horseman's Axe" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe_v1_h0" name="{=BalanceMe}Horseman's Axe" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe_h1" name="{=BalanceMe}Horseman's Axe +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe_v1_h1" name="{=BalanceMe}Horseman's Axe +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe_h2" name="{=BalanceMe}Horseman's Axe +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe_v1_h2" name="{=BalanceMe}Horseman's Axe +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe_h3" name="{=BalanceMe}Horseman's Axe +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe_v1_h3" name="{=BalanceMe}Horseman's Axe +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe2_h0" name="{=BalanceMe}Horseman's Axe" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe2_v1_h0" name="{=BalanceMe}Horseman's Axe" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe2_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe2_h1" name="{=BalanceMe}Horseman's Axe +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe2_v1_h1" name="{=BalanceMe}Horseman's Axe +1" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe2_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe2_h2" name="{=BalanceMe}Horseman's Axe +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe2_v1_h2" name="{=BalanceMe}Horseman's Axe +2" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe2_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_horsemansaxe2_h3" name="{=BalanceMe}Horseman's Axe +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
+  <CraftedItem id="crpg_horsemansaxe2_v1_h3" name="{=BalanceMe}Horseman's Axe +3" crafting_template="crpg_Mace" culture="Culture.sturgia" modifier_group="axe">
     <Pieces>
       <Piece id="crpg_horsemansaxe2_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_horsemansaxe2_handle_h3" Type="Handle" scale_factor="100" />
@@ -14276,56 +14276,56 @@
     </ItemComponent>
     <Flags />
   </Item>
-  <CraftedItem id="crpg_disabled_jamescross_h0" name="{=Yeldur}St. James Cross" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h0" name="{=Yeldur}St. James Cross" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_1h_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h1" name="{=Yeldur}St. James Cross +1" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h1" name="{=Yeldur}St. James Cross +1" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_1h_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h2" name="{=Yeldur}St. James Cross +2" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h2" name="{=Yeldur}St. James Cross +2" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_1h_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h3" name="{=Yeldur}St. James Cross +3" crafting_template="crpg_Mace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h3" name="{=Yeldur}St. James Cross +3" crafting_template="crpg_Mace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_1h_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_handle_h3" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_1h_pommel_h3" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h0" name="{=Yeldur}St. James Cross" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h0" name="{=Yeldur}St. James Cross" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_2h_blade_h0" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_handle_h0" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_pommel_h0" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h1" name="{=Yeldur}St. James Cross +1" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h1" name="{=Yeldur}St. James Cross +1" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_2h_blade_h1" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_handle_h1" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_pommel_h1" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h2" name="{=Yeldur}St. James Cross +2" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h2" name="{=Yeldur}St. James Cross +2" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_2h_blade_h2" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_handle_h2" Type="Handle" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_pommel_h2" Type="Pommel" scale_factor="100" />
     </Pieces>
   </CraftedItem>
-  <CraftedItem id="crpg_disabled_jamescross_h3" name="{=Yeldur}St. James Cross +3" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
+  <CraftedItem id="crpg_disabled_jamescross_v1_h3" name="{=Yeldur}St. James Cross +3" crafting_template="crpg_TwoHandedMace" modifier_group="mace">
     <Pieces>
       <Piece id="crpg_jamescross_2h_blade_h3" Type="Blade" scale_factor="100" />
       <Piece id="crpg_jamescross_2h_handle_h3" Type="Handle" scale_factor="100" />


### PR DESCRIPTION
Refunds the following items, based on not happening for https://github.com/namidaka/itembalancing/pull/528

- All melee weapons which have blunt damage
- Cut & pierce damage maces

Note includes slight "changes" to Tier based on a "change" Nami did for Tier calc. Nothing has actually changed, tiers and costs have very very slightly adjusted for most weapons - think 6th decimal place for tier. It was part of putting in the code to allow for tier stretching. @namidaka just tagging you for more info if required.